### PR TITLE
Fixed race issue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
         run: go build -tags release -v .
 
       - name: Test
-        run: go test -tags release -timeout 1m -v -coverprofile=coverage.out ./...
+        run: go test -tags release -timeout 1m -race -v -coverprofile=coverage.out ./...
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .idea
 node_modules
 .uncors.yaml
+coverage.out

--- a/internal/helpers/graceful_shutdown_internal_test.go
+++ b/internal/helpers/graceful_shutdown_internal_test.go
@@ -39,10 +39,10 @@ func (e *Env) Unlock() {
 	e.mutex.Unlock()
 }
 
-func WithGoroutines(test func(t *testing.T, env Env)) func(t *testing.T) {
+func WithGoroutines(test func(t *testing.T, env *Env)) func(t *testing.T) {
 	return func(t *testing.T) {
 		env := Env{wg: &sync.WaitGroup{}, mutex: sync.Mutex{}}
-		test(t, env)
+		test(t, &env)
 		env.wg.Wait()
 		for _, f := range env.afterAll {
 			f()
@@ -51,7 +51,7 @@ func WithGoroutines(test func(t *testing.T, env Env)) func(t *testing.T) {
 }
 
 func TestGracefulShutdown(t *testing.T) {
-	t.Run("shutdown when context is done", WithGoroutines(func(t *testing.T, env Env) {
+	t.Run("shutdown when context is done", WithGoroutines(func(t *testing.T, env *Env) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		called := false
@@ -91,7 +91,7 @@ func TestGracefulShutdown(t *testing.T) {
 		}
 
 		for _, testCase := range tests {
-			t.Run(testCase.name, WithGoroutines(func(t *testing.T, env Env) {
+			t.Run(testCase.name, WithGoroutines(func(t *testing.T, env *Env) {
 				env.Lock()
 				var systemSig chan<- os.Signal
 				notifyFn = func(c chan<- os.Signal, _ ...os.Signal) {
@@ -124,7 +124,7 @@ func TestGracefulShutdown(t *testing.T) {
 		}
 	})
 
-	t.Run("apply additional ui fix for SIGINT signal", WithGoroutines(func(t *testing.T, env Env) {
+	t.Run("apply additional ui fix for SIGINT signal", WithGoroutines(func(t *testing.T, env *Env) {
 		var systemSig chan<- os.Signal
 		env.Lock()
 		notifyFn = func(c chan<- os.Signal, _ ...os.Signal) {

--- a/internal/uncors/app.go
+++ b/internal/uncors/app.go
@@ -29,8 +29,8 @@ type App struct {
 	httpListenerMutex  *sync.Mutex
 	httpListener       net.Listener
 	httpsListenerMutex *sync.Mutex
-	httpsListener net.Listener
-	cache         appCache
+	httpsListener      net.Listener
+	cache              appCache
 }
 
 const (
@@ -145,12 +145,14 @@ func (app *App) Shutdown(ctx context.Context) error {
 func (app *App) HTTPAddr() net.Addr {
 	app.httpListenerMutex.Lock()
 	defer app.httpListenerMutex.Unlock()
+
 	return app.httpListener.Addr() // TODO: Add nil handing
 }
 
 func (app *App) HTTPSAddr() net.Addr {
 	app.httpsListenerMutex.Lock()
 	defer app.httpsListenerMutex.Unlock()
+
 	return app.httpsListener.Addr() // TODO: Add nil handing
 }
 

--- a/internal/uncors/app.go
+++ b/internal/uncors/app.go
@@ -19,14 +19,16 @@ import (
 )
 
 type App struct {
-	fs            afero.Fs
-	version       string
-	waitGroup     *sync.WaitGroup
-	httpMutex     *sync.Mutex
-	httpsMutex    *sync.Mutex
-	server        *http.Server
-	shuttingDown  *atomic.Bool
-	httpListener  net.Listener
+	fs                 afero.Fs
+	version            string
+	waitGroup          *sync.WaitGroup
+	httpMutex          *sync.Mutex
+	httpsMutex         *sync.Mutex
+	server             *http.Server
+	shuttingDown       *atomic.Bool
+	httpListenerMutex  *sync.Mutex
+	httpListener       net.Listener
+	httpsListenerMutex *sync.Mutex
 	httpsListener net.Listener
 	cache         appCache
 }
@@ -39,12 +41,14 @@ const (
 
 func CreateApp(fs afero.Fs, version string) *App {
 	return &App{
-		fs:           fs,
-		version:      version,
-		waitGroup:    &sync.WaitGroup{},
-		httpMutex:    &sync.Mutex{},
-		httpsMutex:   &sync.Mutex{},
-		shuttingDown: &atomic.Bool{},
+		fs:                 fs,
+		version:            version,
+		waitGroup:          &sync.WaitGroup{},
+		httpMutex:          &sync.Mutex{},
+		httpsMutex:         &sync.Mutex{},
+		shuttingDown:       &atomic.Bool{},
+		httpListenerMutex:  &sync.Mutex{},
+		httpsListenerMutex: &sync.Mutex{},
 	}
 }
 
@@ -139,10 +143,14 @@ func (app *App) Shutdown(ctx context.Context) error {
 }
 
 func (app *App) HTTPAddr() net.Addr {
+	app.httpListenerMutex.Lock()
+	defer app.httpListenerMutex.Unlock()
 	return app.httpListener.Addr() // TODO: Add nil handing
 }
 
 func (app *App) HTTPSAddr() net.Addr {
+	app.httpsListenerMutex.Lock()
+	defer app.httpsListenerMutex.Unlock()
 	return app.httpsListener.Addr() // TODO: Add nil handing
 }
 

--- a/internal/uncors/listen.go
+++ b/internal/uncors/listen.go
@@ -18,6 +18,8 @@ func (app *App) listenAndServe(addr string) error {
 		addr:  addr,
 		serve: app.server.Serve,
 		setListener: func(l net.Listener) {
+			app.httpListenerMutex.Lock()
+			defer app.httpListenerMutex.Unlock()
 			app.httpListener = l
 		},
 	})
@@ -30,6 +32,8 @@ func (app *App) listenAndServeTLS(addr string, certFile, keyFile string) error {
 			return app.server.ServeTLS(l, certFile, keyFile)
 		},
 		setListener: func(l net.Listener) {
+			app.httpsListenerMutex.Lock()
+			defer app.httpsListenerMutex.Unlock()
 			app.httpsListener = l
 		},
 	})


### PR DESCRIPTION
<details>
<summary>Test output</summary>

```
?   	github.com/evg4b/uncors	[no test files]
ok  	github.com/evg4b/uncors/internal/config	(cached)
ok  	github.com/evg4b/uncors/internal/config/validators	(cached)
ok  	github.com/evg4b/uncors/internal/config/validators/base	(cached)
ok  	github.com/evg4b/uncors/internal/contracts	(cached)
ok  	github.com/evg4b/uncors/internal/handler	(cached)
ok  	github.com/evg4b/uncors/internal/handler/cache	(cached)
ok  	github.com/evg4b/uncors/internal/handler/mock	(cached)
ok  	github.com/evg4b/uncors/internal/handler/proxy	(cached)
ok  	github.com/evg4b/uncors/internal/handler/static	(cached)
?   	github.com/evg4b/uncors/testing/hosts	[no test files]
?   	github.com/evg4b/uncors/testing/mocks	[no test files]
?   	github.com/evg4b/uncors/testing/testconstants	[no test files]
?   	github.com/evg4b/uncors/testing/testutils	[no test files]
?   	github.com/evg4b/uncors/testing/testutils/appbuilder	[no test files]
?   	github.com/evg4b/uncors/testing/testutils/params	[no test files]
==================
WARNING: DATA RACE
Read at 0x00c0001a2010 by goroutine 13:
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func2.1()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:106 +0x280
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func2.WithGoroutines.2()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:36 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0001a2010 by goroutine 14:
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func2.1.1()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:88 +0x30
  github.com/evg4b/uncors/internal/helpers.waiteSignal()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown.go:29 +0x130
  github.com/evg4b/uncors/internal/helpers.GracefulShutdown()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown.go:19 +0x34
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func2.1.3()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:97 +0x6c
  github.com/evg4b/uncors/internal/helpers.(*Env).Go.func1()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:25 +0x90

Goroutine 13 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func2()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:85 +0x110
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 14 (running) created at:
  github.com/evg4b/uncors/internal/helpers.(*Env).Go()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:23 +0xe0
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func2.1()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:96 +0x240
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func2.WithGoroutines.2()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:36 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40
==================

==================
WARNING: DATA RACE
Read at 0x00c0001a2050 by goroutine 22:
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func3()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:137 +0x2dc
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.WithGoroutines.func5()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:36 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0001a2050 by goroutine 23:
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func3.1()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:118 +0x30
  github.com/evg4b/uncors/internal/helpers.waiteSignal()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown.go:29 +0x130
  github.com/evg4b/uncors/internal/helpers.GracefulShutdown()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown.go:19 +0x34
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func3.4()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:130 +0x40
  github.com/evg4b/uncors/internal/helpers.(*Env).Go.func1()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:25 +0x90

Goroutine 22 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:115 +0x11c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 23 (running) created at:
  github.com/evg4b/uncors/internal/helpers.(*Env).Go()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:23 +0xe0
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.func3()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:129 +0x294
  github.com/evg4b/uncors/internal/helpers.TestGracefulShutdown.WithGoroutines.func5()
      /Users/evg4b/Documents/uncors/internal/helpers/graceful_shutdown_internal_test.go:36 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40
==================
--- FAIL: TestGracefulShutdown (0.21s)
    --- FAIL: TestGracefulShutdown/shutdown_after_system_signal (0.15s)
        --- FAIL: TestGracefulShutdown/shutdown_after_system_signal/SIGINT (0.05s)
            testing.go:1398: race detected during execution of test
    --- FAIL: TestGracefulShutdown/apply_additional_ui_fix_for_SIGINT_signal (0.05s)
        testing.go:1398: race detected during execution of test
FAIL
FAIL	github.com/evg4b/uncors/internal/helpers	0.251s
ok  	github.com/evg4b/uncors/internal/infra	(cached)
ok  	github.com/evg4b/uncors/internal/log	(cached)
==================
WARNING: DATA RACE
Read at 0x00c000169a48 by goroutine 9:
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x5c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:34 +0x36c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000169a48 by goroutine 13:
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:21 +0x3c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:48 +0xa4
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:30 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 13 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0001114c0 by goroutine 9:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x2c
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x70
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:34 +0x36c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0001114c0 by goroutine 13:
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:193 +0xf0
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:30 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 13 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000169e60 by goroutine 9:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x44
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x70
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:34 +0x36c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000169e60 by goroutine 13:
  net.newFD()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:27 +0xbc
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:27 +0x84
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:30 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 13 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0001dd5f0 by goroutine 9:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:34 +0x36c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0001dd5f0 by goroutine 13:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:30 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 13 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c00017d088 by goroutine 9:
  net.IP.String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:305 +0x1a8
  net.ipEmptyString()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:324 +0x5c
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:34 +0x36c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00017d088 by goroutine 13:
  syscall.anyToSockaddr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:260 +0xec
  syscall.Getsockname()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:310 +0x90
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:176 +0x4c0
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:30 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 13 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0001dd610 by goroutine 9:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:49 +0x80
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:34 +0x36c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0001dd610 by goroutine 13:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:30 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 13 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0001dd608 by goroutine 9:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:52 +0x17c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:34 +0x36c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0001dd608 by goroutine 13:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:30 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 13 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000de2c8 by goroutine 21:
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x5c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000de2c8 by goroutine 36:
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:21 +0x3c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:48 +0xa4
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 36 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000c0000 by goroutine 21:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x2c
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x70
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000c0000 by goroutine 36:
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:193 +0xf0
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 36 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c00042a060 by goroutine 21:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x44
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x70
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00042a060 by goroutine 36:
  net.newFD()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:27 +0xbc
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:27 +0x84
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 36 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c00011e390 by goroutine 21:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00011e390 by goroutine 36:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 36 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000281a8 by goroutine 21:
  net.IP.String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:305 +0x1a8
  net.ipEmptyString()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:324 +0x5c
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000281a8 by goroutine 36:
  syscall.anyToSockaddr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:260 +0xec
  syscall.Getsockname()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:310 +0x90
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:176 +0x4c0
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 36 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c00011e3b0 by goroutine 21:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:49 +0x80
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00011e3b0 by goroutine 36:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 36 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c00011e3a8 by goroutine 21:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:52 +0x17c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00011e3a8 by goroutine 36:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 36 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000de2d8 by goroutine 21:
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPSAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:146 +0xb0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xc8
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000de2d8 by goroutine 37:
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:33 +0x3c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:48 +0xa4
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 37 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000111340 by goroutine 21:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x2c
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPSAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:146 +0xc4
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xc8
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000111340 by goroutine 37:
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:193 +0xf0
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 37 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000de6e0 by goroutine 21:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x44
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPSAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:146 +0xc4
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xc8
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000de6e0 by goroutine 37:
  net.newFD()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:27 +0xbc
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:27 +0x84
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 37 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0003077a0 by goroutine 21:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xd0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0003077a0 by goroutine 37:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 37 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c00017d288 by goroutine 21:
  net.IP.String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:305 +0x1a8
  net.ipEmptyString()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:324 +0x5c
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xd0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00017d288 by goroutine 37:
  syscall.anyToSockaddr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:260 +0xec
  syscall.Getsockname()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:310 +0x90
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:176 +0x4c0
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 37 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0003077c0 by goroutine 21:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:49 +0x80
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xd0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0003077c0 by goroutine 37:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 37 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0003077b8 by goroutine 21:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:52 +0x17c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xd0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:59 +0x470
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0003077b8 by goroutine 37:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:54 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func3()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 37 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000de148 by goroutine 47:
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x5c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:96 +0x370
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000de148 by goroutine 51:
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:21 +0x3c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:48 +0xa4
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:91 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 51 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000c0680 by goroutine 47:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x2c
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x70
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:96 +0x370
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000c0680 by goroutine 51:
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:193 +0xf0
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:91 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 51 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000de5e0 by goroutine 47:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x44
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x70
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:96 +0x370
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000de5e0 by goroutine 51:
  net.newFD()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:27 +0xbc
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:27 +0x84
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:91 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 51 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0003068a0 by goroutine 47:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:96 +0x370
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0003068a0 by goroutine 51:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:91 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 51 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c00017ccc8 by goroutine 47:
  net.IP.String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:305 +0x1a8
  net.ipEmptyString()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:324 +0x5c
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:96 +0x370
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00017ccc8 by goroutine 51:
  syscall.anyToSockaddr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:260 +0xec
  syscall.Getsockname()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:310 +0x90
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:176 +0x4c0
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:91 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 51 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0003068c0 by goroutine 47:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:49 +0x80
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:96 +0x370
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0003068c0 by goroutine 51:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:91 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 51 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0003068b8 by goroutine 47:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:52 +0x17c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.1()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:96 +0x370
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0003068b8 by goroutine 51:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:91 +0x14c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 51 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0004803c8 by goroutine 67:
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x5c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0004803c8 by goroutine 71:
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:21 +0x3c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:48 +0xa4
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 71 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000ce000 by goroutine 67:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x2c
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x70
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000ce000 by goroutine 71:
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:193 +0xf0
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 71 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000686160 by goroutine 67:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x44
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:142 +0x70
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x74
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000686160 by goroutine 71:
  net.newFD()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:27 +0xbc
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:27 +0x84
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 71 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000306000 by goroutine 67:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000306000 by goroutine 71:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 71 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000308008 by goroutine 67:
  net.IP.String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:305 +0x1a8
  net.ipEmptyString()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:324 +0x5c
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000308008 by goroutine 71:
  syscall.anyToSockaddr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:260 +0xec
  syscall.Getsockname()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:310 +0x90
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:176 +0x4c0
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 71 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000306020 by goroutine 67:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:49 +0x80
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000306020 by goroutine 71:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 71 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000306018 by goroutine 67:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:52 +0x17c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:64 +0x7c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000306018 by goroutine 71:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:17 +0x158
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:74 +0x210

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 71 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:67 +0x168
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0004803d8 by goroutine 67:
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPSAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:146 +0xb0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xc8
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0004803d8 by goroutine 72:
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:33 +0x3c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:48 +0xa4
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 72 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0000c0e20 by goroutine 67:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x2c
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPSAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:146 +0xc4
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xc8
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0000c0e20 by goroutine 72:
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:193 +0xf0
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 72 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0004807e0 by goroutine 67:
  net.(*TCPListener).Addr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:349 +0x44
  github.com/evg4b/uncors/internal/uncors.(*App).HTTPSAddr()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:146 +0xc4
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xc8
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0004807e0 by goroutine 72:
  net.newFD()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:27 +0xbc
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:27 +0x84
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 72 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c0006229f0 by goroutine 67:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xd0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c0006229f0 by goroutine 72:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 72 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c00017d248 by goroutine 67:
  net.IP.String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:305 +0x1a8
  net.ipEmptyString()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ip.go:324 +0x5c
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:48 +0x30
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xd0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00017d248 by goroutine 72:
  syscall.anyToSockaddr()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:260 +0xec
  syscall.Getsockname()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/syscall/syscall_bsd.go:310 +0x90
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:176 +0x4c0
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 72 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000622a10 by goroutine 67:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:49 +0x80
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xd0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000622a10 by goroutine 72:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 72 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
==================
WARNING: DATA RACE
Read at 0x00c000622a08 by goroutine 67:
  net.(*TCPAddr).String()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock.go:52 +0x17c
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).addr()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:66 +0xd0
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:56 +0x3e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:138 +0x47c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2.WithTmpCerts.3()
      /Users/evg4b/Documents/uncors/testing/testutils/certs.go:35 +0x64
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000622a08 by goroutine 72:
  net.sockaddrToTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:19 +0x70
  net.(*netFD).listenStream()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:177 +0x5a4
  net.socket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:57 +0x22c
  net.internetSocket()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb0
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:189 +0xd4
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:179 +0x384
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:734 +0x36c
  net.Listen()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:808 +0x5c
  github.com/evg4b/uncors/internal/uncors.(*App).internalServe()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:43 +0x74
  github.com/evg4b/uncors/internal/uncors.(*App).listenAndServeTLS()
      /Users/evg4b/Documents/uncors/internal/uncors/listen.go:27 +0x1c4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:88 +0x1b4
  github.com/evg4b/uncors/internal/uncors.(*App).initServer.gowrap1()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:90 +0x44

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.func2()
      /Users/evg4b/Documents/uncors/internal/uncors/app_test.go:132 +0x30c
  github.com/evg4b/uncors/internal/uncors_test.TestUncorsApp.LogTest.func4()
      /Users/evg4b/Documents/uncors/testing/testutils/log.go:15 +0x48
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Goroutine 72 (running) created at:
  github.com/evg4b/uncors/internal/uncors.(*App).initServer()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:82 +0x414
  github.com/evg4b/uncors/internal/uncors.(*App).Start()
      /Users/evg4b/Documents/uncors/internal/uncors/app.go:59 +0x264
  github.com/evg4b/uncors/testing/testutils/appbuilder.(*Builder).Start.gowrap1()
      /Users/evg4b/Documents/uncors/testing/testutils/appbuilder/builder.go:53 +0x58
==================
--- FAIL: TestUncorsApp (7.60s)
    --- FAIL: TestUncorsApp/handle_request (5.08s)
        --- FAIL: TestUncorsApp/handle_request/HTTP (0.02s)
            testing.go:1398: race detected during execution of test
        --- FAIL: TestUncorsApp/handle_request/HTTPS (5.06s)
            testing.go:1398: race detected during execution of test
    --- FAIL: TestUncorsApp/restart_server (2.52s)
        --- FAIL: TestUncorsApp/restart_server/HTTP (0.03s)
            testing.go:1398: race detected during execution of test
        --- FAIL: TestUncorsApp/restart_server/HTTPS (2.50s)
            testing.go:1398: race detected during execution of test
FAIL
FAIL	github.com/evg4b/uncors/internal/uncors	7.652s
ok  	github.com/evg4b/uncors/internal/urlreplacer	(cached)
ok  	github.com/evg4b/uncors/internal/version	(cached)
ok  	github.com/evg4b/uncors/pkg/urlx	(cached)
FAIL
```

<details>