### PR TITLE
feat: HAR collector middleware

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,13 +115,40 @@ standalone middleware (`internal/handler/har`).
 
 **Configuration:**
 
+The simplest form uses a string shorthand — the value is treated as the output file path:
+
+```yaml
+mappings:
+  - from: http://localhost:3000
+    to: https://api.example.com
+    har: ./recordings/api.har
+```
+
+For full control, use the object form:
+
 ```yaml
 mappings:
   - from: http://localhost:3000
     to: https://api.example.com
     har:
       file: ./recordings/api.har
+      capture-secure-headers: true   # default: false
 ```
+
+**Security-sensitive headers:**
+
+By default the following headers are **excluded** from HAR entries to avoid
+persisting credentials on disk. Set `capture-secure-headers: true` to include
+them.
+
+| Header                | Why it is sensitive                        |
+|-----------------------|--------------------------------------------|
+| `Cookie`              | Session identifiers                        |
+| `Set-Cookie`          | Session identifiers set by the server      |
+| `Authorization`       | Bearer tokens, Basic credentials           |
+| `WWW-Authenticate`    | Server auth challenges (reveals scheme)    |
+| `Proxy-Authorization` | Proxy credentials                          |
+| `Proxy-Authenticate`  | Proxy auth challenges                      |
 
 ## Key Design Patterns
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,6 +39,7 @@ Routes requests and builds middleware chains based on configuration.
 - **Cache** - In-memory response caching with TTL
 - **Rewrite** - URL/header/query parameter manipulation
 - **Options** - Handles CORS preflight requests
+- **HAR Collector** - Records all request/response pairs to an HTTP Archive (HAR 1.2) file
 
 ### Infrastructure (`internal/infra`)
 
@@ -52,10 +53,10 @@ Colored logging and request/response formatting.
 
 1. **Client sends request** → UNCORS server
 2. **Route matching** - Find mapping by host/port
-3. **Middleware pipeline** - Apply options, rewrite, cache, static
+3. **Middleware pipeline** - Apply HAR capture → options → cache → static
 4. **Handler selection** - Choose mock, script, or proxy handler
 5. **CORS modification** - Add/modify CORS headers
-6. **Response** - Return to client
+6. **Response** - Return to client (HAR entry is enqueued asynchronously)
 
 Example CORS headers added:
 
@@ -76,6 +77,7 @@ uncors/
 │   ├── contracts/        # Interfaces (handler, logger, http client)
 │   ├── handler/          # Request handlers & middleware
 │   │   ├── cache/
+│   │   ├── har/          # HAR collector middleware & async writer
 │   │   ├── mock/
 │   │   ├── proxy/
 │   │   ├── script/
@@ -87,6 +89,38 @@ uncors/
 │   └── helpers/          # Utilities
 ├── testing/              # Mocks & test helpers
 └── tests/                # Integration tests
+```
+
+## HAR Collector
+
+The HAR (HTTP Archive) collector records every proxied request/response pair to
+a [HAR 1.2](https://w3c.github.io/web-performance/specs/HAR/Overview.html) file.
+It is enabled per-mapping via the `har.file` config key and is implemented as a
+standalone middleware (`internal/handler/har`).
+
+**Design goals:**
+- **Non-blocking** — the middleware never blocks the request goroutine. Entries
+  are sent over a buffered channel (capacity 4096). If the channel is full the
+  entry is silently dropped rather than stalling the request.
+- **High throughput writes** — a single background goroutine serialises all
+  disk I/O. After every new entry it atomically replaces the HAR file using a
+  write-to-tmp-then-rename strategy so the file is always in a valid state.
+- **Per-mapping isolation** — each mapping creates its own `Writer` instance and
+  its own output file, so traffic from different mappings can be captured
+  independently.
+- **Lifecycle management** — `Writer` implements `io.Closer`. The app registers
+  each writer via `registerCloser`; on shutdown or config reload it calls
+  `Close()` which drains the channel and flushes outstanding entries before
+  stopping the background goroutine.
+
+**Configuration:**
+
+```yaml
+mappings:
+  - from: http://localhost:3000
+    to: https://api.example.com
+    har:
+      file: ./recordings/api.har
 ```
 
 ## Key Design Patterns

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [Static file serving](https://github.com/evg4b/uncors/wiki/Static-file-serving)
 - [Response caching](https://github.com/evg4b/uncors/wiki/Response-caching)
 - [Request rewriting](https://github.com/evg4b/uncors/wiki/Request-rewriting)
+- [HAR traffic recording](https://github.com/evg4b/uncors/wiki/HAR-Collector)
 
 Full documentation can be found on the [wiki pages](https://github.com/evg4b/uncors/wiki).
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -292,6 +292,40 @@ mappings:
 > [!WARNING]
 > Domain mappings only work for hosts defined in your system's hosts file. A placeholder mapping like `http://{name}.local.com` will not intercept all internet traffic—only requests to domains explicitly configured in your hosts file.
 
+# HAR Recording
+
+UNCORS can record all proxied traffic to an [HTTP Archive (HAR 1.2)](https://w3c.github.io/web-performance/specs/HAR/Overview.html) file per mapping. The file can be opened in browser DevTools, Postman, or any HAR viewer.
+
+**Shorthand** — pass the output file path as a string:
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har: ./recordings/api.har
+```
+
+**Full form** — use an object for additional control:
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har:
+      file: ./recordings/api.har
+      capture-secure-headers: false   # default: false
+```
+
+| Property                 | Type    | Default | Description                                                   |
+| ------------------------ | ------- | ------- | ------------------------------------------------------------- |
+| `file`                   | string  | —       | Output `.har` file path. Collector is disabled when empty.    |
+| `capture-secure-headers` | boolean | `false` | Include auth/cookie headers in the recording (see [HAR Collector](./HAR-Collector#secure-headers)). |
+
+> [!WARNING]
+> Enabling `capture-secure-headers` writes tokens and cookies to disk in plain text. Never commit such files to version control.
+
+See [HAR Collector](./HAR-Collector) for the full reference.
+
 # HTTPS Configuration
 
 UNCORS supports HTTPS for both incoming requests and upstream connections using auto-generated certificates.

--- a/docs/HAR-Collector.md
+++ b/docs/HAR-Collector.md
@@ -1,0 +1,165 @@
+The HAR Collector records every request and response that passes through a mapping to an [HTTP Archive (HAR 1.2)](https://w3c.github.io/web-performance/specs/HAR/Overview.html) file. The resulting file can be opened in browser DevTools, Postman, or any HAR-compatible viewer for offline inspection, debugging, or sharing with teammates.
+
+**Benefits:**
+
+- Capture real API traffic without touching the browser or adding custom scripts
+- Replay or inspect captured traffic in any HAR-compatible tool
+- Share exact request/response sequences as a single portable file
+- Audit what headers and payloads your frontend actually sends
+
+# Quick Start
+
+Add `har` to any mapping with the path to the output file:
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har: ./recordings/api.har
+```
+
+UNCORS creates the file on the first request and keeps it updated atomically after each subsequent request.
+
+# Configuration
+
+## Shorthand Syntax
+
+Pass a file path string directly — this is the most concise form:
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har: ./recordings/api.har
+```
+
+## Full Syntax
+
+Use the object form when you need extra control:
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har:
+      file: ./recordings/api.har
+      capture-secure-headers: false
+```
+
+## Configuration Properties
+
+| Property                 | Type    | Default | Description                                                                     |
+| ------------------------ | ------- | ------- | ------------------------------------------------------------------------------- |
+| `file`                   | string  | —       | Path to the output `.har` file. Collector is disabled when this is empty.       |
+| `capture-secure-headers` | boolean | `false` | Include security-sensitive headers (see [Secure Headers](#secure-headers)) in the HAR entry. |
+
+# Secure Headers
+
+To prevent credentials from being written to disk, the following headers are **stripped from HAR entries by default**:
+
+| Header                | Why it is sensitive                            |
+| --------------------- | ---------------------------------------------- |
+| `Cookie`              | Session identifiers sent by the browser        |
+| `Set-Cookie`          | Session identifiers set by the upstream server |
+| `Authorization`       | Bearer tokens, Basic auth credentials          |
+| `WWW-Authenticate`    | Server auth challenges (reveals scheme/realm)  |
+| `Proxy-Authorization` | Proxy credentials                              |
+| `Proxy-Authenticate`  | Proxy auth challenges                          |
+
+Set `capture-secure-headers: true` to include these headers in the recording:
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har:
+      file: ./recordings/api.har
+      capture-secure-headers: true
+```
+
+> [!WARNING]
+> HAR files with `capture-secure-headers: true` contain tokens, cookies, and other credentials in plain text. Do not commit them to version control or share them without scrubbing sensitive values first.
+
+# Per-Mapping Isolation
+
+Each mapping writes to its own independent HAR file. Traffic from different mappings never mixes:
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har: ./recordings/api.har        # captures api.local traffic only
+
+  - from: http://auth.local:3001
+    to: https://auth.example.com
+    har: ./recordings/auth.har       # captures auth.local traffic only
+```
+
+# File Lifecycle
+
+- **Created** on the first captured request (parent directory must exist).
+- **Updated atomically** after every request — UNCORS writes to a temporary file then renames it, so the `.har` file is always in a valid, complete state even if you open it mid-session.
+- **Flushed and closed** on shutdown or when the configuration is reloaded. All buffered entries are written before the file handle is released.
+
+> [!NOTE]
+> If the internal write buffer (4 096 entries) fills up during a traffic spike, new entries are silently dropped rather than slowing down your requests. This is uncommon in normal development use.
+
+# Using Captured HAR Files
+
+Open the generated file with any of these tools:
+
+| Tool | How |
+| ---- | --- |
+| **Chrome / Edge DevTools** | Network tab → Import HAR |
+| **Firefox DevTools** | Network tab → Import HAR |
+| **Postman** | File → Import → select `.har` |
+| **HAR Viewer** (online) | [google.github.io/har-viewer](https://google.github.io/har-viewer/) |
+
+# Examples
+
+## Record All API Traffic
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har: ./recordings/session.har
+```
+
+## Debug Authentication Flows
+
+Capture auth headers to see exactly what the browser sends:
+
+```yaml
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+    har:
+      file: ./recordings/auth-debug.har
+      capture-secure-headers: true
+```
+
+> [!WARNING]
+> Delete `auth-debug.har` when done — it contains your credentials in plain text.
+
+## Combine with Other Features
+
+HAR recording works alongside mocking, caching, and static file serving:
+
+```yaml
+mappings:
+  - from: http://app.local:3000
+    to: https://api.example.com
+    har: ./recordings/app.har
+    cache:
+      - /api/config
+    mocks:
+      - path: /api/feature-flags
+        response:
+          code: 200
+          raw: '{"newUi": true}'
+    statics:
+      - path: /
+        dir: ./dist
+        index: index.html
+```

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -105,6 +105,7 @@ Understanding these terms will help you navigate the documentation more effectiv
 - [Response caching](./Response-Caching)
 - [Request rewriting](./Request-Rewriting)
 - [Migration guide](./Migration-Guide)
+- [HAR recording](./HAR-Collector)
 - [Script handler](./Script-Handler)
 - [Troubleshooting](./Troubleshooting)
 - [Real-world examples](./Real-World-Examples)
@@ -120,6 +121,7 @@ Understanding these terms will help you navigate the documentation more effectiv
 - [Static file serving](./Static-File-Serving)
 - [Response caching](./Response-Caching)
 - [Request rewriting](./Request-Rewriting)
+- [HAR traffic recording](./HAR-Collector)
 
 ## Overview
 

--- a/internal/config/har.go
+++ b/internal/config/har.go
@@ -1,0 +1,16 @@
+package config
+
+// HARConfig defines settings for the HAR (HTTP Archive) collector middleware.
+// When File is non-empty, all requests/responses passing through the proxy
+// for this mapping will be recorded to the specified HAR file.
+type HARConfig struct {
+	File string `mapstructure:"file"`
+}
+
+func (h HARConfig) Enabled() bool {
+	return h.File != ""
+}
+
+func (h HARConfig) Clone() HARConfig {
+	return HARConfig{File: h.File}
+}

--- a/internal/config/har.go
+++ b/internal/config/har.go
@@ -4,7 +4,8 @@ package config
 // When File is non-empty, all requests/responses passing through the proxy
 // for this mapping will be recorded to the specified HAR file.
 type HARConfig struct {
-	File string `mapstructure:"file"`
+	File           string `mapstructure:"file"`
+	CaptureCookies bool   `mapstructure:"capture-cookies"`
 }
 
 func (h HARConfig) Enabled() bool {
@@ -12,5 +13,8 @@ func (h HARConfig) Enabled() bool {
 }
 
 func (h HARConfig) Clone() HARConfig {
-	return HARConfig{File: h.File}
+	return HARConfig{
+		File:           h.File,
+		CaptureCookies: h.CaptureCookies,
+	}
 }

--- a/internal/config/har.go
+++ b/internal/config/har.go
@@ -1,11 +1,17 @@
 package config
 
+import (
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+)
+
 // HARConfig defines settings for the HAR (HTTP Archive) collector middleware.
 // When File is non-empty, all requests/responses passing through the proxy
 // for this mapping will be recorded to the specified HAR file.
 type HARConfig struct {
-	File                  string `mapstructure:"file"`
-	CaptureSecureHeaders  bool   `mapstructure:"capture-secure-headers"`
+	File                 string `mapstructure:"file"`
+	CaptureSecureHeaders bool   `mapstructure:"capture-secure-headers"`
 }
 
 func (h HARConfig) Enabled() bool {
@@ -16,5 +22,26 @@ func (h HARConfig) Clone() HARConfig {
 	return HARConfig{
 		File:                 h.File,
 		CaptureSecureHeaders: h.CaptureSecureHeaders,
+	}
+}
+
+var harConfigType = reflect.TypeFor[HARConfig]()
+
+// HARConfigHookFunc returns a mapstructure decode hook that allows HARConfig
+// to be specified as a plain string in YAML/config files.
+//
+// Short form:  har: ./recordings/api.har
+// Full form:   har: { file: ./recordings/api.har, capture-secure-headers: true }
+func HARConfigHookFunc() mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, rawData any) (any, error) {
+		if t != harConfigType || f.Kind() != reflect.String {
+			return rawData, nil
+		}
+
+		if file, ok := rawData.(string); ok {
+			return HARConfig{File: file}, nil
+		}
+
+		return rawData, nil
 	}
 }

--- a/internal/config/har.go
+++ b/internal/config/har.go
@@ -31,7 +31,7 @@ var harConfigType = reflect.TypeFor[HARConfig]()
 // to be specified as a plain string in YAML/config files.
 //
 // Short form:  har: ./recordings/api.har
-// Full form:   har: { file: ./recordings/api.har, capture-secure-headers: true }
+// Full form:   har: { file: ./recordings/api.har, capture-secure-headers: true }.
 func HARConfigHookFunc() mapstructure.DecodeHookFunc {
 	return func(f reflect.Type, t reflect.Type, rawData any) (any, error) {
 		if t != harConfigType || f.Kind() != reflect.String {

--- a/internal/config/har.go
+++ b/internal/config/har.go
@@ -4,8 +4,8 @@ package config
 // When File is non-empty, all requests/responses passing through the proxy
 // for this mapping will be recorded to the specified HAR file.
 type HARConfig struct {
-	File           string `mapstructure:"file"`
-	CaptureCookies bool   `mapstructure:"capture-cookies"`
+	File                  string `mapstructure:"file"`
+	CaptureSecureHeaders  bool   `mapstructure:"capture-secure-headers"`
 }
 
 func (h HARConfig) Enabled() bool {
@@ -14,7 +14,7 @@ func (h HARConfig) Enabled() bool {
 
 func (h HARConfig) Clone() HARConfig {
 	return HARConfig{
-		File:           h.File,
-		CaptureCookies: h.CaptureCookies,
+		File:                 h.File,
+		CaptureSecureHeaders: h.CaptureSecureHeaders,
 	}
 }

--- a/internal/config/har_test.go
+++ b/internal/config/har_test.go
@@ -46,19 +46,20 @@ func TestHARConfigHookFunc(t *testing.T) {
 
 func TestHARShorthandInMapping(t *testing.T) {
 	const configFile = "config.yaml"
+
 	const yaml = `
 from: http://localhost:3000
 to: https://api.example.com
 har: ./recordings/api.har
 `
 
-	v := viper.New()
-	v.SetFs(testutils.FsFromMap(t, map[string]string{configFile: yaml}))
-	v.SetConfigFile(configFile)
-	require.NoError(t, v.ReadInConfig())
+	viperCfg := viper.New()
+	viperCfg.SetFs(testutils.FsFromMap(t, map[string]string{configFile: yaml}))
+	viperCfg.SetConfigFile(configFile)
+	require.NoError(t, viperCfg.ReadInConfig())
 
 	actual := config.Mapping{}
-	require.NoError(t, v.Unmarshal(&actual, viper.DecodeHook(
+	require.NoError(t, viperCfg.Unmarshal(&actual, viper.DecodeHook(
 		config.URLMappingHookFunc(),
 	)))
 

--- a/internal/config/har_test.go
+++ b/internal/config/har_test.go
@@ -1,0 +1,67 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/testing/testutils"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHARConfigHookFunc(t *testing.T) {
+	decode := func(t *testing.T, raw any) config.HARConfig {
+		t.Helper()
+
+		var out config.HARConfig
+
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			Result:     &out,
+			DecodeHook: config.HARConfigHookFunc(),
+		})
+		require.NoError(t, err)
+		require.NoError(t, decoder.Decode(raw))
+
+		return out
+	}
+
+	t.Run("string shorthand sets File", func(t *testing.T) {
+		cfg := decode(t, "./recordings/api.har")
+		assert.Equal(t, config.HARConfig{File: "./recordings/api.har"}, cfg)
+	})
+
+	t.Run("map form decoded normally", func(t *testing.T) {
+		cfg := decode(t, map[string]any{
+			"file":                   "./out.har",
+			"capture-secure-headers": true,
+		})
+		assert.Equal(t, config.HARConfig{
+			File:                 "./out.har",
+			CaptureSecureHeaders: true,
+		}, cfg)
+	})
+}
+
+func TestHARShorthandInMapping(t *testing.T) {
+	const configFile = "config.yaml"
+	const yaml = `
+from: http://localhost:3000
+to: https://api.example.com
+har: ./recordings/api.har
+`
+
+	v := viper.New()
+	v.SetFs(testutils.FsFromMap(t, map[string]string{configFile: yaml}))
+	v.SetConfigFile(configFile)
+	require.NoError(t, v.ReadInConfig())
+
+	actual := config.Mapping{}
+	require.NoError(t, v.Unmarshal(&actual, viper.DecodeHook(
+		config.URLMappingHookFunc(),
+	)))
+
+	assert.Equal(t, "./recordings/api.har", actual.HAR.File)
+	assert.False(t, actual.HAR.CaptureSecureHeaders)
+}

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -19,6 +19,7 @@ type Mapping struct {
 	Cache           CacheGlobs        `mapstructure:"cache"`
 	Rewrites        RewriteOptions    `mapstructure:"rewrites"`
 	OptionsHandling OptionsHandling   `mapstructure:"options-handling"`
+	HAR             HARConfig         `mapstructure:"har"`
 
 	// Cached parsed URL and its components (not serialized)
 	fromURL  *url.URL `json:"-" mapstructure:"-" yaml:"-"`
@@ -36,6 +37,7 @@ func (m *Mapping) Clone() Mapping {
 		Cache:           m.Cache.Clone(),
 		Rewrites:        m.Rewrites.Clone(),
 		OptionsHandling: m.OptionsHandling.Clone(),
+		HAR:             m.HAR.Clone(),
 		fromURL:         m.fromURL, // Share cached URL
 		fromHost:        m.fromHost,
 		fromPort:        m.fromPort,

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -115,6 +115,7 @@ func URLMappingHookFunc() mapstructure.DecodeHookFunc {
 				data,
 				&mapping,
 				StaticDirMappingHookFunc(),
+				HARConfigHookFunc(),
 			)
 
 			return mapping, err

--- a/internal/config/validators/har.go
+++ b/internal/config/validators/har.go
@@ -1,0 +1,20 @@
+package validators
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/evg4b/uncors/internal/config"
+)
+
+func ValidateHAR(field string, value config.HARConfig, errs *Errors) {
+	if !value.Enabled() {
+		return
+	}
+
+	file := value.File
+
+	if filepath.Ext(file) == "" {
+		errs.add(fmt.Sprintf("%s: HAR file path %q must have a file extension (e.g. .har)", field, file))
+	}
+}

--- a/internal/config/validators/har_test.go
+++ b/internal/config/validators/har_test.go
@@ -1,0 +1,54 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/config/validators"
+	"github.com/gobuffalo/validate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHARValidator(t *testing.T) {
+	t.Run("valid cases", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			value config.HARConfig
+		}{
+			{
+				name:  "disabled (empty file)",
+				value: config.HARConfig{},
+			},
+			{
+				name:  "valid file path with extension",
+				value: config.HARConfig{File: "output.har"},
+			},
+			{
+				name:  "path with directory and extension",
+				value: config.HARConfig{File: "/tmp/trace.har"},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				errs := validate.Validate(&validators.HARValidator{
+					Field: "mappings[0].har",
+					Value: tc.value,
+				})
+
+				assert.False(t, errs.HasAny())
+			})
+		}
+	})
+
+	t.Run("invalid cases", func(t *testing.T) {
+		t.Run("file path without extension", func(t *testing.T) {
+			errs := validate.Validate(&validators.HARValidator{
+				Field: "mappings[0].har",
+				Value: config.HARConfig{File: "outputfile"},
+			})
+
+			assert.True(t, errs.HasAny())
+		})
+	})
+}

--- a/internal/config/validators/har_test.go
+++ b/internal/config/validators/har_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/config/validators"
-	"github.com/gobuffalo/validate"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,10 +30,8 @@ func TestHARValidator(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				errs := validate.Validate(&validators.HARValidator{
-					Field: "mappings[0].har",
-					Value: tc.value,
-				})
+				errs := &validators.Errors{}
+				validators.ValidateHAR("mappings[0].har", tc.value, errs)
 
 				assert.False(t, errs.HasAny())
 			})
@@ -43,10 +40,8 @@ func TestHARValidator(t *testing.T) {
 
 	t.Run("invalid cases", func(t *testing.T) {
 		t.Run("file path without extension", func(t *testing.T) {
-			errs := validate.Validate(&validators.HARValidator{
-				Field: "mappings[0].har",
-				Value: config.HARConfig{File: "outputfile"},
-			})
+			errs := &validators.Errors{}
+			validators.ValidateHAR("mappings[0].har", config.HARConfig{File: "outputfile"}, errs)
 
 			assert.True(t, errs.HasAny())
 		})

--- a/internal/config/validators/validators.go
+++ b/internal/config/validators/validators.go
@@ -146,6 +146,7 @@ func ValidateMapping(field string, value config.Mapping, fs afero.Fs, errs *Erro
 	ValidateHost(joinPath(field, "from"), value.From, errs)
 	ValidateHost(joinPath(field, "to"), value.To, errs)
 	ValidateOptionsHandling(joinPath(field, "options-handling"), value.OptionsHandling, errs)
+	ValidateHAR(joinPath(field, "har"), value.HAR, errs)
 	ValidateTLS(field, value, fs, errs)
 
 	for i, static := range value.Statics {

--- a/internal/handler/har/capture_writer.go
+++ b/internal/handler/har/capture_writer.go
@@ -1,0 +1,48 @@
+package har
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/evg4b/uncors/internal/contracts"
+)
+
+// captureWriter wraps a ResponseWriter and tees the response body
+// into an internal buffer so the middleware can build a HAR entry
+// after the handler returns. It satisfies contracts.ResponseWriter.
+type captureWriter struct {
+	contracts.ResponseWriter
+
+	buffer bytes.Buffer
+	output io.Writer
+	code   int
+}
+
+func newCaptureWriter(w contracts.ResponseWriter) *captureWriter {
+	cw := &captureWriter{
+		ResponseWriter: w,
+		code:           http.StatusOK,
+	}
+
+	cw.output = io.MultiWriter(&cw.buffer, w)
+
+	return cw
+}
+
+func (cw *captureWriter) Write(b []byte) (int, error) {
+	return cw.output.Write(b)
+}
+
+func (cw *captureWriter) WriteHeader(statusCode int) {
+	cw.code = statusCode
+	cw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (cw *captureWriter) StatusCode() int {
+	return cw.code
+}
+
+func (cw *captureWriter) body() []byte {
+	return cw.buffer.Bytes()
+}

--- a/internal/handler/har/capture_writer.go
+++ b/internal/handler/har/capture_writer.go
@@ -19,15 +19,15 @@ type captureWriter struct {
 	code   int
 }
 
-func newCaptureWriter(w contracts.ResponseWriter) *captureWriter {
-	cw := &captureWriter{
-		ResponseWriter: w,
+func newCaptureWriter(wrapped contracts.ResponseWriter) *captureWriter {
+	capture := &captureWriter{
+		ResponseWriter: wrapped,
 		code:           http.StatusOK,
 	}
 
-	cw.output = io.MultiWriter(&cw.buffer, w)
+	capture.output = io.MultiWriter(&capture.buffer, wrapped)
 
-	return cw
+	return capture
 }
 
 func (cw *captureWriter) Write(b []byte) (int, error) {

--- a/internal/handler/har/capture_writer.go
+++ b/internal/handler/har/capture_writer.go
@@ -8,9 +8,6 @@ import (
 	"github.com/evg4b/uncors/internal/contracts"
 )
 
-// captureWriter wraps a ResponseWriter and tees the response body
-// into an internal buffer so the middleware can build a HAR entry
-// after the handler returns. It satisfies contracts.ResponseWriter.
 type captureWriter struct {
 	contracts.ResponseWriter
 

--- a/internal/handler/har/capture_writer_internal_test.go
+++ b/internal/handler/har/capture_writer_internal_test.go
@@ -1,8 +1,5 @@
 package har
 
-// Internal tests for captureWriter — kept in package har so that the
-// unexported type and constructor are directly accessible.
-
 import (
 	"net/http"
 	"net/http/httptest"

--- a/internal/handler/har/capture_writer_internal_test.go
+++ b/internal/handler/har/capture_writer_internal_test.go
@@ -1,0 +1,31 @@
+package har
+
+// Internal tests for captureWriter — kept in package har so that the
+// unexported type and constructor are directly accessible.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCaptureWriter_StatusCode(t *testing.T) {
+	t.Run("returns 200 by default", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		cw := newCaptureWriter(contracts.WrapResponseWriter(rec))
+
+		assert.Equal(t, http.StatusOK, cw.StatusCode())
+	})
+
+	t.Run("returns code set by WriteHeader", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		cw := newCaptureWriter(contracts.WrapResponseWriter(rec))
+
+		cw.WriteHeader(http.StatusNotFound)
+
+		assert.Equal(t, http.StatusNotFound, cw.StatusCode())
+	})
+}

--- a/internal/handler/har/content.go
+++ b/internal/handler/har/content.go
@@ -1,0 +1,79 @@
+package har
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"encoding/base64"
+	"io"
+	"strings"
+)
+
+// buildContent creates a HAR Content object from the raw (possibly encoded)
+// response body. It attempts to decode gzip and deflate-compressed bodies so
+// the HAR stores readable text. Unknown or undecipherable encodings are stored
+// as base64 per the HAR 1.2 spec.
+func buildContent(raw []byte, contentEncoding, mimeType string) Content {
+	if len(raw) == 0 {
+		return Content{Size: 0, MimeType: mimeType}
+	}
+
+	encoding := strings.ToLower(strings.TrimSpace(contentEncoding))
+
+	switch encoding {
+	case "gzip", "x-gzip":
+		if decoded, err := decodeGzip(raw); err == nil {
+			return Content{
+				Size:     int64(len(decoded)),
+				MimeType: mimeType,
+				Text:     string(decoded),
+			}
+		}
+
+	case "deflate":
+		if decoded, err := decodeDeflate(raw); err == nil {
+			return Content{
+				Size:     int64(len(decoded)),
+				MimeType: mimeType,
+				Text:     string(decoded),
+			}
+		}
+
+	case "", "identity":
+		// No compression — store as plain text.
+		return Content{
+			Size:     int64(len(raw)),
+			MimeType: mimeType,
+			Text:     string(raw),
+		}
+	}
+
+	// Unknown or failed encoding: store as base64 so the HAR remains valid.
+	return Content{
+		Size:     int64(len(raw)),
+		MimeType: mimeType,
+		Text:     base64.StdEncoding.EncodeToString(raw),
+		Encoding: "base64",
+	}
+}
+
+func decodeGzip(data []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Close()
+
+	return io.ReadAll(r)
+}
+
+func decodeDeflate(data []byte) ([]byte, error) {
+	// The deflate encoding used in HTTP can be raw DEFLATE or zlib-wrapped.
+	// Try zlib first; fall back to raw flate.
+	r := flate.NewReader(bytes.NewReader(data))
+
+	defer r.Close()
+
+	return io.ReadAll(r)
+}

--- a/internal/handler/har/content.go
+++ b/internal/handler/har/content.go
@@ -22,7 +22,8 @@ func buildContent(raw []byte, contentEncoding, mimeType string) Content {
 
 	switch encoding {
 	case "gzip", "x-gzip":
-		if decoded, err := decodeGzip(raw); err == nil {
+		decoded, err := decodeGzip(raw)
+		if err == nil {
 			return Content{
 				Size:     int64(len(decoded)),
 				MimeType: mimeType,
@@ -31,7 +32,8 @@ func buildContent(raw []byte, contentEncoding, mimeType string) Content {
 		}
 
 	case "deflate":
-		if decoded, err := decodeDeflate(raw); err == nil {
+		decoded, err := decodeDeflate(raw)
+		if err == nil {
 			return Content{
 				Size:     int64(len(decoded)),
 				MimeType: mimeType,
@@ -58,22 +60,22 @@ func buildContent(raw []byte, contentEncoding, mimeType string) Content {
 }
 
 func decodeGzip(data []byte) ([]byte, error) {
-	r, err := gzip.NewReader(bytes.NewReader(data))
+	reader, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
 
-	defer r.Close()
+	defer reader.Close()
 
-	return io.ReadAll(r)
+	return io.ReadAll(reader)
 }
 
 func decodeDeflate(data []byte) ([]byte, error) {
 	// The deflate encoding used in HTTP can be raw DEFLATE or zlib-wrapped.
 	// Try zlib first; fall back to raw flate.
-	r := flate.NewReader(bytes.NewReader(data))
+	reader := flate.NewReader(bytes.NewReader(data))
 
-	defer r.Close()
+	defer reader.Close()
 
-	return io.ReadAll(r)
+	return io.ReadAll(reader)
 }

--- a/internal/handler/har/content.go
+++ b/internal/handler/har/content.go
@@ -10,10 +10,6 @@ import (
 	"strings"
 )
 
-// buildContent creates a HAR Content object from the raw (possibly encoded)
-// response body. It attempts to decode gzip and deflate-compressed bodies so
-// the HAR stores readable text. Unknown or undecipherable encodings are stored
-// as base64 per the HAR 1.2 spec.
 func buildContent(raw []byte, contentEncoding, mimeType string) Content {
 	if len(raw) == 0 {
 		return Content{Size: 0, MimeType: mimeType}

--- a/internal/handler/har/content.go
+++ b/internal/handler/har/content.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/base64"
 	"io"
 	"strings"
@@ -71,9 +72,25 @@ func decodeGzip(data []byte) ([]byte, error) {
 }
 
 func decodeDeflate(data []byte) ([]byte, error) {
-	// The deflate encoding used in HTTP can be raw DEFLATE or zlib-wrapped.
-	// Try zlib first; fall back to raw flate.
+	// HTTP "deflate" is technically zlib-wrapped DEFLATE (RFC 1950), but many
+	// servers incorrectly send raw DEFLATE (RFC 1951). Try zlib first, then
+	// fall back to raw flate so both variants are handled correctly.
+	decoded, err := decodeZlib(data)
+	if err == nil {
+		return decoded, nil
+	}
+
 	reader := flate.NewReader(bytes.NewReader(data))
+	defer reader.Close()
+
+	return io.ReadAll(reader)
+}
+
+func decodeZlib(data []byte) ([]byte, error) {
+	reader, err := zlib.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
 
 	defer reader.Close()
 

--- a/internal/handler/har/content_internal_test.go
+++ b/internal/handler/har/content_internal_test.go
@@ -1,8 +1,5 @@
 package har
 
-// Internal tests for buildContent, decodeGzip, decodeDeflate, and decodeZlib.
-// Kept in package har so that unexported functions are directly accessible.
-
 import (
 	"bytes"
 	"compress/flate"
@@ -12,8 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// rawDeflate compresses data using raw DEFLATE (RFC 1951), without the zlib
-// wrapper. Many servers incorrectly send this instead of RFC 1950 zlib.
 func rawDeflate(t *testing.T, data []byte) []byte {
 	t.Helper()
 
@@ -66,7 +61,6 @@ func TestBuildContent(t *testing.T) {
 	})
 
 	t.Run("invalid deflate data falls back to base64", func(t *testing.T) {
-		// Bytes that are neither valid zlib nor valid raw DEFLATE.
 		c := buildContent([]byte{0x00, 0x01, 0x02}, "deflate", "application/octet-stream")
 
 		assert.Equal(t, "base64", c.Encoding)

--- a/internal/handler/har/content_internal_test.go
+++ b/internal/handler/har/content_internal_test.go
@@ -1,0 +1,97 @@
+package har
+
+// Internal tests for buildContent, decodeGzip, decodeDeflate, and decodeZlib.
+// Kept in package har so that unexported functions are directly accessible.
+
+import (
+	"bytes"
+	"compress/flate"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rawDeflate compresses data using raw DEFLATE (RFC 1951), without the zlib
+// wrapper. Many servers incorrectly send this instead of RFC 1950 zlib.
+func rawDeflate(t *testing.T, data []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	w, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	require.NoError(t, err)
+
+	_, err = w.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	return buf.Bytes()
+}
+
+func TestBuildContent(t *testing.T) {
+	t.Run("empty body returns zero-size content", func(t *testing.T) {
+		c := buildContent(nil, "", "text/plain")
+
+		assert.Equal(t, int64(0), c.Size)
+		assert.Equal(t, "text/plain", c.MimeType)
+		assert.Empty(t, c.Text)
+		assert.Empty(t, c.Encoding)
+	})
+
+	t.Run("empty encoding stores plain text", func(t *testing.T) {
+		c := buildContent([]byte("hello"), "", "text/plain")
+
+		assert.Equal(t, "hello", c.Text)
+		assert.Empty(t, c.Encoding)
+	})
+
+	t.Run("identity encoding stores plain text", func(t *testing.T) {
+		c := buildContent([]byte("hello"), "identity", "text/plain")
+
+		assert.Equal(t, "hello", c.Text)
+		assert.Empty(t, c.Encoding)
+	})
+
+	t.Run("unknown encoding falls back to base64", func(t *testing.T) {
+		c := buildContent([]byte("data"), "br", "text/plain")
+
+		assert.Equal(t, "base64", c.Encoding)
+	})
+
+	t.Run("invalid gzip data falls back to base64", func(t *testing.T) {
+		c := buildContent([]byte("not-gzip-data"), "gzip", "application/octet-stream")
+
+		assert.Equal(t, "base64", c.Encoding)
+	})
+
+	t.Run("invalid deflate data falls back to base64", func(t *testing.T) {
+		// Bytes that are neither valid zlib nor valid raw DEFLATE.
+		c := buildContent([]byte{0x00, 0x01, 0x02}, "deflate", "application/octet-stream")
+
+		assert.Equal(t, "base64", c.Encoding)
+	})
+
+	t.Run("raw deflate (RFC 1951) is decoded when zlib wrapper absent", func(t *testing.T) {
+		const original = "raw deflate content"
+
+		compressed := rawDeflate(t, []byte(original))
+
+		c := buildContent(compressed, "deflate", "text/plain")
+
+		assert.Equal(t, original, c.Text)
+		assert.Empty(t, c.Encoding, "decoded content must not carry an encoding field")
+	})
+}
+
+func TestDecodeGzip_InvalidData(t *testing.T) {
+	_, err := decodeGzip([]byte("not-gzip"))
+
+	assert.Error(t, err)
+}
+
+func TestDecodeZlib_InvalidData(t *testing.T) {
+	_, err := decodeZlib([]byte("not-zlib"))
+
+	assert.Error(t, err)
+}

--- a/internal/handler/har/content_test.go
+++ b/internal/handler/har/content_test.go
@@ -15,6 +15,7 @@ func gzipEncode(t *testing.T, data string) []byte {
 	t.Helper()
 
 	var buf bytes.Buffer
+
 	w := gzip.NewWriter(&buf)
 	_, err := w.Write([]byte(data))
 	require.NoError(t, err)
@@ -29,6 +30,7 @@ func gzipEncode(t *testing.T, data string) []byte {
 
 func TestBuildContent_Gzip(t *testing.T) {
 	const body = `{"hello":"world"}`
+
 	compressed := gzipEncode(t, body)
 
 	// The function is unexported; test via middleware_test helpers.

--- a/internal/handler/har/content_test.go
+++ b/internal/handler/har/content_test.go
@@ -1,0 +1,57 @@
+package har_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/handler/har"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gzipEncode(t *testing.T, data string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, err := w.Write([]byte(data))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	return buf.Bytes()
+}
+
+// buildContent is tested indirectly via a gzip-compressed response
+// captured by the middleware, and directly via exported helpers
+// (since HAR types are in the same test package).
+
+func TestBuildContent_Gzip(t *testing.T) {
+	const body = `{"hello":"world"}`
+	compressed := gzipEncode(t, body)
+
+	// The function is unexported; test via middleware_test helpers.
+	// Here we verify the flow through the middleware instead.
+	_ = compressed // used in middleware integration test below
+}
+
+func TestContent_Encoding(t *testing.T) {
+	t.Run("unknown encoding stored as base64", func(t *testing.T) {
+		raw := []byte{0x1f, 0x8b, 0x00} // truncated gzip → cannot decode
+		b64 := base64.StdEncoding.EncodeToString(raw)
+
+		entry := har.Entry{
+			Response: har.Response{
+				Content: har.Content{
+					Text:     b64,
+					Encoding: "base64",
+					MimeType: "application/octet-stream",
+				},
+			},
+		}
+
+		assert.Equal(t, "base64", entry.Response.Content.Encoding)
+		assert.Equal(t, b64, entry.Response.Content.Text)
+	})
+}

--- a/internal/handler/har/content_test.go
+++ b/internal/handler/har/content_test.go
@@ -1,42 +1,12 @@
 package har_test
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/base64"
 	"testing"
 
 	"github.com/evg4b/uncors/internal/handler/har"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func gzipEncode(t *testing.T, data string) []byte {
-	t.Helper()
-
-	var buf bytes.Buffer
-
-	w := gzip.NewWriter(&buf)
-	_, err := w.Write([]byte(data))
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-
-	return buf.Bytes()
-}
-
-// buildContent is tested indirectly via a gzip-compressed response
-// captured by the middleware, and directly via exported helpers
-// (since HAR types are in the same test package).
-
-func TestBuildContent_Gzip(t *testing.T) {
-	const body = `{"hello":"world"}`
-
-	compressed := gzipEncode(t, body)
-
-	// The function is unexported; test via middleware_test helpers.
-	// Here we verify the flow through the middleware instead.
-	_ = compressed // used in middleware integration test below
-}
 
 func TestContent_Encoding(t *testing.T) {
 	t.Run("unknown encoding stored as base64", func(t *testing.T) {

--- a/internal/handler/har/middleware.go
+++ b/internal/handler/har/middleware.go
@@ -12,6 +12,9 @@ import (
 	"github.com/evg4b/uncors/internal/helpers"
 )
 
+// nanosecondsPerMillisecond is used to convert nanoseconds to milliseconds.
+const nanosecondsPerMillisecond = 1e6
+
 // secureHeaderNames is the set of HTTP headers that may carry credentials or
 // session data. They are stripped from HAR entries by default and are only
 // included when captureSecureHeaders is true.
@@ -46,48 +49,48 @@ func NewMiddleware(opts ...MiddlewareOption) *Middleware {
 // Wrap returns a Handler that records the transaction before passing
 // control to next.
 func (m *Middleware) Wrap(next contracts.Handler) contracts.Handler {
-	return contracts.HandlerFunc(func(w contracts.ResponseWriter, r *contracts.Request) {
+	return contracts.HandlerFunc(func(w contracts.ResponseWriter, req *contracts.Request) {
 		start := time.Now()
 
-		cw := newCaptureWriter(w)
+		capture := newCaptureWriter(w)
 
 		var reqBodySize int64
 
-		if r.Body != nil && r.Body != http.NoBody {
+		if req.Body != nil && req.Body != http.NoBody {
 			var buf strings.Builder
 
-			n, _ := io.Copy(&buf, r.Body)
+			n, _ := io.Copy(&buf, req.Body)
 			reqBodySize = n
-			_ = r.Body.Close()
+			_ = req.Body.Close()
 
 			// Restore body so the next handler can read it.
-			r.Body = io.NopCloser(strings.NewReader(buf.String()))
+			req.Body = io.NopCloser(strings.NewReader(buf.String()))
 		}
 
-		next.ServeHTTP(cw, r)
+		next.ServeHTTP(capture, req)
 
 		elapsed := time.Since(start)
 
-		entry := m.buildEntry(r, cw, start, elapsed, reqBodySize)
+		entry := m.buildEntry(req, capture, start, elapsed, reqBodySize)
 
 		m.writer.AddEntry(entry)
 	})
 }
 
 func (m *Middleware) buildEntry(
-	r *http.Request,
-	cw *captureWriter,
+	req *http.Request,
+	capture *captureWriter,
 	start time.Time,
 	elapsed time.Duration,
 	reqBodySize int64,
 ) Entry {
-	elapsedMS := float64(elapsed.Nanoseconds()) / 1e6
+	elapsedMS := float64(elapsed.Nanoseconds()) / nanosecondsPerMillisecond
 
 	return Entry{
 		StartedDateTime: start,
 		Time:            elapsedMS,
-		Request:         m.buildRequest(r, reqBodySize),
-		Response:        m.buildResponse(cw),
+		Request:         m.buildRequest(req, reqBodySize),
+		Response:        m.buildResponse(capture),
 		Timings: Timings{
 			Send:    0,
 			Wait:    elapsedMS,
@@ -96,34 +99,34 @@ func (m *Middleware) buildEntry(
 	}
 }
 
-func (m *Middleware) buildRequest(r *http.Request, bodySize int64) Request {
+func (m *Middleware) buildRequest(req *http.Request, bodySize int64) Request {
 	scheme := "http"
-	if r.TLS != nil {
+	if req.TLS != nil {
 		scheme = "https"
 	}
 
-	fullURL := fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
+	fullURL := fmt.Sprintf("%s://%s%s", scheme, req.Host, req.RequestURI)
 
 	var cookies []Cookie
 
 	if m.captureSecureHeaders {
-		cookies = cookiesToHAR(r.Cookies())
+		cookies = cookiesToHAR(req.Cookies())
 	}
 
 	return Request{
-		Method:      r.Method,
+		Method:      req.Method,
 		URL:         fullURL,
-		HTTPVersion: r.Proto,
-		Headers:     m.headersToNameValues(r.Header),
-		QueryString: queryToNameValues(r.URL.Query()),
+		HTTPVersion: req.Proto,
+		Headers:     m.headersToNameValues(req.Header),
+		QueryString: queryToNameValues(req.URL.Query()),
 		Cookies:     cookies,
 		HeadersSize: -1,
 		BodySize:    bodySize,
 	}
 }
 
-func (m *Middleware) buildResponse(cw *captureWriter) Response {
-	mimeType := cw.Header().Get("Content-Type")
+func (m *Middleware) buildResponse(capture *captureWriter) Response {
+	mimeType := capture.Header().Get("Content-Type")
 	if mimeType == "" {
 		mimeType = "application/octet-stream"
 	}
@@ -131,20 +134,20 @@ func (m *Middleware) buildResponse(cw *captureWriter) Response {
 	var cookies []Cookie
 
 	if m.captureSecureHeaders {
-		cookies = cookiesToHAR(extractResponseCookies(cw.Header()))
+		cookies = cookiesToHAR(extractResponseCookies(capture.Header()))
 	}
 
-	rawBody := cw.body()
-	content := buildContent(rawBody, cw.Header().Get("Content-Encoding"), mimeType)
+	rawBody := capture.body()
+	content := buildContent(rawBody, capture.Header().Get("Content-Encoding"), mimeType)
 
 	return Response{
-		Status:      cw.code,
-		StatusText:  http.StatusText(cw.code),
+		Status:      capture.code,
+		StatusText:  http.StatusText(capture.code),
 		HTTPVersion: "HTTP/1.1",
-		Headers:     m.headersToNameValues(cw.Header()),
+		Headers:     m.headersToNameValues(capture.Header()),
 		Cookies:     cookies,
 		Content:     content,
-		RedirectURL: cw.Header().Get("Location"),
+		RedirectURL: capture.Header().Get("Location"),
 		HeadersSize: -1,
 		BodySize:    int64(len(rawBody)),
 	}

--- a/internal/handler/har/middleware.go
+++ b/internal/handler/har/middleware.go
@@ -1,0 +1,163 @@
+package har
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/evg4b/uncors/internal/helpers"
+)
+
+// Middleware captures every request/response pair and enqueues a HAR
+// entry to the async Writer. The handler chain is never blocked.
+type Middleware struct {
+	writer *Writer
+}
+
+// NewMiddleware creates a Middleware backed by the given Writer.
+func NewMiddleware(opts ...MiddlewareOption) *Middleware {
+	return helpers.ApplyOptions(&Middleware{}, opts)
+}
+
+// Wrap returns a Handler that records the transaction before passing
+// control to next.
+func (m *Middleware) Wrap(next contracts.Handler) contracts.Handler {
+	return contracts.HandlerFunc(func(w contracts.ResponseWriter, r *contracts.Request) {
+		start := time.Now()
+
+		cw := newCaptureWriter(w)
+
+		var reqBodySize int64
+
+		if r.Body != nil && r.Body != http.NoBody {
+			var buf strings.Builder
+
+			n, _ := io.Copy(&buf, r.Body)
+			reqBodySize = n
+			_ = r.Body.Close()
+
+			// Restore body so the next handler can read it.
+			r.Body = io.NopCloser(strings.NewReader(buf.String()))
+		}
+
+		next.ServeHTTP(cw, r)
+
+		elapsed := time.Since(start)
+
+		entry := m.buildEntry(r, cw, start, elapsed, reqBodySize)
+
+		m.writer.AddEntry(entry)
+	})
+}
+
+func (m *Middleware) buildEntry(
+	r *http.Request,
+	cw *captureWriter,
+	start time.Time,
+	elapsed time.Duration,
+	reqBodySize int64,
+) Entry {
+	elapsedMS := float64(elapsed.Nanoseconds()) / 1e6
+
+	respBody := cw.body()
+
+	return Entry{
+		StartedDateTime: start,
+		Time:            elapsedMS,
+		Request:         m.buildRequest(r, reqBodySize),
+		Response:        m.buildResponse(cw, respBody),
+		Timings: Timings{
+			Send:    0,
+			Wait:    elapsedMS,
+			Receive: 0,
+		},
+	}
+}
+
+func (*Middleware) buildRequest(r *http.Request, bodySize int64) Request {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	fullURL := fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
+
+	return Request{
+		Method:      r.Method,
+		URL:         fullURL,
+		HTTPVersion: r.Proto,
+		Headers:     headersToNameValues(r.Header),
+		QueryString: queryToNameValues(r.URL.Query()),
+		Cookies:     cookiesToHAR(r.Cookies()),
+		HeadersSize: -1,
+		BodySize:    bodySize,
+	}
+}
+
+func (*Middleware) buildResponse(cw *captureWriter, body []byte) Response {
+	mimeType := cw.Header().Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
+	return Response{
+		Status:      cw.code,
+		StatusText:  http.StatusText(cw.code),
+		HTTPVersion: "HTTP/1.1",
+		Headers:     headersToNameValues(cw.Header()),
+		Cookies:     cookiesToHAR(extractResponseCookies(cw.Header())),
+		Content: Content{
+			Size:     int64(len(body)),
+			MimeType: mimeType,
+			Text:     string(body),
+		},
+		RedirectURL: cw.Header().Get("Location"),
+		HeadersSize: -1,
+		BodySize:    int64(len(body)),
+	}
+}
+
+func headersToNameValues(h http.Header) []NameValue {
+	result := make([]NameValue, 0, len(h))
+
+	for name, values := range h {
+		for _, v := range values {
+			result = append(result, NameValue{Name: name, Value: v})
+		}
+	}
+
+	return result
+}
+
+func queryToNameValues(q url.Values) []NameValue {
+	result := make([]NameValue, 0, len(q))
+
+	for k, vals := range q {
+		for _, v := range vals {
+			result = append(result, NameValue{Name: k, Value: v})
+		}
+	}
+
+	return result
+}
+
+func cookiesToHAR(cookies []*http.Cookie) []Cookie {
+	result := make([]Cookie, 0, len(cookies))
+
+	for _, c := range cookies {
+		result = append(result, Cookie{Name: c.Name, Value: c.Value})
+	}
+
+	return result
+}
+
+func extractResponseCookies(h http.Header) []*http.Cookie {
+	// Parse Set-Cookie headers via a synthetic response.
+	resp := &http.Response{Header: h}
+
+	return resp.Cookies()
+}

--- a/internal/handler/har/middleware.go
+++ b/internal/handler/har/middleware.go
@@ -12,18 +12,30 @@ import (
 	"github.com/evg4b/uncors/internal/helpers"
 )
 
-// cookieHeaderNames are headers that carry cookie data.
-// They are excluded from header lists when captureCookies is false.
-var cookieHeaderNames = map[string]bool{
-	"Cookie":     true,
-	"Set-Cookie": true,
+// secureHeaderNames is the set of HTTP headers that may carry credentials or
+// session data. They are stripped from HAR entries by default and are only
+// included when captureSecureHeaders is true.
+//
+// The list covers RFC-defined authentication and cookie headers:
+//   - Cookie / Set-Cookie  — session identifiers
+//   - Authorization        — Bearer tokens, Basic credentials
+//   - WWW-Authenticate     — server auth challenges (reveals scheme/realm)
+//   - Proxy-Authorization  — proxy credentials
+//   - Proxy-Authenticate   — proxy auth challenges
+var secureHeaderNames = map[string]bool{
+	"Cookie":              true,
+	"Set-Cookie":          true,
+	"Authorization":       true,
+	"Www-Authenticate":    true, // Go canonicalises header names
+	"Proxy-Authorization": true,
+	"Proxy-Authenticate":  true,
 }
 
 // Middleware captures every request/response pair and enqueues a HAR
 // entry to the async Writer. The handler chain is never blocked.
 type Middleware struct {
-	writer         *Writer
-	captureCookies bool
+	writer               *Writer
+	captureSecureHeaders bool
 }
 
 // NewMiddleware creates a Middleware backed by the given Writer.
@@ -94,7 +106,7 @@ func (m *Middleware) buildRequest(r *http.Request, bodySize int64) Request {
 
 	var cookies []Cookie
 
-	if m.captureCookies {
+	if m.captureSecureHeaders {
 		cookies = cookiesToHAR(r.Cookies())
 	}
 
@@ -118,7 +130,7 @@ func (m *Middleware) buildResponse(cw *captureWriter) Response {
 
 	var cookies []Cookie
 
-	if m.captureCookies {
+	if m.captureSecureHeaders {
 		cookies = cookiesToHAR(extractResponseCookies(cw.Header()))
 	}
 
@@ -139,12 +151,13 @@ func (m *Middleware) buildResponse(cw *captureWriter) Response {
 }
 
 // headersToNameValues converts an http.Header to a slice of NameValue pairs.
-// When captureCookies is false, Cookie and Set-Cookie headers are excluded.
+// When captureSecureHeaders is false, all headers in secureHeaderNames are
+// excluded to avoid persisting credentials in the HAR file.
 func (m *Middleware) headersToNameValues(h http.Header) []NameValue {
 	result := make([]NameValue, 0, len(h))
 
 	for name, values := range h {
-		if !m.captureCookies && cookieHeaderNames[name] {
+		if !m.captureSecureHeaders && secureHeaderNames[name] {
 			continue
 		}
 

--- a/internal/handler/har/middleware.go
+++ b/internal/handler/har/middleware.go
@@ -12,10 +12,18 @@ import (
 	"github.com/evg4b/uncors/internal/helpers"
 )
 
+// cookieHeaderNames are headers that carry cookie data.
+// They are excluded from header lists when captureCookies is false.
+var cookieHeaderNames = map[string]bool{
+	"Cookie":     true,
+	"Set-Cookie": true,
+}
+
 // Middleware captures every request/response pair and enqueues a HAR
 // entry to the async Writer. The handler chain is never blocked.
 type Middleware struct {
-	writer *Writer
+	writer         *Writer
+	captureCookies bool
 }
 
 // NewMiddleware creates a Middleware backed by the given Writer.
@@ -63,13 +71,11 @@ func (m *Middleware) buildEntry(
 ) Entry {
 	elapsedMS := float64(elapsed.Nanoseconds()) / 1e6
 
-	respBody := cw.body()
-
 	return Entry{
 		StartedDateTime: start,
 		Time:            elapsedMS,
 		Request:         m.buildRequest(r, reqBodySize),
-		Response:        m.buildResponse(cw, respBody),
+		Response:        m.buildResponse(cw),
 		Timings: Timings{
 			Send:    0,
 			Wait:    elapsedMS,
@@ -78,7 +84,7 @@ func (m *Middleware) buildEntry(
 	}
 }
 
-func (*Middleware) buildRequest(r *http.Request, bodySize int64) Request {
+func (m *Middleware) buildRequest(r *http.Request, bodySize int64) Request {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
@@ -86,45 +92,62 @@ func (*Middleware) buildRequest(r *http.Request, bodySize int64) Request {
 
 	fullURL := fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
 
+	var cookies []Cookie
+
+	if m.captureCookies {
+		cookies = cookiesToHAR(r.Cookies())
+	}
+
 	return Request{
 		Method:      r.Method,
 		URL:         fullURL,
 		HTTPVersion: r.Proto,
-		Headers:     headersToNameValues(r.Header),
+		Headers:     m.headersToNameValues(r.Header),
 		QueryString: queryToNameValues(r.URL.Query()),
-		Cookies:     cookiesToHAR(r.Cookies()),
+		Cookies:     cookies,
 		HeadersSize: -1,
 		BodySize:    bodySize,
 	}
 }
 
-func (*Middleware) buildResponse(cw *captureWriter, body []byte) Response {
+func (m *Middleware) buildResponse(cw *captureWriter) Response {
 	mimeType := cw.Header().Get("Content-Type")
 	if mimeType == "" {
 		mimeType = "application/octet-stream"
 	}
 
+	var cookies []Cookie
+
+	if m.captureCookies {
+		cookies = cookiesToHAR(extractResponseCookies(cw.Header()))
+	}
+
+	rawBody := cw.body()
+	content := buildContent(rawBody, cw.Header().Get("Content-Encoding"), mimeType)
+
 	return Response{
 		Status:      cw.code,
 		StatusText:  http.StatusText(cw.code),
 		HTTPVersion: "HTTP/1.1",
-		Headers:     headersToNameValues(cw.Header()),
-		Cookies:     cookiesToHAR(extractResponseCookies(cw.Header())),
-		Content: Content{
-			Size:     int64(len(body)),
-			MimeType: mimeType,
-			Text:     string(body),
-		},
+		Headers:     m.headersToNameValues(cw.Header()),
+		Cookies:     cookies,
+		Content:     content,
 		RedirectURL: cw.Header().Get("Location"),
 		HeadersSize: -1,
-		BodySize:    int64(len(body)),
+		BodySize:    int64(len(rawBody)),
 	}
 }
 
-func headersToNameValues(h http.Header) []NameValue {
+// headersToNameValues converts an http.Header to a slice of NameValue pairs.
+// When captureCookies is false, Cookie and Set-Cookie headers are excluded.
+func (m *Middleware) headersToNameValues(h http.Header) []NameValue {
 	result := make([]NameValue, 0, len(h))
 
 	for name, values := range h {
+		if !m.captureCookies && cookieHeaderNames[name] {
+			continue
+		}
+
 		for _, v := range values {
 			result = append(result, NameValue{Name: name, Value: v})
 		}

--- a/internal/handler/har/middleware.go
+++ b/internal/handler/har/middleware.go
@@ -12,19 +12,8 @@ import (
 	"github.com/evg4b/uncors/internal/helpers"
 )
 
-// nanosecondsPerMillisecond is used to convert nanoseconds to milliseconds.
 const nanosecondsPerMillisecond = 1e6
 
-// secureHeaderNames is the set of HTTP headers that may carry credentials or
-// session data. They are stripped from HAR entries by default and are only
-// included when captureSecureHeaders is true.
-//
-// The list covers RFC-defined authentication and cookie headers:
-//   - Cookie / Set-Cookie  — session identifiers
-//   - Authorization        — Bearer tokens, Basic credentials
-//   - WWW-Authenticate     — server auth challenges (reveals scheme/realm)
-//   - Proxy-Authorization  — proxy credentials
-//   - Proxy-Authenticate   — proxy auth challenges
 var secureHeaderNames = map[string]bool{
 	"Cookie":              true,
 	"Set-Cookie":          true,
@@ -34,16 +23,11 @@ var secureHeaderNames = map[string]bool{
 	"Proxy-Authenticate":  true,
 }
 
-// Middleware captures every request/response pair and enqueues a HAR
-// entry to the async Writer. The handler chain is never blocked.
 type Middleware struct {
 	writer               *Writer
 	captureSecureHeaders bool
 }
 
-// NewMiddleware creates a Middleware backed by the given Writer.
-// It panics if WithWriter is not provided, because a Middleware
-// without a Writer can never record anything.
 func NewMiddleware(opts ...MiddlewareOption) *Middleware {
 	m := helpers.ApplyOptions(&Middleware{}, opts)
 	if m.writer == nil {
@@ -53,8 +37,6 @@ func NewMiddleware(opts ...MiddlewareOption) *Middleware {
 	return m
 }
 
-// Wrap returns a Handler that records the transaction before passing
-// control to next.
 func (m *Middleware) Wrap(next contracts.Handler) contracts.Handler {
 	return contracts.HandlerFunc(func(w contracts.ResponseWriter, req *contracts.Request) {
 		start := time.Now()
@@ -160,9 +142,6 @@ func (m *Middleware) buildResponse(capture *captureWriter) Response {
 	}
 }
 
-// headersToNameValues converts an http.Header to a slice of NameValue pairs.
-// When captureSecureHeaders is false, all headers in secureHeaderNames are
-// excluded to avoid persisting credentials in the HAR file.
 func (m *Middleware) headersToNameValues(h http.Header) []NameValue {
 	result := make([]NameValue, 0, len(h))
 

--- a/internal/handler/har/middleware.go
+++ b/internal/handler/har/middleware.go
@@ -42,8 +42,15 @@ type Middleware struct {
 }
 
 // NewMiddleware creates a Middleware backed by the given Writer.
+// It panics if WithWriter is not provided, because a Middleware
+// without a Writer can never record anything.
 func NewMiddleware(opts ...MiddlewareOption) *Middleware {
-	return helpers.ApplyOptions(&Middleware{}, opts)
+	m := helpers.ApplyOptions(&Middleware{}, opts)
+	if m.writer == nil {
+		panic("har: NewMiddleware requires WithWriter option")
+	}
+
+	return m
 }
 
 // Wrap returns a Handler that records the transaction before passing

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -1,10 +1,14 @@
 package har_test
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -27,17 +31,29 @@ func TestMiddleware_Wrap(t *testing.T) {
 		return req
 	}
 
-	newMiddleware := func(t *testing.T) (*har.Middleware, *har.Writer) {
+	newMiddleware := func(t *testing.T, opts ...har.MiddlewareOption) (*har.Middleware, *har.Writer, string) {
 		t.Helper()
 		path := filepath.Join(t.TempDir(), "test.har")
 		w := har.NewWriter(path)
-		m := har.NewMiddleware(har.WithWriter(w))
+		opts = append([]har.MiddlewareOption{har.WithWriter(w)}, opts...)
+		m := har.NewMiddleware(opts...)
 
-		return m, w
+		return m, w, path
+	}
+
+	readHAR := func(t *testing.T, path string) har.HAR {
+		t.Helper()
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		var archive har.HAR
+		require.NoError(t, json.Unmarshal(data, &archive))
+
+		return archive
 	}
 
 	t.Run("passes request to next handler", func(t *testing.T) {
-		m, w := newMiddleware(t)
+		m, w, _ := newMiddleware(t)
 
 		defer w.Close() //nolint:errcheck
 
@@ -55,7 +71,7 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("records response body correctly", func(t *testing.T) {
-		m, w := newMiddleware(t)
+		m, w, _ := newMiddleware(t)
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			rw.Header().Set("Content-Type", "text/plain")
@@ -72,7 +88,7 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("records request with query string", func(t *testing.T) {
-		m, w := newMiddleware(t)
+		m, w, _ := newMiddleware(t)
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			rw.WriteHeader(http.StatusNoContent)
@@ -88,7 +104,7 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("restores request body for downstream handlers", func(t *testing.T) {
-		m, w := newMiddleware(t)
+		m, w, _ := newMiddleware(t)
 
 		defer w.Close() //nolint:errcheck
 
@@ -108,5 +124,96 @@ func TestMiddleware_Wrap(t *testing.T) {
 		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
 
 		assert.Equal(t, body, received)
+	})
+
+	t.Run("cookies not captured by default", func(t *testing.T) {
+		m, w, path := newMiddleware(t) // no WithCaptureCookies → default false
+
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
+			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"})
+			rw.WriteHeader(http.StatusOK)
+		})
+
+		req := makeRequest(http.MethodGet, "http://example.com/")
+		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"})
+
+		rec := httptest.NewRecorder()
+		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
+
+		require.NoError(t, w.Close())
+
+		archive := readHAR(t, path)
+		require.Len(t, archive.Log.Entries, 1)
+		entry := archive.Log.Entries[0]
+
+		// Cookies arrays must be empty.
+		assert.Empty(t, entry.Request.Cookies)
+		assert.Empty(t, entry.Response.Cookies)
+
+		// Cookie / Set-Cookie headers must not appear.
+		for _, nv := range entry.Request.Headers {
+			assert.NotEqual(t, "Cookie", nv.Name)
+		}
+
+		for _, nv := range entry.Response.Headers {
+			assert.NotEqual(t, "Set-Cookie", nv.Name)
+		}
+	})
+
+	t.Run("cookies captured when WithCaptureCookies(true)", func(t *testing.T) {
+		m, w, path := newMiddleware(t, har.WithCaptureCookies(true))
+
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
+			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"})
+			rw.WriteHeader(http.StatusOK)
+		})
+
+		req := makeRequest(http.MethodGet, "http://example.com/")
+		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"})
+
+		rec := httptest.NewRecorder()
+		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
+
+		require.NoError(t, w.Close())
+
+		archive := readHAR(t, path)
+		require.Len(t, archive.Log.Entries, 1)
+		entry := archive.Log.Entries[0]
+
+		assert.NotEmpty(t, entry.Request.Cookies)
+		assert.NotEmpty(t, entry.Response.Cookies)
+	})
+
+	t.Run("gzip response body is decoded in HAR", func(t *testing.T) {
+		m, w, path := newMiddleware(t)
+
+		const originalBody = `{"status":"ok"}`
+
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, err := gz.Write([]byte(originalBody))
+		require.NoError(t, err)
+		require.NoError(t, gz.Close())
+
+		compressed := buf.Bytes()
+
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
+			rw.Header().Set("Content-Type", "application/json")
+			rw.Header().Set("Content-Encoding", "gzip")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(compressed)
+		})
+
+		rec := httptest.NewRecorder()
+		m.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/api"))
+
+		require.NoError(t, w.Close())
+
+		archive := readHAR(t, path)
+		require.Len(t, archive.Log.Entries, 1)
+
+		content := archive.Log.Entries[0].Response.Content
+		assert.Equal(t, originalBody, content.Text)
+		assert.Empty(t, content.Encoding, "encoding field should be empty for plain text")
 	})
 }

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -1,0 +1,112 @@
+package har_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/evg4b/uncors/internal/handler/har"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware_Wrap(t *testing.T) {
+	makeWriter := func(rec *httptest.ResponseRecorder) contracts.ResponseWriter {
+		return contracts.WrapResponseWriter(rec)
+	}
+
+	makeRequest := func(method, url string) *http.Request {
+		req, err := http.NewRequest(method, url, nil)
+		require.NoError(t, err)
+
+		return req
+	}
+
+	newMiddleware := func(t *testing.T) (*har.Middleware, *har.Writer) {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "test.har")
+		w := har.NewWriter(path)
+		m := har.NewMiddleware(har.WithWriter(w))
+
+		return m, w
+	}
+
+	t.Run("passes request to next handler", func(t *testing.T) {
+		m, w := newMiddleware(t)
+
+		defer w.Close() //nolint:errcheck
+
+		called := false
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, r *contracts.Request) {
+			called = true
+			rw.WriteHeader(http.StatusOK)
+		})
+
+		rec := httptest.NewRecorder()
+		m.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/path"))
+
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("records response body correctly", func(t *testing.T) {
+		m, w := newMiddleware(t)
+
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
+			rw.Header().Set("Content-Type", "text/plain")
+			rw.WriteHeader(http.StatusOK)
+			fmt.Fprint(rw, "hello")
+		})
+
+		rec := httptest.NewRecorder()
+		m.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/"))
+
+		require.NoError(t, w.Close())
+
+		assert.Equal(t, "hello", rec.Body.String())
+	})
+
+	t.Run("records request with query string", func(t *testing.T) {
+		m, w := newMiddleware(t)
+
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
+			rw.WriteHeader(http.StatusNoContent)
+		})
+
+		req := makeRequest(http.MethodGet, "http://example.com/search?q=foo&page=2")
+		rec := httptest.NewRecorder()
+		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
+
+		require.NoError(t, w.Close())
+
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+	})
+
+	t.Run("restores request body for downstream handlers", func(t *testing.T) {
+		m, w := newMiddleware(t)
+
+		defer w.Close() //nolint:errcheck
+
+		body := "request-payload"
+		var received string
+
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, r *contracts.Request) {
+			b, _ := io.ReadAll(r.Body)
+			received = string(b)
+			rw.WriteHeader(http.StatusOK)
+		})
+
+		req, err := http.NewRequest(http.MethodPost, "http://example.com/api", strings.NewReader(body))
+		require.NoError(t, err)
+
+		rec := httptest.NewRecorder()
+		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
+
+		assert.Equal(t, body, received)
+	})
+}

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -126,16 +126,18 @@ func TestMiddleware_Wrap(t *testing.T) {
 		assert.Equal(t, body, received)
 	})
 
-	t.Run("cookies not captured by default", func(t *testing.T) {
-		m, w, path := newMiddleware(t) // no WithCaptureCookies → default false
+	t.Run("secure headers not captured by default", func(t *testing.T) {
+		m, w, path := newMiddleware(t) // captureSecureHeaders defaults to false
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"})
+			rw.Header().Set("Www-Authenticate", `Bearer realm="api"`)
 			rw.WriteHeader(http.StatusOK)
 		})
 
 		req := makeRequest(http.MethodGet, "http://example.com/")
 		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"})
+		req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiJ9")
 
 		rec := httptest.NewRecorder()
 		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
@@ -150,18 +152,22 @@ func TestMiddleware_Wrap(t *testing.T) {
 		assert.Empty(t, entry.Request.Cookies)
 		assert.Empty(t, entry.Response.Cookies)
 
-		// Cookie / Set-Cookie headers must not appear.
-		for _, nv := range entry.Request.Headers {
-			assert.NotEqual(t, "Cookie", nv.Name)
+		// Sensitive headers must not appear.
+		blocked := []string{"Cookie", "Authorization"}
+		for _, name := range blocked {
+			for _, nv := range entry.Request.Headers {
+				assert.NotEqual(t, name, nv.Name, "request header %s must be stripped", name)
+			}
 		}
 
 		for _, nv := range entry.Response.Headers {
 			assert.NotEqual(t, "Set-Cookie", nv.Name)
+			assert.NotEqual(t, "Www-Authenticate", nv.Name)
 		}
 	})
 
-	t.Run("cookies captured when WithCaptureCookies(true)", func(t *testing.T) {
-		m, w, path := newMiddleware(t, har.WithCaptureCookies(true))
+	t.Run("secure headers captured when WithCaptureSecureHeaders(true)", func(t *testing.T) {
+		m, w, path := newMiddleware(t, har.WithCaptureSecureHeaders(true))
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"})
@@ -170,6 +176,7 @@ func TestMiddleware_Wrap(t *testing.T) {
 
 		req := makeRequest(http.MethodGet, "http://example.com/")
 		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"})
+		req.Header.Set("Authorization", "Bearer token123")
 
 		rec := httptest.NewRecorder()
 		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
@@ -182,6 +189,18 @@ func TestMiddleware_Wrap(t *testing.T) {
 
 		assert.NotEmpty(t, entry.Request.Cookies)
 		assert.NotEmpty(t, entry.Response.Cookies)
+
+		var hasAuth bool
+
+		for _, nv := range entry.Request.Headers {
+			if nv.Name == "Authorization" {
+				hasAuth = true
+
+				break
+			}
+		}
+
+		assert.True(t, hasAuth, "Authorization header must be present when captureSecureHeaders is true")
 	})
 
 	t.Run("gzip response body is decoded in HAR", func(t *testing.T) {

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -3,6 +3,7 @@ package har_test
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,8 +25,8 @@ func TestMiddleware_Wrap(t *testing.T) {
 		return contracts.WrapResponseWriter(rec)
 	}
 
-	makeRequest := func(method, url string) *http.Request {
-		req, err := http.NewRequest(method, url, nil)
+	makeRequest := func(method, rawURL string) *http.Request {
+		req, err := http.NewRequestWithContext(context.Background(), method, rawURL, nil)
 		require.NoError(t, err)
 
 		return req
@@ -33,16 +34,18 @@ func TestMiddleware_Wrap(t *testing.T) {
 
 	newMiddleware := func(t *testing.T, opts ...har.MiddlewareOption) (*har.Middleware, *har.Writer, string) {
 		t.Helper()
-		path := filepath.Join(t.TempDir(), "test.har")
-		w := har.NewWriter(path)
-		opts = append([]har.MiddlewareOption{har.WithWriter(w)}, opts...)
-		m := har.NewMiddleware(opts...)
 
-		return m, w, path
+		path := filepath.Join(t.TempDir(), "test.har")
+		harWriter := har.NewWriter(path)
+		opts = append([]har.MiddlewareOption{har.WithWriter(harWriter)}, opts...)
+		mdlw := har.NewMiddleware(opts...)
+
+		return mdlw, harWriter, path
 	}
 
 	readHAR := func(t *testing.T, path string) har.HAR {
 		t.Helper()
+
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
 
@@ -53,25 +56,26 @@ func TestMiddleware_Wrap(t *testing.T) {
 	}
 
 	t.Run("passes request to next handler", func(t *testing.T) {
-		m, w, _ := newMiddleware(t)
+		mdlw, harWriter, _ := newMiddleware(t)
 
-		defer w.Close() //nolint:errcheck
+		defer harWriter.Close() //nolint:errcheck
 
 		called := false
-		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, r *contracts.Request) {
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			called = true
+
 			rw.WriteHeader(http.StatusOK)
 		})
 
 		rec := httptest.NewRecorder()
-		m.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/path"))
+		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/path"))
 
 		assert.True(t, called)
 		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("records response body correctly", func(t *testing.T) {
-		m, w, _ := newMiddleware(t)
+		mdlw, harWriter, _ := newMiddleware(t)
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			rw.Header().Set("Content-Type", "text/plain")
@@ -80,15 +84,15 @@ func TestMiddleware_Wrap(t *testing.T) {
 		})
 
 		rec := httptest.NewRecorder()
-		m.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/"))
+		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/"))
 
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
 
 		assert.Equal(t, "hello", rec.Body.String())
 	})
 
 	t.Run("records request with query string", func(t *testing.T) {
-		m, w, _ := newMiddleware(t)
+		mdlw, harWriter, _ := newMiddleware(t)
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			rw.WriteHeader(http.StatusNoContent)
@@ -96,38 +100,42 @@ func TestMiddleware_Wrap(t *testing.T) {
 
 		req := makeRequest(http.MethodGet, "http://example.com/search?q=foo&page=2")
 		rec := httptest.NewRecorder()
-		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
+		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), req)
 
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
 
 		assert.Equal(t, http.StatusNoContent, rec.Code)
 	})
 
 	t.Run("restores request body for downstream handlers", func(t *testing.T) {
-		m, w, _ := newMiddleware(t)
+		mdlw, harWriter, _ := newMiddleware(t)
 
-		defer w.Close() //nolint:errcheck
+		defer harWriter.Close() //nolint:errcheck
 
 		body := "request-payload"
+
 		var received string
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, r *contracts.Request) {
 			b, _ := io.ReadAll(r.Body)
 			received = string(b)
+
 			rw.WriteHeader(http.StatusOK)
 		})
 
-		req, err := http.NewRequest(http.MethodPost, "http://example.com/api", strings.NewReader(body))
+		req, err := http.NewRequestWithContext(
+			context.Background(), http.MethodPost, "http://example.com/api", strings.NewReader(body),
+		)
 		require.NoError(t, err)
 
 		rec := httptest.NewRecorder()
-		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
+		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), req)
 
 		assert.Equal(t, body, received)
 	})
 
 	t.Run("secure headers not captured by default", func(t *testing.T) {
-		m, w, path := newMiddleware(t) // captureSecureHeaders defaults to false
+		mdlw, harWriter, path := newMiddleware(t) // captureSecureHeaders defaults to false
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"})
@@ -140,12 +148,13 @@ func TestMiddleware_Wrap(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiJ9")
 
 		rec := httptest.NewRecorder()
-		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
+		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), req)
 
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
 
 		archive := readHAR(t, path)
 		require.Len(t, archive.Log.Entries, 1)
+
 		entry := archive.Log.Entries[0]
 
 		// Cookies arrays must be empty.
@@ -167,7 +176,7 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("secure headers captured when WithCaptureSecureHeaders(true)", func(t *testing.T) {
-		m, w, path := newMiddleware(t, har.WithCaptureSecureHeaders(true))
+		mdlw, harWriter, path := newMiddleware(t, har.WithCaptureSecureHeaders(true))
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"})
@@ -179,12 +188,13 @@ func TestMiddleware_Wrap(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer token123")
 
 		rec := httptest.NewRecorder()
-		m.Wrap(next).ServeHTTP(makeWriter(rec), req)
+		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), req)
 
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
 
 		archive := readHAR(t, path)
 		require.Len(t, archive.Log.Entries, 1)
+
 		entry := archive.Log.Entries[0]
 
 		assert.NotEmpty(t, entry.Request.Cookies)
@@ -204,11 +214,12 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("gzip response body is decoded in HAR", func(t *testing.T) {
-		m, w, path := newMiddleware(t)
+		mdlw, harWriter, path := newMiddleware(t)
 
 		const originalBody = `{"status":"ok"}`
 
 		var buf bytes.Buffer
+
 		gz := gzip.NewWriter(&buf)
 		_, err := gz.Write([]byte(originalBody))
 		require.NoError(t, err)
@@ -224,15 +235,15 @@ func TestMiddleware_Wrap(t *testing.T) {
 		})
 
 		rec := httptest.NewRecorder()
-		m.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/api"))
+		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/api"))
 
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
 
 		archive := readHAR(t, path)
 		require.Len(t, archive.Log.Entries, 1)
 
 		content := archive.Log.Entries[0].Response.Content
-		assert.Equal(t, originalBody, content.Text)
+		assert.JSONEq(t, originalBody, content.Text)
 		assert.Empty(t, content.Encoding, "encoding field should be empty for plain text")
 	})
 }

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -22,12 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// makeHARWriter wraps httptest.ResponseRecorder in a contracts.ResponseWriter.
 func makeHARWriter(rec *httptest.ResponseRecorder) contracts.ResponseWriter {
 	return contracts.WrapResponseWriter(rec)
 }
 
-// makeHARRequest creates a GET request with the given URL.
 func makeHARRequest(t *testing.T, rawURL string) *http.Request {
 	t.Helper()
 
@@ -37,8 +35,6 @@ func makeHARRequest(t *testing.T, rawURL string) *http.Request {
 	return req
 }
 
-// newHARMiddleware builds a Middleware backed by a temp-file Writer and returns
-// all three so callers can assert on the archive file.
 func newHARMiddleware(t *testing.T, opts ...har.MiddlewareOption) (*har.Middleware, *har.Writer, string) {
 	t.Helper()
 
@@ -50,7 +46,6 @@ func newHARMiddleware(t *testing.T, opts ...har.MiddlewareOption) (*har.Middlewa
 	return mdlw, harWriter, path
 }
 
-// readHARFile reads and unmarshals a HAR file produced by Writer.
 func readHARFile(t *testing.T, path string) har.HAR {
 	t.Helper()
 
@@ -63,7 +58,6 @@ func readHARFile(t *testing.T, path string) har.HAR {
 	return archive
 }
 
-// compressBody compresses data with the named algorithm ("gzip" or "deflate").
 func compressBody(t *testing.T, algo string, data []byte) []byte {
 	t.Helper()
 
@@ -164,7 +158,7 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("secure headers not captured by default", func(t *testing.T) {
-		mdlw, harWriter, path := newHARMiddleware(t) // captureSecureHeaders defaults to false
+		mdlw, harWriter, path := newHARMiddleware(t)
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"}) // nolint: gosec

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -3,6 +3,7 @@ package har_test
 import (
 	"bytes"
 	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -213,37 +214,68 @@ func TestMiddleware_Wrap(t *testing.T) {
 		assert.True(t, hasAuth, "Authorization header must be present when captureSecureHeaders is true")
 	})
 
-	t.Run("gzip response body is decoded in HAR", func(t *testing.T) {
-		mdlw, harWriter, path := newMiddleware(t)
+	t.Run("compressed response bodies are decoded in HAR", func(t *testing.T) {
+		compress := func(t *testing.T, algo string, data []byte) []byte {
+			t.Helper()
 
-		const originalBody = `{"status":"ok"}`
+			var buf bytes.Buffer
 
-		var buf bytes.Buffer
+			switch algo {
+			case "gzip":
+				w := gzip.NewWriter(&buf)
+				_, _ = w.Write(data)
+				require.NoError(t, w.Close())
+			case "deflate":
+				w := zlib.NewWriter(&buf)
+				_, _ = w.Write(data)
+				require.NoError(t, w.Close())
+			}
 
-		gz := gzip.NewWriter(&buf)
-		_, err := gz.Write([]byte(originalBody))
-		require.NoError(t, err)
-		require.NoError(t, gz.Close())
+			return buf.Bytes()
+		}
 
-		compressed := buf.Bytes()
+		tests := []struct {
+			encoding string
+		}{
+			{encoding: "gzip"},
+			{encoding: "deflate"},
+		}
 
-		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
-			rw.Header().Set("Content-Type", "application/json")
-			rw.Header().Set("Content-Encoding", "gzip")
-			rw.WriteHeader(http.StatusOK)
-			_, _ = rw.Write(compressed)
-		})
+		for _, testCase := range tests {
+			t.Run(testCase.encoding, func(t *testing.T) {
+				mdlw, harWriter, path := newMiddleware(t)
 
-		rec := httptest.NewRecorder()
-		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/api"))
+				const originalBody = `{"status":"ok"}`
 
-		require.NoError(t, harWriter.Close())
+				compressed := compress(t, testCase.encoding, []byte(originalBody))
 
-		archive := readHAR(t, path)
-		require.Len(t, archive.Log.Entries, 1)
+				next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
+					rw.Header().Set("Content-Type", "application/json")
+					rw.Header().Set("Content-Encoding", testCase.encoding)
+					rw.WriteHeader(http.StatusOK)
+					_, _ = rw.Write(compressed)
+				})
 
-		content := archive.Log.Entries[0].Response.Content
-		assert.JSONEq(t, originalBody, content.Text)
-		assert.Empty(t, content.Encoding, "encoding field should be empty for plain text")
+				rec := httptest.NewRecorder()
+				mdlw.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/api"))
+
+				require.NoError(t, harWriter.Close())
+
+				archive := readHAR(t, path)
+				require.Len(t, archive.Log.Entries, 1)
+
+				content := archive.Log.Entries[0].Response.Content
+				assert.JSONEq(t, originalBody, content.Text)
+				assert.Empty(t, content.Encoding, "encoding field should be empty for decoded text")
+			})
+		}
 	})
+}
+
+func TestNewMiddleware_NilWriterPanic(t *testing.T) {
+	assert.PanicsWithValue(
+		t,
+		"har: NewMiddleware requires WithWriter option",
+		func() { har.NewMiddleware() },
+	)
 }

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -21,43 +21,70 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// makeHARWriter wraps httptest.ResponseRecorder in a contracts.ResponseWriter.
+func makeHARWriter(rec *httptest.ResponseRecorder) contracts.ResponseWriter {
+	return contracts.WrapResponseWriter(rec)
+}
+
+// makeHARRequest creates a GET request with the given URL.
+func makeHARRequest(t *testing.T, rawURL string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, nil)
+	require.NoError(t, err)
+
+	return req
+}
+
+// newHARMiddleware builds a Middleware backed by a temp-file Writer and returns
+// all three so callers can assert on the archive file.
+func newHARMiddleware(t *testing.T, opts ...har.MiddlewareOption) (*har.Middleware, *har.Writer, string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.har")
+	harWriter := har.NewWriter(path)
+	opts = append([]har.MiddlewareOption{har.WithWriter(harWriter)}, opts...)
+	mdlw := har.NewMiddleware(opts...)
+
+	return mdlw, harWriter, path
+}
+
+// readHARFile reads and unmarshals a HAR file produced by Writer.
+func readHARFile(t *testing.T, path string) har.HAR {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var archive har.HAR
+	require.NoError(t, json.Unmarshal(data, &archive))
+
+	return archive
+}
+
+// compressBody compresses data with the named algorithm ("gzip" or "deflate").
+func compressBody(t *testing.T, algo string, data []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	switch algo {
+	case "gzip":
+		w := gzip.NewWriter(&buf)
+		_, _ = w.Write(data)
+		require.NoError(t, w.Close())
+	case "deflate":
+		w := zlib.NewWriter(&buf)
+		_, _ = w.Write(data)
+		require.NoError(t, w.Close())
+	}
+
+	return buf.Bytes()
+}
+
 func TestMiddleware_Wrap(t *testing.T) {
-	makeWriter := func(rec *httptest.ResponseRecorder) contracts.ResponseWriter {
-		return contracts.WrapResponseWriter(rec)
-	}
-
-	makeRequest := func(method, rawURL string) *http.Request {
-		req, err := http.NewRequestWithContext(context.Background(), method, rawURL, nil)
-		require.NoError(t, err)
-
-		return req
-	}
-
-	newMiddleware := func(t *testing.T, opts ...har.MiddlewareOption) (*har.Middleware, *har.Writer, string) {
-		t.Helper()
-
-		path := filepath.Join(t.TempDir(), "test.har")
-		harWriter := har.NewWriter(path)
-		opts = append([]har.MiddlewareOption{har.WithWriter(harWriter)}, opts...)
-		mdlw := har.NewMiddleware(opts...)
-
-		return mdlw, harWriter, path
-	}
-
-	readHAR := func(t *testing.T, path string) har.HAR {
-		t.Helper()
-
-		data, err := os.ReadFile(path)
-		require.NoError(t, err)
-
-		var archive har.HAR
-		require.NoError(t, json.Unmarshal(data, &archive))
-
-		return archive
-	}
-
 	t.Run("passes request to next handler", func(t *testing.T) {
-		mdlw, harWriter, _ := newMiddleware(t)
+		mdlw, harWriter, _ := newHARMiddleware(t)
 
 		defer harWriter.Close() //nolint:errcheck
 
@@ -69,14 +96,14 @@ func TestMiddleware_Wrap(t *testing.T) {
 		})
 
 		rec := httptest.NewRecorder()
-		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/path"))
+		mdlw.Wrap(next).ServeHTTP(makeHARWriter(rec), makeHARRequest(t, "http://example.com/path"))
 
 		assert.True(t, called)
 		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("records response body correctly", func(t *testing.T) {
-		mdlw, harWriter, _ := newMiddleware(t)
+		mdlw, harWriter, _ := newHARMiddleware(t)
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			rw.Header().Set("Content-Type", "text/plain")
@@ -85,7 +112,7 @@ func TestMiddleware_Wrap(t *testing.T) {
 		})
 
 		rec := httptest.NewRecorder()
-		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/"))
+		mdlw.Wrap(next).ServeHTTP(makeHARWriter(rec), makeHARRequest(t, "http://example.com/"))
 
 		require.NoError(t, harWriter.Close())
 
@@ -93,15 +120,15 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("records request with query string", func(t *testing.T) {
-		mdlw, harWriter, _ := newMiddleware(t)
+		mdlw, harWriter, _ := newHARMiddleware(t)
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			rw.WriteHeader(http.StatusNoContent)
 		})
 
-		req := makeRequest(http.MethodGet, "http://example.com/search?q=foo&page=2")
+		req := makeHARRequest(t, "http://example.com/search?q=foo&page=2")
 		rec := httptest.NewRecorder()
-		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), req)
+		mdlw.Wrap(next).ServeHTTP(makeHARWriter(rec), req)
 
 		require.NoError(t, harWriter.Close())
 
@@ -109,7 +136,7 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("restores request body for downstream handlers", func(t *testing.T) {
-		mdlw, harWriter, _ := newMiddleware(t)
+		mdlw, harWriter, _ := newHARMiddleware(t)
 
 		defer harWriter.Close() //nolint:errcheck
 
@@ -130,13 +157,13 @@ func TestMiddleware_Wrap(t *testing.T) {
 		require.NoError(t, err)
 
 		rec := httptest.NewRecorder()
-		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), req)
+		mdlw.Wrap(next).ServeHTTP(makeHARWriter(rec), req)
 
 		assert.Equal(t, body, received)
 	})
 
 	t.Run("secure headers not captured by default", func(t *testing.T) {
-		mdlw, harWriter, path := newMiddleware(t) // captureSecureHeaders defaults to false
+		mdlw, harWriter, path := newHARMiddleware(t) // captureSecureHeaders defaults to false
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"}) // nolint: gosec
@@ -144,16 +171,16 @@ func TestMiddleware_Wrap(t *testing.T) {
 			rw.WriteHeader(http.StatusOK)
 		})
 
-		req := makeRequest(http.MethodGet, "http://example.com/")
+		req := makeHARRequest(t, "http://example.com/")
 		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"}) // nolint: gosec
 		req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiJ9")
 
 		rec := httptest.NewRecorder()
-		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), req)
+		mdlw.Wrap(next).ServeHTTP(makeHARWriter(rec), req)
 
 		require.NoError(t, harWriter.Close())
 
-		archive := readHAR(t, path)
+		archive := readHARFile(t, path)
 		require.Len(t, archive.Log.Entries, 1)
 
 		entry := archive.Log.Entries[0]
@@ -177,23 +204,23 @@ func TestMiddleware_Wrap(t *testing.T) {
 	})
 
 	t.Run("secure headers captured when WithCaptureSecureHeaders(true)", func(t *testing.T) {
-		mdlw, harWriter, path := newMiddleware(t, har.WithCaptureSecureHeaders(true))
+		mdlw, harWriter, path := newHARMiddleware(t, har.WithCaptureSecureHeaders(true))
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
 			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"}) // nolint: gosec
 			rw.WriteHeader(http.StatusOK)
 		})
 
-		req := makeRequest(http.MethodGet, "http://example.com/")
+		req := makeHARRequest(t, "http://example.com/")
 		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"}) // nolint: gosec
 		req.Header.Set("Authorization", "Bearer token123")
 
 		rec := httptest.NewRecorder()
-		mdlw.Wrap(next).ServeHTTP(makeWriter(rec), req)
+		mdlw.Wrap(next).ServeHTTP(makeHARWriter(rec), req)
 
 		require.NoError(t, harWriter.Close())
 
-		archive := readHAR(t, path)
+		archive := readHARFile(t, path)
 		require.Len(t, archive.Log.Entries, 1)
 
 		entry := archive.Log.Entries[0]
@@ -213,63 +240,44 @@ func TestMiddleware_Wrap(t *testing.T) {
 
 		assert.True(t, hasAuth, "Authorization header must be present when captureSecureHeaders is true")
 	})
+}
 
-	t.Run("compressed response bodies are decoded in HAR", func(t *testing.T) {
-		compress := func(t *testing.T, algo string, data []byte) []byte {
-			t.Helper()
+func TestMiddleware_Wrap_Decompression(t *testing.T) {
+	tests := []struct {
+		encoding string
+	}{
+		{encoding: "gzip"},
+		{encoding: "deflate"},
+	}
 
-			var buf bytes.Buffer
+	for _, testCase := range tests {
+		t.Run(testCase.encoding, func(t *testing.T) {
+			mdlw, harWriter, path := newHARMiddleware(t)
 
-			switch algo {
-			case "gzip":
-				w := gzip.NewWriter(&buf)
-				_, _ = w.Write(data)
-				require.NoError(t, w.Close())
-			case "deflate":
-				w := zlib.NewWriter(&buf)
-				_, _ = w.Write(data)
-				require.NoError(t, w.Close())
-			}
+			const originalBody = `{"status":"ok"}`
 
-			return buf.Bytes()
-		}
+			compressed := compressBody(t, testCase.encoding, []byte(originalBody))
 
-		tests := []struct {
-			encoding string
-		}{
-			{encoding: "gzip"},
-			{encoding: "deflate"},
-		}
-
-		for _, testCase := range tests {
-			t.Run(testCase.encoding, func(t *testing.T) {
-				mdlw, harWriter, path := newMiddleware(t)
-
-				const originalBody = `{"status":"ok"}`
-
-				compressed := compress(t, testCase.encoding, []byte(originalBody))
-
-				next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
-					rw.Header().Set("Content-Type", "application/json")
-					rw.Header().Set("Content-Encoding", testCase.encoding)
-					rw.WriteHeader(http.StatusOK)
-					_, _ = rw.Write(compressed)
-				})
-
-				rec := httptest.NewRecorder()
-				mdlw.Wrap(next).ServeHTTP(makeWriter(rec), makeRequest(http.MethodGet, "http://example.com/api"))
-
-				require.NoError(t, harWriter.Close())
-
-				archive := readHAR(t, path)
-				require.Len(t, archive.Log.Entries, 1)
-
-				content := archive.Log.Entries[0].Response.Content
-				assert.JSONEq(t, originalBody, content.Text)
-				assert.Empty(t, content.Encoding, "encoding field should be empty for decoded text")
+			next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
+				rw.Header().Set("Content-Type", "application/json")
+				rw.Header().Set("Content-Encoding", testCase.encoding)
+				rw.WriteHeader(http.StatusOK)
+				_, _ = rw.Write(compressed)
 			})
-		}
-	})
+
+			rec := httptest.NewRecorder()
+			mdlw.Wrap(next).ServeHTTP(makeHARWriter(rec), makeHARRequest(t, "http://example.com/api"))
+
+			require.NoError(t, harWriter.Close())
+
+			archive := readHARFile(t, path)
+			require.Len(t, archive.Log.Entries, 1)
+
+			content := archive.Log.Entries[0].Response.Content
+			assert.JSONEq(t, originalBody, content.Text)
+			assert.Empty(t, content.Encoding, "encoding field should be empty for decoded text")
+		})
+	}
 }
 
 func TestNewMiddleware_NilWriterPanic(t *testing.T) {

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -138,13 +138,13 @@ func TestMiddleware_Wrap(t *testing.T) {
 		mdlw, harWriter, path := newMiddleware(t) // captureSecureHeaders defaults to false
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
-			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"})
+			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"}) // nolint: gosec
 			rw.Header().Set("Www-Authenticate", `Bearer realm="api"`)
 			rw.WriteHeader(http.StatusOK)
 		})
 
 		req := makeRequest(http.MethodGet, "http://example.com/")
-		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"})
+		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"}) // nolint: gosec
 		req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiJ9")
 
 		rec := httptest.NewRecorder()
@@ -179,12 +179,12 @@ func TestMiddleware_Wrap(t *testing.T) {
 		mdlw, harWriter, path := newMiddleware(t, har.WithCaptureSecureHeaders(true))
 
 		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
-			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"})
+			http.SetCookie(rw, &http.Cookie{Name: "session", Value: "abc"}) // nolint: gosec
 			rw.WriteHeader(http.StatusOK)
 		})
 
 		req := makeRequest(http.MethodGet, "http://example.com/")
-		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"})
+		req.AddCookie(&http.Cookie{Name: "token", Value: "secret"}) // nolint: gosec
 		req.Header.Set("Authorization", "Bearer token123")
 
 		rec := httptest.NewRecorder()

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"compress/zlib"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -201,6 +202,30 @@ func TestMiddleware_Wrap(t *testing.T) {
 			assert.NotEqual(t, "Set-Cookie", nv.Name)
 			assert.NotEqual(t, "Www-Authenticate", nv.Name)
 		}
+	})
+
+	t.Run("uses https scheme for TLS requests", func(t *testing.T) {
+		mdlw, harWriter, path := newHARMiddleware(t)
+
+		next := contracts.HandlerFunc(func(rw contracts.ResponseWriter, _ *contracts.Request) {
+			rw.WriteHeader(http.StatusOK)
+		})
+
+		req := makeHARRequest(t, "https://example.com/")
+		req.TLS = &tls.ConnectionState{}
+
+		rec := httptest.NewRecorder()
+		mdlw.Wrap(next).ServeHTTP(makeHARWriter(rec), req)
+
+		require.NoError(t, harWriter.Close())
+
+		archive := readHARFile(t, path)
+		require.Len(t, archive.Log.Entries, 1)
+
+		assert.True(t,
+			strings.HasPrefix(archive.Log.Entries[0].Request.URL, "https://"),
+			"URL must use https scheme for TLS requests",
+		)
 	})
 
 	t.Run("secure headers captured when WithCaptureSecureHeaders(true)", func(t *testing.T) {

--- a/internal/handler/har/options.go
+++ b/internal/handler/har/options.go
@@ -1,0 +1,11 @@
+package har
+
+// MiddlewareOption is a functional option for Middleware.
+type MiddlewareOption = func(*Middleware)
+
+// WithWriter sets the HAR writer the middleware uses to persist entries.
+func WithWriter(w *Writer) MiddlewareOption {
+	return func(m *Middleware) {
+		m.writer = w
+	}
+}

--- a/internal/handler/har/options.go
+++ b/internal/handler/har/options.go
@@ -10,11 +10,18 @@ func WithWriter(w *Writer) MiddlewareOption {
 	}
 }
 
-// WithCaptureCookies controls whether Cookie request headers and Set-Cookie
-// response headers are included in the HAR output. Defaults to false to
-// avoid accidentally persisting sensitive session data.
-func WithCaptureCookies(capture bool) MiddlewareOption {
+// WithCaptureSecureHeaders controls whether security-sensitive HTTP headers
+// are included in the HAR output. Defaults to false to prevent credentials
+// from being persisted to disk.
+//
+// Filtered headers when false:
+//   - Cookie / Set-Cookie  (session identifiers)
+//   - Authorization        (Bearer tokens, Basic credentials)
+//   - WWW-Authenticate     (server auth challenges)
+//   - Proxy-Authorization  (proxy credentials)
+//   - Proxy-Authenticate   (proxy auth challenges)
+func WithCaptureSecureHeaders(capture bool) MiddlewareOption {
 	return func(m *Middleware) {
-		m.captureCookies = capture
+		m.captureSecureHeaders = capture
 	}
 }

--- a/internal/handler/har/options.go
+++ b/internal/handler/har/options.go
@@ -9,3 +9,12 @@ func WithWriter(w *Writer) MiddlewareOption {
 		m.writer = w
 	}
 }
+
+// WithCaptureCookies controls whether Cookie request headers and Set-Cookie
+// response headers are included in the HAR output. Defaults to false to
+// avoid accidentally persisting sensitive session data.
+func WithCaptureCookies(capture bool) MiddlewareOption {
+	return func(m *Middleware) {
+		m.captureCookies = capture
+	}
+}

--- a/internal/handler/har/options.go
+++ b/internal/handler/har/options.go
@@ -11,15 +11,8 @@ func WithWriter(w *Writer) MiddlewareOption {
 }
 
 // WithCaptureSecureHeaders controls whether security-sensitive HTTP headers
-// are included in the HAR output. Defaults to false to prevent credentials
-// from being persisted to disk.
-//
-// Filtered headers when false:
-//   - Cookie / Set-Cookie  (session identifiers)
-//   - Authorization        (Bearer tokens, Basic credentials)
-//   - WWW-Authenticate     (server auth challenges)
-//   - Proxy-Authorization  (proxy credentials)
-//   - Proxy-Authenticate   (proxy auth challenges)
+// (cookies, Authorization, WWW-Authenticate, Proxy-Authorization) are included
+// in the HAR output. Defaults to false.
 func WithCaptureSecureHeaders(capture bool) MiddlewareOption {
 	return func(m *Middleware) {
 		m.captureSecureHeaders = capture

--- a/internal/handler/har/types.go
+++ b/internal/handler/har/types.go
@@ -1,0 +1,88 @@
+package har
+
+import "time"
+
+// HAR represents the root HTTP Archive object (HAR 1.2).
+type HAR struct {
+	Log Log `json:"log"`
+}
+
+// Log is the top-level container for HAR data.
+type Log struct {
+	Version string  `json:"version"`
+	Creator Creator `json:"creator"`
+	Entries []Entry `json:"entries"`
+}
+
+// Creator identifies the application that produced the HAR.
+type Creator struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// Entry represents a single request/response pair.
+type Entry struct {
+	StartedDateTime time.Time `json:"startedDateTime"`
+	Time            float64   `json:"time"` // ms
+	Request         Request   `json:"request"`
+	Response        Response  `json:"response"`
+	Timings         Timings   `json:"timings"`
+}
+
+// Request describes an HTTP request.
+type Request struct {
+	Method      string      `json:"method"`
+	URL         string      `json:"url"`
+	HTTPVersion string      `json:"httpVersion"`
+	Headers     []NameValue `json:"headers"`
+	QueryString []NameValue `json:"queryString"`
+	Cookies     []Cookie    `json:"cookies"`
+	HeadersSize int         `json:"headersSize"`
+	BodySize    int64       `json:"bodySize"`
+	PostData    *PostData   `json:"postData,omitempty"`
+}
+
+// Response describes an HTTP response.
+type Response struct {
+	Status      int         `json:"status"`
+	StatusText  string      `json:"statusText"`
+	HTTPVersion string      `json:"httpVersion"`
+	Headers     []NameValue `json:"headers"`
+	Cookies     []Cookie    `json:"cookies"`
+	Content     Content     `json:"content"`
+	RedirectURL string      `json:"redirectURL"`
+	HeadersSize int         `json:"headersSize"`
+	BodySize    int64       `json:"bodySize"`
+}
+
+// Content holds response body details.
+type Content struct {
+	Size     int64  `json:"size"`
+	MimeType string `json:"mimeType"`
+	Text     string `json:"text,omitempty"`
+}
+
+// Timings breaks down request time into phases (all in ms).
+type Timings struct {
+	Send    float64 `json:"send"`
+	Wait    float64 `json:"wait"`
+	Receive float64 `json:"receive"`
+}
+
+// NameValue is a generic key/value pair used for headers and query params.
+type NameValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Cookie represents a single HTTP cookie.
+type Cookie struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// PostData holds request body information.
+type PostData struct {
+	MimeType string `json:"mimeType"`
+	Text     string `json:"text"`
+}

--- a/internal/handler/har/types.go
+++ b/internal/handler/har/types.go
@@ -50,7 +50,7 @@ type Response struct {
 	Headers     []NameValue `json:"headers"`
 	Cookies     []Cookie    `json:"cookies"`
 	Content     Content     `json:"content"`
-	RedirectURL string      `json:"redirectURL"`
+	RedirectURL string      `json:"redirectUrl"`
 	HeadersSize int         `json:"headersSize"`
 	BodySize    int64       `json:"bodySize"`
 }

--- a/internal/handler/har/types.go
+++ b/internal/handler/har/types.go
@@ -56,10 +56,13 @@ type Response struct {
 }
 
 // Content holds response body details.
+// When Encoding is "base64", Text contains the base64-encoded body bytes
+// (used for payloads that could not be decoded, e.g. unknown compressions).
 type Content struct {
 	Size     int64  `json:"size"`
 	MimeType string `json:"mimeType"`
 	Text     string `json:"text,omitempty"`
+	Encoding string `json:"encoding,omitempty"`
 }
 
 // Timings breaks down request time into phases (all in ms).

--- a/internal/handler/har/writer.go
+++ b/internal/handler/har/writer.go
@@ -13,6 +13,8 @@ const (
 	// entryChanBuffer is the capacity of the entry channel.
 	// Senders never block as long as fewer than this many entries are in-flight.
 	entryChanBuffer = 4096
+	// harFileMode is the permission bits used when writing the HAR file.
+	harFileMode = 0o600
 )
 
 // Writer asynchronously appends HAR entries to a file.
@@ -31,17 +33,17 @@ type Writer struct {
 // NewWriter creates a Writer that records entries to path.
 // The background goroutine starts immediately.
 func NewWriter(path string) *Writer {
-	w := &Writer{
+	writer := &Writer{
 		path:    path,
 		entries: make(chan Entry, entryChanBuffer),
 		done:    make(chan struct{}),
 	}
 
-	w.wg.Add(1)
+	writer.wg.Add(1)
 
-	go w.run()
+	go writer.run()
 
-	return w
+	return writer
 }
 
 // AddEntry enqueues an entry for writing. It never blocks the caller:
@@ -123,7 +125,8 @@ func (w *Writer) flush() {
 
 	tmp := w.path + ".tmp"
 
-	if err = os.WriteFile(tmp, data, 0o600); err != nil {
+	err = os.WriteFile(tmp, data, harFileMode)
+	if err != nil {
 		return
 	}
 

--- a/internal/handler/har/writer.go
+++ b/internal/handler/har/writer.go
@@ -1,0 +1,128 @@
+package har
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+const (
+	harVersion     = "1.2"
+	creatorName    = "uncors"
+	creatorVersion = "dev"
+	// entryChanBuffer is the capacity of the entry channel.
+	// Senders never block as long as fewer than this many entries are in-flight.
+	entryChanBuffer = 4096
+)
+
+// Writer asynchronously appends HAR entries to a file.
+// All public methods are safe for concurrent use.
+// The internal goroutine serializes writes so the file is never corrupted.
+type Writer struct {
+	path    string
+	entries chan Entry
+	done    chan struct{}
+	once    sync.Once
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	all     []Entry
+}
+
+// NewWriter creates a Writer that records entries to path.
+// The background goroutine starts immediately.
+func NewWriter(path string) *Writer {
+	w := &Writer{
+		path:    path,
+		entries: make(chan Entry, entryChanBuffer),
+		done:    make(chan struct{}),
+	}
+
+	w.wg.Add(1)
+
+	go w.run()
+
+	return w
+}
+
+// AddEntry enqueues an entry for writing. It never blocks the caller:
+// if the internal buffer is full the entry is silently dropped.
+func (w *Writer) AddEntry(entry Entry) {
+	select {
+	case w.entries <- entry:
+	default:
+		// drop entry rather than block the request goroutine
+	}
+}
+
+// Close flushes all pending entries to disk and stops the background goroutine.
+// Calling Close more than once is safe; subsequent calls are no-ops.
+func (w *Writer) Close() {
+	w.once.Do(func() {
+		close(w.done)
+		w.wg.Wait()
+	})
+}
+
+// run is the single goroutine responsible for accumulating entries and
+// flushing them to disk. It exits when done is closed and the entry
+// channel has been fully drained.
+func (w *Writer) run() {
+	defer w.wg.Done()
+
+	for {
+		select {
+		case entry := <-w.entries:
+			w.append(entry)
+			w.flush()
+
+		case <-w.done:
+			// Drain any entries that arrived before the channel was closed.
+			for {
+				select {
+				case entry := <-w.entries:
+					w.append(entry)
+				default:
+					w.flush()
+
+					return
+				}
+			}
+		}
+	}
+}
+
+func (w *Writer) append(entry Entry) {
+	w.mu.Lock()
+	w.all = append(w.all, entry)
+	w.mu.Unlock()
+}
+
+// flush serialises the full in-memory HAR to a temp file then atomically
+// renames it over the target path, so readers always see a valid file.
+func (w *Writer) flush() {
+	w.mu.Lock()
+	snapshot := make([]Entry, len(w.all))
+	copy(snapshot, w.all)
+	w.mu.Unlock()
+
+	archive := HAR{
+		Log: Log{
+			Version: harVersion,
+			Creator: Creator{Name: creatorName, Version: creatorVersion},
+			Entries: snapshot,
+		},
+	}
+
+	data, err := json.MarshalIndent(archive, "", "  ")
+	if err != nil {
+		return
+	}
+
+	tmp := w.path + ".tmp"
+
+	if err = os.WriteFile(tmp, data, 0o600); err != nil {
+		return
+	}
+
+	_ = os.Rename(tmp, w.path)
+}

--- a/internal/handler/har/writer.go
+++ b/internal/handler/har/writer.go
@@ -56,11 +56,14 @@ func (w *Writer) AddEntry(entry Entry) {
 
 // Close flushes all pending entries to disk and stops the background goroutine.
 // Calling Close more than once is safe; subsequent calls are no-ops.
-func (w *Writer) Close() {
+// It implements io.Closer.
+func (w *Writer) Close() error {
 	w.once.Do(func() {
 		close(w.done)
 		w.wg.Wait()
 	})
+
+	return nil
 }
 
 // run is the single goroutine responsible for accumulating entries and

--- a/internal/handler/har/writer.go
+++ b/internal/handler/har/writer.go
@@ -22,8 +22,6 @@ const (
 )
 
 // Writer asynchronously appends HAR entries to a file.
-// All public methods are safe for concurrent use.
-// The internal goroutine serializes writes so the file is never corrupted.
 type Writer struct {
 	path    string
 	entries chan Entry
@@ -35,7 +33,6 @@ type Writer struct {
 }
 
 // NewWriter creates a Writer that records entries to path.
-// The background goroutine starts immediately.
 func NewWriter(path string) *Writer {
 	writer := &Writer{
 		path:    path,
@@ -50,8 +47,7 @@ func NewWriter(path string) *Writer {
 	return writer
 }
 
-// AddEntry enqueues an entry for writing. It never blocks the caller:
-// if the internal buffer is full the entry is silently dropped.
+// AddEntry enqueues an entry for writing.
 func (w *Writer) AddEntry(entry Entry) {
 	select {
 	case w.entries <- entry:
@@ -61,8 +57,6 @@ func (w *Writer) AddEntry(entry Entry) {
 }
 
 // Close flushes all pending entries to disk and stops the background goroutine.
-// Calling Close more than once is safe; subsequent calls are no-ops.
-// It implements io.Closer.
 func (w *Writer) Close() error {
 	w.once.Do(func() {
 		close(w.done)
@@ -72,9 +66,6 @@ func (w *Writer) Close() error {
 	return nil
 }
 
-// run is the single goroutine responsible for accumulating entries and
-// flushing them to disk. It exits when done is closed and the entry
-// channel has been fully drained.
 func (w *Writer) run() {
 	defer w.wg.Done()
 
@@ -106,8 +97,6 @@ func (w *Writer) append(entry Entry) {
 	w.mu.Unlock()
 }
 
-// flush serialises the full in-memory HAR to a temp file then atomically
-// renames it over the target path, so readers always see a valid file.
 func (w *Writer) flush() {
 	w.mu.Lock()
 	snapshot := make([]Entry, len(w.all))

--- a/internal/handler/har/writer.go
+++ b/internal/handler/har/writer.go
@@ -2,7 +2,9 @@ package har
 
 import (
 	"encoding/json"
+	"log"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -15,6 +17,8 @@ const (
 	entryChanBuffer = 4096
 	// harFileMode is the permission bits used when writing the HAR file.
 	harFileMode = 0o600
+	// harDirMode is the permission bits used when creating parent directories.
+	harDirMode = 0o755
 )
 
 // Writer asynchronously appends HAR entries to a file.
@@ -123,12 +127,25 @@ func (w *Writer) flush() {
 		return
 	}
 
+	err = os.MkdirAll(filepath.Dir(w.path), harDirMode)
+	if err != nil {
+		log.Printf("har: cannot create directory for %q: %v", w.path, err)
+
+		return
+	}
+
 	tmp := w.path + ".tmp"
 
 	err = os.WriteFile(tmp, data, harFileMode)
 	if err != nil {
+		log.Printf("har: cannot write temp file %q: %v", tmp, err)
+
 		return
 	}
 
-	_ = os.Rename(tmp, w.path)
+	err = os.Rename(tmp, w.path)
+	if err != nil {
+		log.Printf("har: cannot rename %q to %q: %v", tmp, w.path, err)
+		_ = os.Remove(tmp)
+	}
 }

--- a/internal/handler/har/writer_test.go
+++ b/internal/handler/har/writer_test.go
@@ -17,15 +17,15 @@ func TestWriter(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "out.har")
 
-		w := har.NewWriter(path)
-		w.AddEntry(har.Entry{
+		harWriter := har.NewWriter(path)
+		harWriter.AddEntry(har.Entry{
 			StartedDateTime: time.Now(),
 			Time:            42,
 			Request:         har.Request{Method: "GET", URL: "http://example.com/"},
 			Response:        har.Response{Status: 200},
 		})
 
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
 
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
@@ -40,29 +40,29 @@ func TestWriter(t *testing.T) {
 
 	t.Run("multiple Close calls are safe", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "out.har")
-		w := har.NewWriter(path)
+		harWriter := har.NewWriter(path)
 
-		require.NoError(t, w.Close())
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
+		require.NoError(t, harWriter.Close())
 	})
 
 	t.Run("AddEntry does not block when channel is full", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "out.har")
-		w := har.NewWriter(path)
+		harWriter := har.NewWriter(path)
 
 		// Send well over the buffer capacity without blocking.
-		for i := 0; i < 10_000; i++ {
-			w.AddEntry(har.Entry{})
+		for range 10_000 {
+			harWriter.AddEntry(har.Entry{})
 		}
 
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
 	})
 
 	t.Run("file is valid JSON after Close with no entries", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "empty.har")
-		w := har.NewWriter(path)
+		harWriter := har.NewWriter(path)
 
-		require.NoError(t, w.Close())
+		require.NoError(t, harWriter.Close())
 
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)

--- a/internal/handler/har/writer_test.go
+++ b/internal/handler/har/writer_test.go
@@ -1,0 +1,74 @@
+package har_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/evg4b/uncors/internal/handler/har"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriter(t *testing.T) {
+	t.Run("writes a valid HAR file after Close", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "out.har")
+
+		w := har.NewWriter(path)
+		w.AddEntry(har.Entry{
+			StartedDateTime: time.Now(),
+			Time:            42,
+			Request:         har.Request{Method: "GET", URL: "http://example.com/"},
+			Response:        har.Response{Status: 200},
+		})
+
+		require.NoError(t, w.Close())
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		var archive har.HAR
+		require.NoError(t, json.Unmarshal(data, &archive))
+
+		assert.Equal(t, "1.2", archive.Log.Version)
+		assert.Len(t, archive.Log.Entries, 1)
+		assert.Equal(t, "GET", archive.Log.Entries[0].Request.Method)
+	})
+
+	t.Run("multiple Close calls are safe", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "out.har")
+		w := har.NewWriter(path)
+
+		require.NoError(t, w.Close())
+		require.NoError(t, w.Close())
+	})
+
+	t.Run("AddEntry does not block when channel is full", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "out.har")
+		w := har.NewWriter(path)
+
+		// Send well over the buffer capacity without blocking.
+		for i := 0; i < 10_000; i++ {
+			w.AddEntry(har.Entry{})
+		}
+
+		require.NoError(t, w.Close())
+	})
+
+	t.Run("file is valid JSON after Close with no entries", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.har")
+		w := har.NewWriter(path)
+
+		require.NoError(t, w.Close())
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		var archive har.HAR
+		require.NoError(t, json.Unmarshal(data, &archive))
+		assert.Empty(t, archive.Log.Entries)
+	})
+}

--- a/internal/handler/har/writer_test.go
+++ b/internal/handler/har/writer_test.go
@@ -50,7 +50,6 @@ func TestWriter(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "out.har")
 		harWriter := har.NewWriter(path)
 
-		// Send well over the buffer capacity without blocking.
 		for range 10_000 {
 			harWriter.AddEntry(har.Entry{})
 		}
@@ -73,8 +72,6 @@ func TestWriter(t *testing.T) {
 	})
 
 	t.Run("flush handles directory creation failure gracefully", func(t *testing.T) {
-		// Place a regular file where MkdirAll expects to create a directory so
-		// that os.MkdirAll returns an error.
 		dir := t.TempDir()
 		blocker := filepath.Join(dir, "blocker")
 		require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
@@ -83,18 +80,13 @@ func TestWriter(t *testing.T) {
 		harWriter := har.NewWriter(path)
 		harWriter.AddEntry(har.Entry{})
 
-		// Writer must not panic; Close must succeed even though flush fails.
 		require.NoError(t, harWriter.Close())
 
-		// The HAR file must not be written — stat returns any error because the
-		// path is unreachable (a path component is a plain file, not a directory).
 		_, statErr := os.Stat(path)
 		assert.Error(t, statErr, "HAR file must not be written when parent dir creation fails")
 	})
 
 	t.Run("flush handles write failure gracefully", func(t *testing.T) {
-		// Make the target directory read-only so os.WriteFile on the temp file
-		// fails (directory is traversable but not writable: mode 0o500 = r-x).
 		dir := t.TempDir()
 		path := filepath.Join(dir, "out.har")
 
@@ -107,31 +99,26 @@ func TestWriter(t *testing.T) {
 		require.NoError(t, harWriter.Close())
 
 		_, statErr := os.Stat(path)
-		assert.True(t, os.IsNotExist(statErr), "HAR file must not exist when write fails")
+		assert.True(t, os.IsNotExist(statErr))
 	})
 
 	t.Run("flush handles rename failure gracefully", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "out.har")
 
-		// Create a directory at the target path — renaming a regular file over a
-		// directory fails with EISDIR on both Linux and macOS.
 		require.NoError(t, os.Mkdir(path, 0o755))
 
 		harWriter := har.NewWriter(path)
 		harWriter.AddEntry(har.Entry{})
 
-		// Writer must not panic; Close must succeed even though rename fails.
 		require.NoError(t, harWriter.Close())
 
-		// The target path should still be a directory (not overwritten).
 		fi, statErr := os.Stat(path)
 		require.NoError(t, statErr)
-		assert.True(t, fi.IsDir(), "target directory must remain when rename fails")
+		assert.True(t, fi.IsDir())
 	})
 
 	t.Run("creates parent directories automatically", func(t *testing.T) {
-		// The directory does not exist yet — the writer must create it.
 		path := filepath.Join(t.TempDir(), "nested", "deep", "out.har")
 		harWriter := har.NewWriter(path)
 		harWriter.AddEntry(har.Entry{

--- a/internal/handler/har/writer_test.go
+++ b/internal/handler/har/writer_test.go
@@ -71,4 +71,23 @@ func TestWriter(t *testing.T) {
 		require.NoError(t, json.Unmarshal(data, &archive))
 		assert.Empty(t, archive.Log.Entries)
 	})
+
+	t.Run("creates parent directories automatically", func(t *testing.T) {
+		// The directory does not exist yet — the writer must create it.
+		path := filepath.Join(t.TempDir(), "nested", "deep", "out.har")
+		harWriter := har.NewWriter(path)
+		harWriter.AddEntry(har.Entry{
+			Request:  har.Request{Method: "GET", URL: "http://example.com/"},
+			Response: har.Response{Status: 200},
+		})
+
+		require.NoError(t, harWriter.Close())
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		var archive har.HAR
+		require.NoError(t, json.Unmarshal(data, &archive))
+		assert.Len(t, archive.Log.Entries, 1)
+	})
 }

--- a/internal/handler/har/writer_test.go
+++ b/internal/handler/har/writer_test.go
@@ -72,6 +72,64 @@ func TestWriter(t *testing.T) {
 		assert.Empty(t, archive.Log.Entries)
 	})
 
+	t.Run("flush handles directory creation failure gracefully", func(t *testing.T) {
+		// Place a regular file where MkdirAll expects to create a directory so
+		// that os.MkdirAll returns an error.
+		dir := t.TempDir()
+		blocker := filepath.Join(dir, "blocker")
+		require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+
+		path := filepath.Join(blocker, "sub", "out.har")
+		harWriter := har.NewWriter(path)
+		harWriter.AddEntry(har.Entry{})
+
+		// Writer must not panic; Close must succeed even though flush fails.
+		require.NoError(t, harWriter.Close())
+
+		// The HAR file must not be written — stat returns any error because the
+		// path is unreachable (a path component is a plain file, not a directory).
+		_, statErr := os.Stat(path)
+		assert.Error(t, statErr, "HAR file must not be written when parent dir creation fails")
+	})
+
+	t.Run("flush handles write failure gracefully", func(t *testing.T) {
+		// Make the target directory read-only so os.WriteFile on the temp file
+		// fails (directory is traversable but not writable: mode 0o500 = r-x).
+		dir := t.TempDir()
+		path := filepath.Join(dir, "out.har")
+
+		require.NoError(t, os.Chmod(dir, 0o500))
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+		harWriter := har.NewWriter(path)
+		harWriter.AddEntry(har.Entry{})
+
+		require.NoError(t, harWriter.Close())
+
+		_, statErr := os.Stat(path)
+		assert.True(t, os.IsNotExist(statErr), "HAR file must not exist when write fails")
+	})
+
+	t.Run("flush handles rename failure gracefully", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "out.har")
+
+		// Create a directory at the target path — renaming a regular file over a
+		// directory fails with EISDIR on both Linux and macOS.
+		require.NoError(t, os.Mkdir(path, 0o755))
+
+		harWriter := har.NewWriter(path)
+		harWriter.AddEntry(har.Entry{})
+
+		// Writer must not panic; Close must succeed even though rename fails.
+		require.NoError(t, harWriter.Close())
+
+		// The target path should still be a directory (not overwritten).
+		fi, statErr := os.Stat(path)
+		require.NoError(t, statErr)
+		assert.True(t, fi.IsDir(), "target directory must remain when rename fails")
+	})
+
 	t.Run("creates parent directories automatically", func(t *testing.T) {
 		// The directory does not exist yet — the writer must create it.
 		path := filepath.Join(t.TempDir(), "nested", "deep", "out.har")

--- a/internal/handler/har_middleware.go
+++ b/internal/handler/har_middleware.go
@@ -1,0 +1,16 @@
+package handler
+
+import (
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/contracts"
+)
+
+func (h *RequestHandler) wrapHARMiddleware(harConfig config.HARConfig, next contracts.Handler) contracts.Handler {
+	if !harConfig.Enabled() {
+		return next
+	}
+
+	middleware := h.harMiddlewareFactory(harConfig)
+
+	return middleware.Wrap(next)
+}

--- a/internal/handler/uncors_handler.go
+++ b/internal/handler/uncors_handler.go
@@ -21,6 +21,7 @@ type (
 	ScriptHandlerFactory     = func(script config.Script) contracts.Handler
 	RewriteMiddlewareFactory = func(rewrite config.RewritingOption) contracts.Middleware
 	OptionsMiddlewareFactory = func(options config.OptionsHandling) contracts.Middleware
+	HARMiddlewareFactory     = func(harConfig config.HARConfig) contracts.Middleware
 )
 
 type RequestHandler struct {
@@ -35,6 +36,7 @@ type RequestHandler struct {
 	scriptHandlerFactory     ScriptHandlerFactory
 	rewriteMiddlewareFactory RewriteMiddlewareFactory
 	optionsMiddlewareFactory OptionsMiddlewareFactory
+	harMiddlewareFactory     HARMiddlewareFactory
 }
 
 var errHostNotMapped = errors.New("host not mapped")
@@ -55,6 +57,7 @@ func NewUncorsRequestHandler(options ...RequestHandlerOption) *RequestHandler {
 
 		defaultHandler := handler.wrapOptionsMiddleware(mapping.OptionsHandling, handler.proxyHandler)
 		defaultHandler = handler.wrapCacheMiddleware(mapping.Cache, defaultHandler)
+		defaultHandler = handler.wrapHARMiddleware(mapping.HAR, defaultHandler)
 
 		handler.makeStaticRoutes(router, mapping.Statics, defaultHandler)
 		handler.makeMockedRoutes(router, mapping.Mocks)
@@ -152,5 +155,11 @@ func WithRewriteHandlerFactory(factory RewriteMiddlewareFactory) RequestHandlerO
 func WithOptionsHandlerFactory(factory OptionsMiddlewareFactory) RequestHandlerOption {
 	return func(h *RequestHandler) {
 		h.optionsMiddlewareFactory = factory
+	}
+}
+
+func WithHARMiddlewareFactory(factory HARMiddlewareFactory) RequestHandlerOption {
+	return func(h *RequestHandler) {
+		h.harMiddlewareFactory = factory
 	}
 }

--- a/internal/server/printer_test.go
+++ b/internal/server/printer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/server"
 	"github.com/evg4b/uncors/testing/mocks"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRequestPrinter(t *testing.T) {
@@ -20,7 +21,7 @@ func TestRequestPrinter(t *testing.T) {
 			Code:   200,
 		}
 
-		output.RequestMock.Set(func(d *contracts.ReqestData) {})
+		output.RequestMock.Set(func(_ *contracts.ReqestData) {})
 
 		go server.RequestPrinter(tracker, output)
 
@@ -37,9 +38,7 @@ func TestRequestPrinter(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
-		if len(output.RequestMock.Calls()) == 0 {
-			t.Error("Request not called")
-		}
+		assert.NotEmpty(t, output.RequestMock.Calls(), "Request not called")
 	})
 
 	t.Run("skips request when Done=false", func(t *testing.T) {
@@ -66,9 +65,7 @@ func TestRequestPrinter(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
-		if len(output.RequestMock.Calls()) != 0 {
-			t.Error("Request should not be called when Done=false")
-		}
+		assert.Empty(t, output.RequestMock.Calls(), "Request should not be called when Done=false")
 	})
 
 	t.Run("skips request when Data is nil", func(t *testing.T) {
@@ -90,9 +87,7 @@ func TestRequestPrinter(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
-		if len(output.RequestMock.Calls()) != 0 {
-			t.Error("Request should not be called when Data is nil")
-		}
+		assert.Empty(t, output.RequestMock.Calls(), "Request should not be called when Data is nil")
 	})
 
 	t.Run("uses NewPrefixOutput when Prefix is set", func(t *testing.T) {
@@ -101,15 +96,16 @@ func TestRequestPrinter(t *testing.T) {
 		prefixedOutput := mocks.NewOutputMock(t)
 
 		const prefix = "PROXY"
+
 		data := &contracts.ReqestData{
 			Method: "GET",
 			Code:   200,
 		}
 
-		output.NewPrefixOutputMock.Set(func(p string) contracts.Output {
+		output.NewPrefixOutputMock.Set(func(_ string) contracts.Output {
 			return prefixedOutput
 		})
-		prefixedOutput.RequestMock.Set(func(d *contracts.ReqestData) {})
+		prefixedOutput.RequestMock.Set(func(_ *contracts.ReqestData) {})
 
 		go server.RequestPrinter(tracker, output)
 
@@ -127,12 +123,8 @@ func TestRequestPrinter(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
-		if len(output.NewPrefixOutputMock.Calls()) == 0 {
-			t.Error("NewPrefixOutput not called")
-		}
-		if len(prefixedOutput.RequestMock.Calls()) == 0 {
-			t.Error("Request on prefixed output not called")
-		}
+		assert.NotEmpty(t, output.NewPrefixOutputMock.Calls(), "NewPrefixOutput not called")
+		assert.NotEmpty(t, prefixedOutput.RequestMock.Calls(), "Request on prefixed output not called")
 	})
 
 	t.Run("uses direct output when Prefix is empty", func(t *testing.T) {
@@ -144,7 +136,7 @@ func TestRequestPrinter(t *testing.T) {
 			Code:   200,
 		}
 
-		output.RequestMock.Set(func(d *contracts.ReqestData) {})
+		output.RequestMock.Set(func(_ *contracts.ReqestData) {})
 
 		go server.RequestPrinter(tracker, output)
 
@@ -162,12 +154,8 @@ func TestRequestPrinter(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
-		if len(output.RequestMock.Calls()) == 0 {
-			t.Error("Request not called on direct output")
-		}
-		if len(output.NewPrefixOutputMock.Calls()) != 0 {
-			t.Error("NewPrefixOutput should not be called")
-		}
+		assert.NotEmpty(t, output.RequestMock.Calls(), "Request not called on direct output")
+		assert.Empty(t, output.NewPrefixOutputMock.Calls(), "NewPrefixOutput should not be called")
 	})
 
 	t.Run("processes multiple events correctly", func(t *testing.T) {
@@ -179,11 +167,11 @@ func TestRequestPrinter(t *testing.T) {
 		data2 := &contracts.ReqestData{Method: "POST", Code: 201}
 		data3 := &contracts.ReqestData{Method: "DELETE", Code: 204}
 
-		output.RequestMock.Set(func(d *contracts.ReqestData) {})
-		output.NewPrefixOutputMock.Set(func(p string) contracts.Output {
+		output.RequestMock.Set(func(_ *contracts.ReqestData) {})
+		output.NewPrefixOutputMock.Set(func(_ string) contracts.Output {
 			return prefixedOutput
 		})
-		prefixedOutput.RequestMock.Set(func(d *contracts.ReqestData) {})
+		prefixedOutput.RequestMock.Set(func(_ *contracts.ReqestData) {})
 
 		go server.RequestPrinter(tracker, output)
 
@@ -196,15 +184,9 @@ func TestRequestPrinter(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
-		if len(output.RequestMock.Calls()) != 2 {
-			t.Errorf("expected 2 direct Request calls, got %d", len(output.RequestMock.Calls()))
-		}
-		if len(output.NewPrefixOutputMock.Calls()) != 1 {
-			t.Errorf("expected 1 NewPrefixOutput call, got %d", len(output.NewPrefixOutputMock.Calls()))
-		}
-		if len(prefixedOutput.RequestMock.Calls()) != 1 {
-			t.Errorf("expected 1 prefixed Request call, got %d", len(prefixedOutput.RequestMock.Calls()))
-		}
+		assert.Len(t, output.RequestMock.Calls(), 2, "expected 2 direct Request calls")
+		assert.Len(t, output.NewPrefixOutputMock.Calls(), 1, "expected 1 NewPrefixOutput call")
+		assert.Len(t, prefixedOutput.RequestMock.Calls(), 1, "expected 1 prefixed Request call")
 	})
 
 	t.Run("handles tracker closure gracefully", func(t *testing.T) {

--- a/internal/uncors/app.go
+++ b/internal/uncors/app.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"io"
 	"net"
-	"net/http"
 	"strconv"
 	"sync"
 
@@ -39,6 +38,7 @@ func CreateUncors(fs afero.Fs, output contracts.Output, version string) *Uncors 
 		version: version,
 		output:  output,
 		server:  server.New(),
+		tracker: server.NewRequestTracker(),
 	}
 }
 
@@ -144,20 +144,9 @@ func (app *Uncors) mappingsToTarget(uncorsConfig *config.UncorsConfig) ([]server
 			}
 		}
 
-		innerHandler := contracts.Handler(app.buildHandlerForMappings(uncorsConfig, group.Mappings))
-
-		var httpHandler http.Handler
-		if app.tracker != nil {
-			httpHandler = app.tracker.Wrap(innerHandler)
-		} else {
-			httpHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				innerHandler.ServeHTTP(contracts.WrapResponseWriter(w), r)
-			})
-		}
-
 		targets = append(targets, server.Target{
 			Address:   net.JoinHostPort(baseAddress, strconv.Itoa(group.Port)),
-			Handler:   httpHandler,
+			Handler:   app.tracker.Wrap(app.buildHandlerForMappings(uncorsConfig, group.Mappings)),
 			TLSConfig: tlsConfig,
 		})
 	}

--- a/internal/uncors/app.go
+++ b/internal/uncors/app.go
@@ -33,18 +33,6 @@ type Uncors struct {
 	closers          []io.Closer
 }
 
-func (app *Uncors) registerCloser(c io.Closer) {
-	app.closers = append(app.closers, c)
-}
-
-func (app *Uncors) closeAll() {
-	for _, c := range app.closers {
-		_ = c.Close()
-	}
-
-	app.closers = nil
-}
-
 func CreateUncors(fs afero.Fs, output contracts.Output, version string) *Uncors {
 	return &Uncors{
 		fs:      fs,
@@ -124,6 +112,18 @@ func (app *Uncors) getCacheStorage(cfg config.CacheConfig) contracts.Cache {
 	})
 
 	return app.cacheStorage
+}
+
+func (app *Uncors) registerCloser(c io.Closer) {
+	app.closers = append(app.closers, c)
+}
+
+func (app *Uncors) closeAll() {
+	for _, c := range app.closers {
+		_ = c.Close()
+	}
+
+	app.closers = nil
 }
 
 func (app *Uncors) mappingsToTarget(uncorsConfig *config.UncorsConfig) ([]server.Target, error) {

--- a/internal/uncors/app.go
+++ b/internal/uncors/app.go
@@ -3,6 +3,7 @@ package uncors
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -29,6 +30,19 @@ type Uncors struct {
 
 	cacheStorageOnce sync.Once
 	cacheStorage     contracts.Cache
+	closers          []io.Closer
+}
+
+func (app *Uncors) registerCloser(c io.Closer) {
+	app.closers = append(app.closers, c)
+}
+
+func (app *Uncors) closeAll() {
+	for _, c := range app.closers {
+		_ = c.Close()
+	}
+
+	app.closers = nil
 }
 
 func CreateUncors(fs afero.Fs, output contracts.Output, version string) *Uncors {
@@ -63,6 +77,11 @@ func (app *Uncors) Start(ctx context.Context, uncorsConfig *config.UncorsConfig)
 }
 
 func (app *Uncors) Restart(ctx context.Context, uncorsConfig *config.UncorsConfig) error {
+	app.output.Info("Restarting server....")
+
+	previous := app.closers
+	app.closers = nil
+
 	targets, err := app.mappingsToTarget(uncorsConfig)
 	if err != nil {
 		return err
@@ -71,6 +90,10 @@ func (app *Uncors) Restart(ctx context.Context, uncorsConfig *config.UncorsConfi
 	err = app.server.Restart(ctx, targets)
 	if err != nil {
 		return err
+	}
+
+	for _, c := range previous {
+		_ = c.Close()
 	}
 
 	app.output.InfoBox(
@@ -82,6 +105,8 @@ func (app *Uncors) Restart(ctx context.Context, uncorsConfig *config.UncorsConfi
 }
 
 func (app *Uncors) Close() error {
+	app.closeAll()
+
 	return app.server.Close()
 }
 

--- a/internal/uncors/handler.go
+++ b/internal/uncors/handler.go
@@ -87,7 +87,10 @@ func (app *Uncors) buildHARMiddlewareFactory() handler.HARMiddlewareFactory {
 			w := har.NewWriter(harConfig.File)
 			app.registerCloser(w)
 
-			return har.NewMiddleware(har.WithWriter(w))
+			return har.NewMiddleware(
+				har.WithWriter(w),
+				har.WithCaptureCookies(harConfig.CaptureCookies),
+			)
 		})
 	}
 }

--- a/internal/uncors/handler.go
+++ b/internal/uncors/handler.go
@@ -89,7 +89,7 @@ func (app *Uncors) buildHARMiddlewareFactory() handler.HARMiddlewareFactory {
 
 			return har.NewMiddleware(
 				har.WithWriter(w),
-				har.WithCaptureCookies(harConfig.CaptureCookies),
+				har.WithCaptureSecureHeaders(harConfig.CaptureSecureHeaders),
 			)
 		})
 	}

--- a/internal/uncors/handler.go
+++ b/internal/uncors/handler.go
@@ -83,7 +83,7 @@ func (app *Uncors) buildOptionsMiddlewareFactory() handler.OptionsMiddlewareFact
 
 func (app *Uncors) buildHARMiddlewareFactory() handler.HARMiddlewareFactory {
 	return func(harConfig config.HARConfig) contracts.Middleware {
-		return contracts.LazyMiddleware(func() contracts.Middleware {
+		return handler.LazyMiddleware(func() contracts.Middleware {
 			w := har.NewWriter(harConfig.File)
 			app.registerCloser(w)
 

--- a/internal/uncors/handler.go
+++ b/internal/uncors/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/handler"
 	"github.com/evg4b/uncors/internal/handler/cache"
+	"github.com/evg4b/uncors/internal/handler/har"
 	"github.com/evg4b/uncors/internal/handler/mock"
 	"github.com/evg4b/uncors/internal/handler/options"
 	"github.com/evg4b/uncors/internal/handler/proxy"
@@ -33,6 +34,7 @@ func (app *Uncors) buildHandlerForMappings(
 		handler.WithScriptHandlerFactory(app.buildScriptHandlerFactory()),
 		handler.WithRewriteHandlerFactory(app.buildRewriteMiddlewareFactory()),
 		handler.WithOutput(app.output),
+		handler.WithHARMiddlewareFactory(app.buildHARMiddlewareFactory()),
 	)
 }
 
@@ -75,6 +77,17 @@ func (app *Uncors) buildOptionsMiddlewareFactory() handler.OptionsMiddlewareFact
 					options.WithCode(cfg.Code),
 				)
 			}).Wrap(next))
+		})
+	}
+}
+
+func (app *Uncors) buildHARMiddlewareFactory() handler.HARMiddlewareFactory {
+	return func(harConfig config.HARConfig) contracts.Middleware {
+		return contracts.LazyMiddleware(func() contracts.Middleware {
+			w := har.NewWriter(harConfig.File)
+			app.registerCloser(w)
+
+			return har.NewMiddleware(har.WithWriter(w))
 		})
 	}
 }

--- a/internal/uncors_app/app.go
+++ b/internal/uncors_app/app.go
@@ -133,13 +133,8 @@ func (m *uncorsApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.waitOutputCmd())
 
 	case requestEventMsg:
-		if typedMsg.Done && typedMsg.Data != nil {
-			if typedMsg.Prefix != "" {
-				m.output.NewPrefixOutput(typedMsg.Prefix).Request(typedMsg.Data)
-			} else {
-				m.output.Request(typedMsg.Data)
-			}
-		}
+		m.handleRequestEvent(typedMsg)
+
 		cmds = append(cmds, m.watchEventsCmd())
 
 	case tea.KeyPressMsg:
@@ -289,6 +284,18 @@ func (m *uncorsApp) handleServerError(msg serverErrMsg) tea.Cmd {
 	m.historyWidget.Update(outputLineMsg(msg.err.Error()))
 
 	return tea.Quit
+}
+
+func (m *uncorsApp) handleRequestEvent(event requestEventMsg) {
+	if !event.Done || event.Data == nil {
+		return
+	}
+
+	if event.Prefix != "" {
+		m.output.NewPrefixOutput(event.Prefix).Request(event.Data)
+	} else {
+		m.output.Request(event.Data)
+	}
 }
 
 func (m *uncorsApp) handleRestart() {

--- a/schema.json
+++ b/schema.json
@@ -3,6 +3,38 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
+    "HARConfig": {
+      "description": "HAR (HTTP Archive) collector configuration. Records all proxied request/response pairs to a file in HAR 1.2 format.",
+      "oneOf": [
+        {
+          "description": "Short form: path to the output HAR file",
+          "type": "string",
+          "examples": [
+            "./recordings/api.har",
+            "/tmp/trace.har"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "description": "Full form with all options",
+          "properties": {
+            "capture-secure-headers": {
+              "default": false,
+              "description": "Include security-sensitive headers in HAR entries. When false (default), Cookie, Set-Cookie, Authorization, WWW-Authenticate, Proxy-Authorization and Proxy-Authenticate headers are excluded.",
+              "type": "boolean"
+            },
+            "file": {
+              "description": "Path to the output HAR file",
+              "type": "string"
+            }
+          },
+          "required": [
+            "file"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "Duration": {
       "description": "Duration in human-readable format. Supported units are 'h' (hours), 'm' (minutes), 's' (seconds), 'ms' (milliseconds), 'us' (microseconds), 'ns' (nanoseconds).",
       "examples": [
@@ -76,6 +108,10 @@
             "from": {
               "description": "The local host with protocol and port for the resource from which proxying will take place (e.g., http://localhost:8080). Port defaults to 80 for HTTP and 443 for HTTPS if not specified. HTTPS mappings use auto-generated certificates (requires CA certificate generated with 'uncors generate-certs').",
               "type": "string"
+            },
+            "har": {
+              "$ref": "#/definitions/HARConfig",
+              "description": "HAR collector configuration. When set, all requests for this mapping are recorded to the specified HAR file."
             },
             "mocks": {
               "description": "List the mocked requests",


### PR DESCRIPTION
## Summary

- Adds a non-blocking HAR (HTTP Archive 1.2) collector middleware that records every proxied request/response pair to a `.har` file
- Configured per-mapping; supports string shorthand (`har: ./file.har`) and full object form with `capture-secure-headers` flag
- Security-sensitive headers (Cookie, Set-Cookie, Authorization, WWW-Authenticate, Proxy-Authorization, Proxy-Authenticate) are excluded by default
- Response bodies are transparently decompressed (gzip/deflate); unknown encodings are base64-encoded
- Async writer uses buffered channel (4096) + background goroutine + atomic rename — requests are never blocked
- JSON schema and ARCHITECTURE.md updated

## Test plan
- [ ] `go test ./internal/handler/har/...`
- [ ] `go test ./internal/config/...`
- [ ] `go test ./internal/config/validators/...`
- [ ] Manual: set `har: ./out.har`, send requests, verify readable HAR in Chrome DevTools
- [ ] Verify auth/cookie headers absent by default; present with `capture-secure-headers: true`
