### PR TITLE
feat: named {key} placeholders in URL mappings

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -210,19 +210,19 @@ mappings:
 > [!NOTE]
 > HTTPS mappings require valid SSL/TLS certificates. See [HTTPS Configuration](#https-configuration) for setup instructions.
 
-## Wildcard Mapping
+## Named Placeholder Mapping
 
-UNCORS supports wildcard patterns in host mappings for flexible domain matching. The `*` wildcard matches any sequence of characters except `.` (dot) and `/` (slash), enabling you to handle multiple subdomains or implement dynamic routing.
+UNCORS supports named placeholders in host mappings for flexible domain matching. A placeholder is written as `{name}` and matches any sequence of characters in that hostname segment (excluding `.` and `/`). Using explicit names makes multi-placeholder mappings self-documenting and allows each placeholder to be referenced by name in the target URL.
 
-**Example 1: Static target with wildcard source**
+**Example 1: Static target with placeholder source**
 
 ```yaml
 mappings:
-  - from: http://*.local.com:8080
+  - from: http://{repo}.local.com:8080
     to: https://github.com
 ```
 
-All requests matching the `*.local.com` pattern on port 8080 are forwarded to the same target:
+All requests matching the `{repo}.local.com` pattern on port 8080 are forwarded to the same target:
 
 | Local request                           | Target request                  |
 | --------------------------------------- | ------------------------------- |
@@ -235,11 +235,11 @@ All requests matching the `*.local.com` pattern on port 8080 are forwarded to th
 
 ```yaml
 mappings:
-  - from: http://*.local.com:8080
-    to: https://*.github.com
+  - from: http://{repo}.local.com:8080
+    to: https://{repo}.github.com
 ```
 
-The wildcard value captured from the source is substituted into the target URL:
+The value captured by `{repo}` from the source URL is substituted into the target URL:
 
 | Local request                           | Target request                       |
 | --------------------------------------- | ------------------------------------ |
@@ -248,8 +248,24 @@ The wildcard value captured from the source is substituted into the target URL:
 | `http://docs.local.com:8080`            | `https://docs.github.com`            |
 | `http://docs.local.com:8080/index.html` | `https://docs.github.com/index.html` |
 
+**Example 3: Multiple named placeholders**
+
+```yaml
+mappings:
+  - from: http://{env}.{service}.local.com
+    to: https://{service}.{env}.api.com
+```
+
+Each placeholder is matched and substituted **by name**, so the order in source and target can differ:
+
+| Local request                             | Target request                        |
+| ----------------------------------------- | ------------------------------------- |
+| `http://prod.auth.local.com`              | `https://auth.prod.api.com`           |
+| `http://prod.auth.local.com/login`        | `https://auth.prod.api.com/login`     |
+| `http://staging.users.local.com`          | `https://users.staging.api.com`       |
+
 > [!NOTE]
-> **Multiple wildcards:** When using multiple `*` characters, they are matched and replaced in order of appearance from left to right.
+> Every placeholder name in a `from` URL must be unique. Using the same name twice (e.g., `{client}.{client}.com`) is a configuration error.
 
 ## Simplified Syntax
 
@@ -266,7 +282,7 @@ Both syntax styles can be mixed within the same configuration file:
 mappings:
   - http://localhost:8080: https://github.com
   - http://host1:3000: https://gitlab.com
-  - http://*.com:8080: https://*.io
+  - http://{repo}.com:8080: https://{repo}.io
   - from: http://host2:9090
     to: https://gitea.com
     mocks: [...]
@@ -274,7 +290,7 @@ mappings:
 ```
 
 > [!WARNING]
-> Domain mappings only work for hosts defined in your system's hosts file. A wildcard mapping like `https://*` will not intercept all internet traffic—only requests to domains explicitly configured in your hosts file.
+> Domain mappings only work for hosts defined in your system's hosts file. A placeholder mapping like `http://{name}.local.com` will not intercept all internet traffic—only requests to domains explicitly configured in your hosts file.
 
 # HTTPS Configuration
 

--- a/internal/handler/uncors_handler_test.go
+++ b/internal/handler/uncors_handler_test.go
@@ -376,8 +376,8 @@ func TestMockMiddleware(t *testing.T) {
 				handler.WithProxyHandler(proxyFactory(t, nil, nil)),
 				handler.WithMappings(config.Mappings{
 					{
-						From: "*",
-						To:   "*",
+						From: "{host}",
+						To:   "{host}",
 						Mocks: config.Mocks{
 							{
 								Matcher: config.RequestMatcher{
@@ -424,7 +424,7 @@ func TestMockMiddleware(t *testing.T) {
 			expectedCode := 299
 			expectedBody := "forwarded"
 			mappings := config.Mappings{
-				{From: "*", To: "*", Mocks: config.Mocks{{
+				{From: "{host}", To: "{host}", Mocks: config.Mocks{{
 					Matcher: config.RequestMatcher{
 						Path:   "/api",
 						Method: http.MethodPut,
@@ -502,7 +502,7 @@ func TestMockMiddleware(t *testing.T) {
 		expectedCode := 299
 		expectedBody := "forwarded"
 		mappings := config.Mappings{
-			{From: "*", To: "*", Mocks: config.Mocks{
+			{From: "{host}", To: "{host}", Mocks: config.Mocks{
 				{
 					Matcher: config.RequestMatcher{
 						Path: userPath,
@@ -618,7 +618,7 @@ func TestMockMiddleware(t *testing.T) {
 	t.Run("query handling", func(t *testing.T) {
 		middleware := handler.NewUncorsRequestHandler(
 			handler.WithMappings(config.Mappings{
-				{From: "*", To: "*", Mocks: config.Mocks{
+				{From: "{host}", To: "{host}", Mocks: config.Mocks{
 					{
 						Matcher: config.RequestMatcher{
 							Path: userPath,
@@ -721,7 +721,7 @@ func TestMockMiddleware(t *testing.T) {
 	t.Run("header handling", func(t *testing.T) {
 		middleware := handler.NewUncorsRequestHandler(
 			handler.WithMappings(config.Mappings{
-				{From: "*", To: "*", Mocks: config.Mocks{
+				{From: "{host}", To: "{host}", Mocks: config.Mocks{
 					{
 						Matcher: config.RequestMatcher{
 							Path: userPath,

--- a/internal/urlparser/parser.go
+++ b/internal/urlparser/parser.go
@@ -34,6 +34,7 @@ func Parse(rawURL string) (*url.URL, error) {
 // If the URL doesn't have a scheme, the provided scheme will be used.
 // If scheme is empty, the URL will be parsed without a default scheme.
 func ParseWithDefaultScheme(rawURL string, scheme string) (*url.URL, error) {
+	rawURL = placeholderRegexp.ReplaceAllString(rawURL, "*")
 	rawURL = defaultScheme(rawURL, scheme)
 
 	// Use net/url.Parse() now.
@@ -83,6 +84,10 @@ func defaultScheme(rawURL, scheme string) string {
 }
 
 var (
+	// placeholderRegexp matches named URL placeholders like {client} or {region}.
+	// Placeholders are normalized to * before URL parsing.
+	placeholderRegexp = regexp.MustCompile(`\{[a-zA-Z][a-zA-Z0-9_]*\}`)
+
 	domainRegexp = regexp.MustCompile(`^([a-zA-Z0-9-_*]{1,63}\.)*([a-zA-Z0-9-*]{1,63})$`)
 	ipv4Regexp   = regexp.MustCompile(`^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$`)
 	ipv6Regexp   = regexp.MustCompile(`^\[[a-fA-F0-9:]+]$`)

--- a/internal/urlparser/parser.go
+++ b/internal/urlparser/parser.go
@@ -89,7 +89,7 @@ var (
 	// placeholderRegexp matches named URL placeholders like {client} or {region}.
 	placeholderRegexp = regexp.MustCompile(`\{[a-zA-Z][a-zA-Z0-9_]*\}`)
 
-	// domainRegexp validates domain names including * wildcards and {key} placeholders
+	// domainRegexp validates domain names including * wildcards and {key} placeholders.
 	domainRegexp = regexp.MustCompile(`^([a-zA-Z0-9-_*]{1,63}\.)*([a-zA-Z0-9-*]{1,63})$`)
 	ipv4Regexp   = regexp.MustCompile(`^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$`)
 	ipv6Regexp   = regexp.MustCompile(`^\[[a-fA-F0-9:]+]$`)

--- a/internal/urlparser/parser.go
+++ b/internal/urlparser/parser.go
@@ -34,6 +34,8 @@ func Parse(rawURL string) (*url.URL, error) {
 // If the URL doesn't have a scheme, the provided scheme will be used.
 // If scheme is empty, the URL will be parsed without a default scheme.
 func ParseWithDefaultScheme(rawURL string, scheme string) (*url.URL, error) {
+	// Replace {key} placeholders with * to allow parsing by net/url
+	// This preserves the placeholder intent while working with Go's URL parser
 	rawURL = placeholderRegexp.ReplaceAllString(rawURL, "*")
 	rawURL = defaultScheme(rawURL, scheme)
 
@@ -85,9 +87,9 @@ func defaultScheme(rawURL, scheme string) string {
 
 var (
 	// placeholderRegexp matches named URL placeholders like {client} or {region}.
-	// Placeholders are normalized to * before URL parsing.
 	placeholderRegexp = regexp.MustCompile(`\{[a-zA-Z][a-zA-Z0-9_]*\}`)
 
+	// domainRegexp validates domain names including * wildcards and {key} placeholders
 	domainRegexp = regexp.MustCompile(`^([a-zA-Z0-9-_*]{1,63}\.)*([a-zA-Z0-9-*]{1,63})$`)
 	ipv4Regexp   = regexp.MustCompile(`^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$`)
 	ipv6Regexp   = regexp.MustCompile(`^\[[a-fA-F0-9:]+]$`)

--- a/internal/urlparser/parser_test.go
+++ b/internal/urlparser/parser_test.go
@@ -85,6 +85,12 @@ func TestParse(t *testing.T) {
 		{in: "https://pressly.餐厅", out: "https://pressly.%E9%A4%90%E5%8E%85"},
 		{in: "https://pressly.组织机构", out: "https://pressly.%E7%BB%84%E7%BB%87%E6%9C%BA%E6%9E%84"},
 
+		// Named placeholder patterns ({key} syntax):
+		{in: "http://{client}.local.com", out: "http://*.local.com"},
+		{in: "{tenant}.local.com", out: "//*.local.com"},
+		{in: "http://{region}.{tenant}.host.com", out: "http://*.*.host.com"},
+		{in: "{tenant}.local.com:8080", out: "//*.local.com:8080"},
+
 		// // Some obviously wrong data:
 		{in: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==", err: true},
 		{in: "javascript:evilFunction()", err: true},

--- a/internal/urlreplacer/helpers.go
+++ b/internal/urlreplacer/helpers.go
@@ -9,24 +9,58 @@ import (
 	"github.com/evg4b/uncors/internal/urlparser"
 )
 
-func wildCardToRegexp(parsedPattern *url.URL) (*regexp.Regexp, int, error) {
+// placeholderRegexp matches named URL placeholders like {client} or {region}.
+var placeholderRegexp = regexp.MustCompile(`\{([a-zA-Z][a-zA-Z0-9_]*)\}`)
+
+// extractKeys returns the ordered list of placeholder key names from a raw URL pattern.
+// For example, "http://{client}.{region}.com" returns ["client", "region"].
+func extractKeys(raw string) []string {
+	matches := placeholderRegexp.FindAllStringSubmatch(raw, -1)
+	keys := make([]string, len(matches))
+	for i, m := range matches {
+		keys[i] = m[1]
+	}
+
+	return keys
+}
+
+// hasDuplicateKeys checks whether keys contains any duplicate.
+// Returns the duplicate key name and true if a duplicate is found.
+func hasDuplicateKeys(keys []string) (string, bool) {
+	seen := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		if _, exists := seen[k]; exists {
+			return k, true
+		}
+
+		seen[k] = struct{}{}
+	}
+
+	return "", false
+}
+
+func wildCardToRegexp(parsedPattern *url.URL, keys []string) (*regexp.Regexp, error) {
 	var (
-		result strings.Builder
-		count  int
+		result   strings.Builder
+		keyIndex int
 	)
 
 	result.WriteString(`^(?P<scheme>(http(s?):)?\/\/)?`)
 
 	host, _, err := urlparser.SplitHostPort(parsedPattern)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to build url glob: %w", err)
+		return nil, fmt.Errorf("failed to build url glob: %w", err)
 	}
 
 	parts := strings.Split(host, "*")
 	for index, literal := range parts {
 		if index > 0 {
-			count++
-			fmt.Fprintf(&result, "(?P<part%d>.+)", count)
+			name := fmt.Sprintf("part%d", keyIndex+1)
+			if keyIndex < len(keys) {
+				name = keys[keyIndex]
+			}
+			keyIndex++
+			fmt.Fprintf(&result, "(?P<%s>.+)", name)
 		}
 
 		result.WriteString(regexp.QuoteMeta(literal))
@@ -37,23 +71,25 @@ func wildCardToRegexp(parsedPattern *url.URL) (*regexp.Regexp, int, error) {
 
 	compiledRegexp, err := regexp.Compile(result.String())
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to build url glob: %w", err)
+		return nil, fmt.Errorf("failed to build url glob: %w", err)
 	}
 
-	return compiledRegexp, count, nil
+	return compiledRegexp, nil
 }
 
-func wildCardToReplacePattern(parsedPattern *url.URL) (string, int) {
+func wildCardToReplacePattern(parsedPattern *url.URL, keys []string) string {
 	result := &strings.Builder{}
-
-	var count int
-
 	result.WriteString("${scheme}")
 
+	keyIndex := 0
 	for i, literal := range strings.Split(parsedPattern.Host, "*") {
 		if i > 0 {
-			count++
-			fmt.Fprintf(result, "${part%d}", count)
+			name := fmt.Sprintf("part%d", keyIndex+1)
+			if keyIndex < len(keys) {
+				name = keys[keyIndex]
+			}
+			keyIndex++
+			fmt.Fprintf(result, "${%s}", name)
 		}
 
 		result.WriteString(literal)
@@ -61,5 +97,5 @@ func wildCardToReplacePattern(parsedPattern *url.URL) (string, int) {
 
 	result.WriteString("${path}")
 
-	return result.String(), count
+	return result.String()
 }

--- a/internal/urlreplacer/helpers.go
+++ b/internal/urlreplacer/helpers.go
@@ -1,31 +1,30 @@
 package urlreplacer
 
 import (
+	"errors"
 	"fmt"
-	"net/url"
 	"regexp"
 	"strings"
-
-	"github.com/evg4b/uncors/internal/urlparser"
 )
 
-// placeholderRegexp matches named URL placeholders like {client} or {region}.
-var placeholderRegexp = regexp.MustCompile(`\{([a-zA-Z][a-zA-Z0-9_]*)\}`)
+var (
+	placeholderRegexp = regexp.MustCompile(`\{([a-zA-Z][a-zA-Z0-9_]*)\}`)
+	errEmptyPort      = errors.New("empty port")
+)
 
-// extractKeys returns the ordered list of placeholder key names from a raw URL pattern.
-// For example, "http://{client}.{region}.com" returns ["client", "region"].
+// extractKeys returns the ordered placeholder key names from a raw URL pattern.
 func extractKeys(raw string) []string {
 	matches := placeholderRegexp.FindAllStringSubmatch(raw, -1)
+
 	keys := make([]string, len(matches))
 	for i, m := range matches {
-		keys[i] = m[1]
+		keys[i] = strings.ToLower(m[1])
 	}
 
 	return keys
 }
 
-// hasDuplicateKeys checks whether keys contains any duplicate.
-// Returns the duplicate key name and true if a duplicate is found.
+// hasDuplicateKeys returns the first duplicate key name and true if one is found.
 func hasDuplicateKeys(keys []string) (string, bool) {
 	seen := make(map[string]struct{}, len(keys))
 	for _, k := range keys {
@@ -39,62 +38,92 @@ func hasDuplicateKeys(keys []string) (string, bool) {
 	return "", false
 }
 
-func wildCardToRegexp(parsedPattern *url.URL, keys []string) (*regexp.Regexp, error) {
-	var (
-		result   strings.Builder
-		keyIndex int
-	)
+// rawHostPort extracts the "host:port" portion from a raw URL pattern string,
+// stripping the scheme and any path/query/fragment.
+func rawHostPort(rawURL string) string {
+	if i := strings.Index(rawURL, "://"); i >= 0 {
+		rawURL = rawURL[i+3:]
+	}
+
+	rawURL = strings.TrimPrefix(rawURL, "//")
+
+	if i := strings.IndexAny(rawURL, "/?#"); i >= 0 {
+		rawURL = rawURL[:i]
+	}
+
+	return strings.ToLower(rawURL)
+}
+
+// rawHost returns the host part of "host:port", validating that the port (if
+// present) is not empty.
+func rawHost(hostport string) (string, error) {
+	if strings.HasPrefix(hostport, "[") {
+		if i := strings.Index(hostport, "]"); i >= 0 {
+			return hostport[:i+1], nil
+		}
+	}
+
+	if i := strings.LastIndex(hostport, ":"); i >= 0 {
+		if hostport[i+1:] == "" {
+			return "", fmt.Errorf("failed to build url glob: port %q: %w", "//"+hostport, errEmptyPort)
+		}
+
+		return hostport[:i], nil
+	}
+
+	return hostport, nil
+}
+
+// wildCardToRegexp builds a regexp from a raw source URL pattern.
+// {key} placeholders become named capture groups (?P<key>.+).
+func wildCardToRegexp(rawSource string) (*regexp.Regexp, error) {
+	var result strings.Builder
 
 	result.WriteString(`^(?P<scheme>(http(s?):)?\/\/)?`)
 
-	host, _, err := urlparser.SplitHostPort(parsedPattern)
+	hp := rawHostPort(rawSource)
+
+	host, err := rawHost(hp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build url glob: %w", err)
+		return nil, err
 	}
 
-	parts := strings.Split(host, "*")
-	for index, literal := range parts {
-		if index > 0 {
-			name := fmt.Sprintf("part%d", keyIndex+1)
-			if keyIndex < len(keys) {
-				name = keys[keyIndex]
-			}
-			keyIndex++
-			fmt.Fprintf(&result, "(?P<%s>.+)", name)
-		}
+	lastIndex := 0
+	for _, match := range placeholderRegexp.FindAllStringIndex(host, -1) {
+		result.WriteString(regexp.QuoteMeta(host[lastIndex:match[0]]))
 
-		result.WriteString(regexp.QuoteMeta(literal))
+		key := host[match[0]+1 : match[1]-1] // strip { and }
+		fmt.Fprintf(&result, "(?P<%s>.+)", key)
+
+		lastIndex = match[1]
 	}
 
+	result.WriteString(regexp.QuoteMeta(host[lastIndex:]))
 	result.WriteString(`(:\d+)?`)
 	result.WriteString(`(?P<path>[\/?].*)?$`)
 
-	compiledRegexp, err := regexp.Compile(result.String())
+	compiled, err := regexp.Compile(result.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to build url glob: %w", err)
 	}
 
-	return compiledRegexp, nil
+	return compiled, nil
 }
 
-func wildCardToReplacePattern(parsedPattern *url.URL, keys []string) string {
+// wildCardToReplacePattern builds a replacement pattern string from a raw
+// target URL pattern. {key} placeholders become ${key} references.
+func wildCardToReplacePattern(rawTarget string) string {
 	result := &strings.Builder{}
 	result.WriteString("${scheme}")
 
-	keyIndex := 0
-	for i, literal := range strings.Split(parsedPattern.Host, "*") {
-		if i > 0 {
-			name := fmt.Sprintf("part%d", keyIndex+1)
-			if keyIndex < len(keys) {
-				name = keys[keyIndex]
-			}
-			keyIndex++
-			fmt.Fprintf(result, "${%s}", name)
-		}
+	hp := rawHostPort(rawTarget)
+	replaced := placeholderRegexp.ReplaceAllStringFunc(hp, func(match string) string {
+		key := match[1 : len(match)-1] // strip { and }
 
-		result.WriteString(literal)
-	}
+		return "${" + key + "}"
+	})
 
+	result.WriteString(replaced)
 	result.WriteString("${path}")
 
 	return result.String()

--- a/internal/urlreplacer/helpers.go
+++ b/internal/urlreplacer/helpers.go
@@ -9,9 +9,13 @@ import (
 )
 
 var (
-	placeholderRegexp = regexp.MustCompile(`\{([a-zA-Z][a-zA-Z0-9_]*)\}`)
-	schemeRegexp      = regexp.MustCompile(`^(https?):`)
-	errEmptyPort      = errors.New("empty port")
+	placeholderRegexp     = regexp.MustCompile(`\{([a-zA-Z][a-zA-Z0-9_]*)\}`)
+	schemeRegexp          = regexp.MustCompile(`^(https?):`)
+	errEmptyPort          = errors.New("empty port")
+	errEmptyURL           = errors.New("url is empty")
+	errWildcardNotAllowed = errors.New("use {key} placeholders instead of * wildcard")
+	errURLHasPath         = errors.New("url must not have a path")
+	errURLHasQuery        = errors.New("url must not have query parameters")
 )
 
 // extractKeys returns the ordered placeholder key names from a raw URL pattern.
@@ -135,12 +139,12 @@ func wildCardToReplacePattern(rawTarget string) string {
 // Only {key} placeholders are allowed, not * wildcards.
 func validateRawURL(rawURL string) error {
 	if len(rawURL) == 0 {
-		return errors.New("url is empty")
+		return errEmptyURL
 	}
 
 	// Check for * wildcard usage - not allowed, use {key} placeholders instead
 	if strings.Contains(rawURL, "*") {
-		return errors.New("wildcard * is not allowed, use {key} placeholders instead (e.g., {tenant}.demo.com)")
+		return errWildcardNotAllowed
 	}
 
 	// Replace {key} placeholders with a placeholder for validation
@@ -164,10 +168,11 @@ func validateRawURL(rawURL string) error {
 
 	// Check for path/query/fragment
 	if len(parsed.Path) > 0 && parsed.Path != "/" {
-		return errors.New("url must not have a path")
+		return errURLHasPath
 	}
+
 	if len(parsed.RawQuery) > 0 {
-		return errors.New("url must not have query parameters")
+		return errURLHasQuery
 	}
 
 	return nil
@@ -179,5 +184,6 @@ func extractScheme(rawURL string) string {
 	if len(matches) > 1 {
 		return matches[1]
 	}
+
 	return ""
 }

--- a/internal/urlreplacer/helpers.go
+++ b/internal/urlreplacer/helpers.go
@@ -3,12 +3,14 @@ package urlreplacer
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 )
 
 var (
 	placeholderRegexp = regexp.MustCompile(`\{([a-zA-Z][a-zA-Z0-9_]*)\}`)
+	schemeRegexp      = regexp.MustCompile(`^(https?):`)
 	errEmptyPort      = errors.New("empty port")
 )
 
@@ -127,4 +129,50 @@ func wildCardToReplacePattern(rawTarget string) string {
 	result.WriteString("${path}")
 
 	return result.String()
+}
+
+// validateRawURL checks that a raw URL pattern is valid: no path or query.
+// It works by temporarily replacing {key} placeholders with * for validation.
+func validateRawURL(rawURL string) error {
+	if len(rawURL) == 0 {
+		return errors.New("url is empty")
+	}
+
+	// Replace {key} placeholders with * for validation (only placeholders, not other braces)
+	// This allows standard url.Parse to validate the structure
+	normalized := placeholderRegexp.ReplaceAllString(rawURL, "*")
+
+	// Ensure URL has a scheme for proper parsing
+	if !strings.Contains(normalized, "://") {
+		if strings.HasPrefix(normalized, "//") {
+			normalized = "http:" + normalized
+		} else {
+			normalized = "http://" + normalized
+		}
+	}
+
+	// Validate with standard library
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+
+	// Check for path/query/fragment
+	if len(parsed.Path) > 0 && parsed.Path != "/" {
+		return errors.New("url must not have a path")
+	}
+	if len(parsed.RawQuery) > 0 {
+		return errors.New("url must not have query parameters")
+	}
+
+	return nil
+}
+
+// extractScheme returns the scheme (http or https) from a raw URL, or empty string.
+func extractScheme(rawURL string) string {
+	matches := schemeRegexp.FindStringSubmatch(rawURL)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return ""
 }

--- a/internal/urlreplacer/helpers.go
+++ b/internal/urlreplacer/helpers.go
@@ -131,16 +131,21 @@ func wildCardToReplacePattern(rawTarget string) string {
 	return result.String()
 }
 
-// validateRawURL checks that a raw URL pattern is valid: no path or query.
-// It works by temporarily replacing {key} placeholders with * for validation.
+// validateRawURL checks that a raw URL pattern is valid: no path or query, no wildcard *.
+// Only {key} placeholders are allowed, not * wildcards.
 func validateRawURL(rawURL string) error {
 	if len(rawURL) == 0 {
 		return errors.New("url is empty")
 	}
 
-	// Replace {key} placeholders with * for validation (only placeholders, not other braces)
+	// Check for * wildcard usage - not allowed, use {key} placeholders instead
+	if strings.Contains(rawURL, "*") {
+		return errors.New("wildcard * is not allowed, use {key} placeholders instead (e.g., {tenant}.demo.com)")
+	}
+
+	// Replace {key} placeholders with a placeholder for validation
 	// This allows standard url.Parse to validate the structure
-	normalized := placeholderRegexp.ReplaceAllString(rawURL, "*")
+	normalized := placeholderRegexp.ReplaceAllString(rawURL, "x")
 
 	// Ensure URL has a scheme for proper parsing
 	if !strings.Contains(normalized, "://") {

--- a/internal/urlreplacer/helpers_internal_test.go
+++ b/internal/urlreplacer/helpers_internal_test.go
@@ -1,12 +1,9 @@
 package urlreplacer
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/evg4b/uncors/internal/urlparser"
 	"github.com/evg4b/uncors/testing/hosts"
-	"github.com/evg4b/uncors/testing/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,11 +80,7 @@ func TestWildCardToRegexp(t *testing.T) {
 	t.Run("regexp", func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				parsedPattern, err := urlparser.Parse(testCase.url)
-				testutils.CheckNoError(t, err)
-
-				keys := extractKeys(testCase.url)
-				compiledRegexp, err := wildCardToRegexp(parsedPattern, keys)
+				compiledRegexp, err := wildCardToRegexp(testCase.url)
 
 				require.NoError(t, err)
 				assert.Equal(t, testCase.expectedRegexp, compiledRegexp.String())
@@ -101,58 +94,22 @@ func TestWildCardToRegexp(t *testing.T) {
 			url      string
 			expected []string
 		}{
-			{
-				name:     "no placeholders",
-				url:      hosts.Localhost.Host(),
-				expected: []string{},
-			},
-			{
-				name:     "single placeholder",
-				url:      "{tenant}",
-				expected: []string{"tenant"},
-			},
-			{
-				name:     "two placeholders",
-				url:      "{region}.{tenant}.com",
-				expected: []string{"region", "tenant"},
-			},
-			{
-				name:     "three placeholders",
-				url:      "api.{env}.{region}.{tenant}.com",
-				expected: []string{"env", "region", "tenant"},
-			},
+			{name: "no placeholders", url: hosts.Localhost.Host(), expected: []string{}},
+			{name: "single placeholder", url: "{tenant}", expected: []string{"tenant"}},
+			{name: "two placeholders", url: "{region}.{tenant}.com", expected: []string{"region", "tenant"}},
+			{name: "three placeholders", url: "api.{env}.{region}.{tenant}.com", expected: []string{"env", "region", "tenant"}},
 		}
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				keys := extractKeys(testCase.url)
-				if testCase.expected == nil {
-					testCase.expected = []string{}
-				}
-				assert.Equal(t, testCase.expected, keys)
+				assert.Equal(t, testCase.expected, extractKeys(testCase.url))
 			})
 		}
 	})
 
 	t.Run("error handling", func(t *testing.T) {
-		testCases := []struct {
-			name          string
-			parsedPattern url.URL
-			expected      string
-		}{
-			{
-				name:          "incorrect port",
-				parsedPattern: url.URL{Host: "localhost:"},
-				expected:      `failed to build url glob: port "//localhost:": empty port`,
-			},
-		}
-		for _, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
-				pattern := testCase.parsedPattern
-				_, err := wildCardToRegexp(&pattern, nil)
+		_, err := wildCardToRegexp("localhost:")
 
-				require.EqualError(t, err, testCase.expected)
-			})
-		}
+		require.EqualError(t, err, `failed to build url glob: port "//localhost:": empty port`)
 	})
 }
 
@@ -160,51 +117,7 @@ func TestWildCardToReplacePattern(t *testing.T) {
 	t.Run("pattern", func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				parsedPattern, err := urlparser.Parse(testCase.url)
-				testutils.CheckNoError(t, err)
-
-				keys := extractKeys(testCase.url)
-				pattern := wildCardToReplacePattern(parsedPattern, keys)
-
-				assert.Equal(t, testCase.expectedPattern, pattern)
-			})
-		}
-	})
-
-	t.Run("extracted keys", func(t *testing.T) {
-		testCases := []struct {
-			name     string
-			url      string
-			expected []string
-		}{
-			{
-				name:     "no placeholders",
-				url:      hosts.Localhost.Host(),
-				expected: []string{},
-			},
-			{
-				name:     "single placeholder",
-				url:      "{tenant}",
-				expected: []string{"tenant"},
-			},
-			{
-				name:     "two placeholders",
-				url:      "{region}.{tenant}.com",
-				expected: []string{"region", "tenant"},
-			},
-			{
-				name:     "three placeholders",
-				url:      "api.{env}.{region}.{tenant}.com",
-				expected: []string{"env", "region", "tenant"},
-			},
-		}
-		for _, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
-				keys := extractKeys(testCase.url)
-				if testCase.expected == nil {
-					testCase.expected = []string{}
-				}
-				assert.Equal(t, testCase.expected, keys)
+				assert.Equal(t, testCase.expectedPattern, wildCardToReplacePattern(testCase.url))
 			})
 		}
 	})

--- a/internal/urlreplacer/helpers_internal_test.go
+++ b/internal/urlreplacer/helpers_internal_test.go
@@ -30,52 +30,52 @@ var testCases = []struct {
 		expectedPattern: "${scheme}localhost:3000${path}",
 	},
 	{
-		name:            "single star",
-		url:             "*",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<part1>.+)(:\d+)?(?P<path>[\/?].*)?$`,
-		expectedPattern: "${scheme}${part1}${path}",
+		name:            "single placeholder",
+		url:             "{tenant}",
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>.+)(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedPattern: "${scheme}${tenant}${path}",
 	},
 	{
-		name:            "single star with port",
-		url:             "*:3001",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<part1>.+)(:\d+)?(?P<path>[\/?].*)?$`,
-		expectedPattern: "${scheme}${part1}:3001${path}",
+		name:            "single placeholder with port",
+		url:             "{tenant}:3001",
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>.+)(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedPattern: "${scheme}${tenant}:3001${path}",
 	},
 	{
-		name:            "single star with url part",
-		url:             "demo.*.com",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?demo\.(?P<part1>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
-		expectedPattern: "${scheme}demo.${part1}.com${path}",
+		name:            "single placeholder with url part",
+		url:             "demo.{tenant}.com",
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?demo\.(?P<tenant>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedPattern: "${scheme}demo.${tenant}.com${path}",
 	},
 	{
-		name:            "single star with url part and port",
-		url:             "api.*.com:3001",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?api\.(?P<part1>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
-		expectedPattern: "${scheme}api.${part1}.com:3001${path}",
+		name:            "single placeholder with url part and port",
+		url:             "api.{tenant}.com:3001",
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?api\.(?P<tenant>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedPattern: "${scheme}api.${tenant}.com:3001${path}",
 	},
 	{
-		name:            "multiple stars with url part",
-		url:             "*.host.*.com",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<part1>.+)\.host\.(?P<part2>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
-		expectedPattern: "${scheme}${part1}.host.${part2}.com${path}",
+		name:            "multiple placeholders with url part",
+		url:             "{region}.host.{tenant}.com",
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<region>.+)\.host\.(?P<tenant>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedPattern: "${scheme}${region}.host.${tenant}.com${path}",
 	},
 	{
-		name:            "multiple stars with url part and port",
-		url:             "*.host.*.com:3001",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<part1>.+)\.host\.(?P<part2>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
-		expectedPattern: "${scheme}${part1}.host.${part2}.com:3001${path}",
+		name:            "multiple placeholders with url part and port",
+		url:             "{region}.host.{tenant}.com:3001",
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<region>.+)\.host\.(?P<tenant>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedPattern: "${scheme}${region}.host.${tenant}.com:3001${path}",
 	},
 	{
 		name:            "host with default http port",
-		url:             "*.api.com:80",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<part1>.+)\.api\.com(:\d+)?(?P<path>[\/?].*)?$`,
-		expectedPattern: "${scheme}${part1}.api.com:80${path}",
+		url:             "{tenant}.api.com:80",
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>.+)\.api\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedPattern: "${scheme}${tenant}.api.com:80${path}",
 	},
 	{
 		name:            "host with default https port",
-		url:             "*.api.com:443",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<part1>.+)\.api\.com(:\d+)?(?P<path>[\/?].*)?$`,
-		expectedPattern: "${scheme}${part1}.api.com:443${path}",
+		url:             "{tenant}.api.com:443",
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>.+)\.api\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedPattern: "${scheme}${tenant}.api.com:443${path}",
 	},
 }
 
@@ -86,50 +86,49 @@ func TestWildCardToRegexp(t *testing.T) {
 				parsedPattern, err := urlparser.Parse(testCase.url)
 				testutils.CheckNoError(t, err)
 
-				regexp, _, err := wildCardToRegexp(parsedPattern)
+				keys := extractKeys(testCase.url)
+				compiledRegexp, err := wildCardToRegexp(parsedPattern, keys)
 
 				require.NoError(t, err)
-				assert.Equal(t, testCase.expectedRegexp, regexp.String())
+				assert.Equal(t, testCase.expectedRegexp, compiledRegexp.String())
 			})
 		}
 	})
 
-	t.Run("wildcard count", func(t *testing.T) {
+	t.Run("extracted keys", func(t *testing.T) {
 		testCases := []struct {
 			name     string
 			url      string
-			expected int
+			expected []string
 		}{
 			{
-				name:     "no wildcards",
+				name:     "no placeholders",
 				url:      hosts.Localhost.Host(),
-				expected: 0,
+				expected: []string{},
 			},
 			{
-				name:     "single star",
-				url:      "*",
-				expected: 1,
+				name:     "single placeholder",
+				url:      "{tenant}",
+				expected: []string{"tenant"},
 			},
 			{
-				name:     "two stars",
-				url:      "*.*.com",
-				expected: 2,
+				name:     "two placeholders",
+				url:      "{region}.{tenant}.com",
+				expected: []string{"region", "tenant"},
 			},
 			{
-				name:     "three stars",
-				url:      "api.*.*.*.com",
-				expected: 3,
+				name:     "three placeholders",
+				url:      "api.{env}.{region}.{tenant}.com",
+				expected: []string{"env", "region", "tenant"},
 			},
 		}
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				parsedPattern, err := urlparser.Parse(testCase.url)
-				testutils.CheckNoError(t, err)
-
-				_, count, err := wildCardToRegexp(parsedPattern)
-
-				require.NoError(t, err)
-				assert.Equal(t, testCase.expected, count)
+				keys := extractKeys(testCase.url)
+				if testCase.expected == nil {
+					testCase.expected = []string{}
+				}
+				assert.Equal(t, testCase.expected, keys)
 			})
 		}
 	})
@@ -149,7 +148,7 @@ func TestWildCardToRegexp(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
 				pattern := testCase.parsedPattern
-				_, _, err := wildCardToRegexp(&pattern)
+				_, err := wildCardToRegexp(&pattern, nil)
 
 				require.EqualError(t, err, testCase.expected)
 			})
@@ -164,49 +163,48 @@ func TestWildCardToReplacePattern(t *testing.T) {
 				parsedPattern, err := urlparser.Parse(testCase.url)
 				testutils.CheckNoError(t, err)
 
-				pattern, _ := wildCardToReplacePattern(parsedPattern)
+				keys := extractKeys(testCase.url)
+				pattern := wildCardToReplacePattern(parsedPattern, keys)
 
 				assert.Equal(t, testCase.expectedPattern, pattern)
 			})
 		}
 	})
 
-	t.Run("wildcard count", func(t *testing.T) {
+	t.Run("extracted keys", func(t *testing.T) {
 		testCases := []struct {
 			name     string
 			url      string
-			expected int
+			expected []string
 		}{
 			{
-				name:     "no wildcards",
+				name:     "no placeholders",
 				url:      hosts.Localhost.Host(),
-				expected: 0,
+				expected: []string{},
 			},
 			{
-				name:     "single star",
-				url:      "*",
-				expected: 1,
+				name:     "single placeholder",
+				url:      "{tenant}",
+				expected: []string{"tenant"},
 			},
 			{
-				name:     "two stars",
-				url:      "*.*.com",
-				expected: 2,
+				name:     "two placeholders",
+				url:      "{region}.{tenant}.com",
+				expected: []string{"region", "tenant"},
 			},
 			{
-				name:     "three stars",
-				url:      "api.*.*.*.com",
-				expected: 3,
+				name:     "three placeholders",
+				url:      "api.{env}.{region}.{tenant}.com",
+				expected: []string{"env", "region", "tenant"},
 			},
 		}
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				parsedPattern, err := urlparser.Parse(testCase.url)
-				testutils.CheckNoError(t, err)
-
-				_, count := wildCardToReplacePattern(parsedPattern)
-
-				require.NoError(t, err)
-				assert.Equal(t, testCase.expected, count)
+				keys := extractKeys(testCase.url)
+				if testCase.expected == nil {
+					testCase.expected = []string{}
+				}
+				assert.Equal(t, testCase.expected, keys)
 			})
 		}
 	})

--- a/internal/urlreplacer/replacer.go
+++ b/internal/urlreplacer/replacer.go
@@ -16,9 +16,10 @@ var (
 )
 
 var (
-	ErrInvalidSourceURL = errors.New("source host is invalid")
-	ErrInvalidTargetURL = errors.New("target host is invalid")
-	ErrURLNotMatched    = errors.New("is not matched")
+	ErrInvalidSourceURL  = errors.New("source host is invalid")
+	ErrInvalidTargetURL  = errors.New("target host is invalid")
+	ErrURLNotMatched     = errors.New("is not matched")
+	ErrDuplicateSourceKey = errors.New("source url contains duplicate placeholder key")
 )
 
 type hook = func(string) string
@@ -40,6 +41,13 @@ func NewReplacer(source, target string) (*Replacer, error) {
 		return nil, ErrEmptyTargetURL
 	}
 
+	sourceKeys := extractKeys(source)
+	if dup, isDup := hasDuplicateKeys(sourceKeys); isDup {
+		return nil, fmt.Errorf("%w: {%s}", ErrDuplicateSourceKey, dup)
+	}
+
+	targetKeys := extractKeys(target)
+
 	var err error
 
 	replacer := &Replacer{
@@ -56,12 +64,12 @@ func NewReplacer(source, target string) (*Replacer, error) {
 		return nil, ErrInvalidTargetURL
 	}
 
-	replacer.regexp, _, err = wildCardToRegexp(replacer.source)
+	replacer.regexp, err = wildCardToRegexp(replacer.source, sourceKeys)
 	if err != nil {
 		return nil, err
 	}
 
-	replacer.pattern, _ = wildCardToReplacePattern(replacer.target)
+	replacer.pattern = wildCardToReplacePattern(replacer.target, targetKeys)
 
 	if len(replacer.target.Scheme) > 0 {
 		replacer.hooks["scheme"] = schemeHookFactory(replacer.target.Scheme)

--- a/internal/urlreplacer/replacer.go
+++ b/internal/urlreplacer/replacer.go
@@ -16,9 +16,9 @@ var (
 )
 
 var (
-	ErrInvalidSourceURL  = errors.New("source host is invalid")
-	ErrInvalidTargetURL  = errors.New("target host is invalid")
-	ErrURLNotMatched     = errors.New("is not matched")
+	ErrInvalidSourceURL   = errors.New("source host is invalid")
+	ErrInvalidTargetURL   = errors.New("target host is invalid")
+	ErrURLNotMatched      = errors.New("is not matched")
 	ErrDuplicateSourceKey = errors.New("source url contains duplicate placeholder key")
 )
 
@@ -46,8 +46,6 @@ func NewReplacer(source, target string) (*Replacer, error) {
 		return nil, fmt.Errorf("%w: {%s}", ErrDuplicateSourceKey, dup)
 	}
 
-	targetKeys := extractKeys(target)
-
 	var err error
 
 	replacer := &Replacer{
@@ -64,12 +62,12 @@ func NewReplacer(source, target string) (*Replacer, error) {
 		return nil, ErrInvalidTargetURL
 	}
 
-	replacer.regexp, err = wildCardToRegexp(replacer.source, sourceKeys)
+	replacer.regexp, err = wildCardToRegexp(source)
 	if err != nil {
 		return nil, err
 	}
 
-	replacer.pattern = wildCardToReplacePattern(replacer.target, targetKeys)
+	replacer.pattern = wildCardToReplacePattern(target)
 
 	if len(replacer.target.Scheme) > 0 {
 		replacer.hooks["scheme"] = schemeHookFactory(replacer.target.Scheme)

--- a/internal/urlreplacer/replacer.go
+++ b/internal/urlreplacer/replacer.go
@@ -3,11 +3,8 @@ package urlreplacer
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"regexp"
 	"strings"
-
-	"github.com/evg4b/uncors/internal/urlparser"
 )
 
 var (
@@ -20,16 +17,17 @@ var (
 	ErrInvalidTargetURL   = errors.New("target host is invalid")
 	ErrURLNotMatched      = errors.New("is not matched")
 	ErrDuplicateSourceKey = errors.New("source url contains duplicate placeholder key")
+	ErrURLHasPath         = errors.New("url must not have a path")
+	ErrURLHasQuery        = errors.New("url must not have query parameters")
 )
 
 type hook = func(string) string
 
 type Replacer struct {
-	source  *url.URL
-	target  *url.URL
 	regexp  *regexp.Regexp
 	pattern string
 	hooks   map[string]hook
+	scheme  string // target scheme (http or https), or empty
 }
 
 func NewReplacer(source, target string) (*Replacer, error) {
@@ -46,22 +44,20 @@ func NewReplacer(source, target string) (*Replacer, error) {
 		return nil, fmt.Errorf("%w: {%s}", ErrDuplicateSourceKey, dup)
 	}
 
-	var err error
+	// Validate raw URLs before any processing
+	if err := validateRawURL(source); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidSourceURL, err)
+	}
+
+	if err := validateRawURL(target); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidTargetURL, err)
+	}
 
 	replacer := &Replacer{
 		hooks: map[string]func(string) string{},
 	}
 
-	replacer.source, err = urlparser.Parse(source)
-	if err != nil {
-		return nil, ErrInvalidSourceURL
-	}
-
-	replacer.target, err = urlparser.Parse(target)
-	if err != nil {
-		return nil, ErrInvalidTargetURL
-	}
-
+	var err error
 	replacer.regexp, err = wildCardToRegexp(source)
 	if err != nil {
 		return nil, err
@@ -69,23 +65,13 @@ func NewReplacer(source, target string) (*Replacer, error) {
 
 	replacer.pattern = wildCardToReplacePattern(target)
 
-	if len(replacer.target.Scheme) > 0 {
-		replacer.hooks["scheme"] = schemeHookFactory(replacer.target.Scheme)
+	// Extract and store target scheme
+	replacer.scheme = extractScheme(target)
+	if len(replacer.scheme) > 0 {
+		replacer.hooks["scheme"] = schemeHookFactory(replacer.scheme)
 	}
 
-	return replacer, validateReplacer(replacer)
-}
-
-func validateReplacer(replacer *Replacer) error {
-	if len(replacer.source.Path) > 0 || len(replacer.source.RawQuery) > 0 {
-		return ErrInvalidSourceURL
-	}
-
-	if len(replacer.target.Path) > 0 || len(replacer.target.RawQuery) > 0 {
-		return ErrInvalidTargetURL
-	}
-
-	return nil
+	return replacer, nil
 }
 
 func (r *Replacer) Replace(source string) (string, error) {
@@ -123,8 +109,8 @@ func (r *Replacer) ReplaceSoft(source string) string {
 }
 
 func (r *Replacer) IsTargetSecure() bool {
-	if len(r.target.Scheme) > 0 {
-		return isSecure(r.target.Scheme)
+	if len(r.scheme) > 0 {
+		return isSecure(r.scheme)
 	}
 
 	return false

--- a/internal/urlreplacer/replacer.go
+++ b/internal/urlreplacer/replacer.go
@@ -45,19 +45,20 @@ func NewReplacer(source, target string) (*Replacer, error) {
 	}
 
 	// Validate raw URLs before any processing
-	if err := validateRawURL(source); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidSourceURL, err)
+	err := validateRawURL(source)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidSourceURL, err)
 	}
 
-	if err := validateRawURL(target); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidTargetURL, err)
+	err = validateRawURL(target)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidTargetURL, err)
 	}
 
 	replacer := &Replacer{
 		hooks: map[string]func(string) string{},
 	}
 
-	var err error
 	replacer.regexp, err = wildCardToRegexp(source)
 	if err != nil {
 		return nil, err

--- a/internal/urlreplacer/replacer_test.go
+++ b/internal/urlreplacer/replacer_test.go
@@ -31,10 +31,16 @@ func TestReplacerV2Replace(t *testing.T) {
 		})
 	})
 
+	t.Run("duplicate source key", func(t *testing.T) {
+		_, err := urlreplacer.NewReplacer("http://{client}.{client}.com", "http://api.com")
+
+		require.ErrorIs(t, err, urlreplacer.ErrDuplicateSourceKey)
+	})
+
 	t.Run("Replace", func(t *testing.T) {
 		t.Run("where schemes given and", func(t *testing.T) {
 			t.Run("schemes are equal", func(t *testing.T) {
-				replacer, err := urlreplacer.NewReplacer("http://*.localhost.com", "http://api.*.com")
+				replacer, err := urlreplacer.NewReplacer("http://{tenant}.localhost.com", "http://api.{tenant}.com")
 				testutils.CheckNoError(t, err)
 
 				testsCases := []replacerTestCase{
@@ -70,7 +76,7 @@ func TestReplacerV2Replace(t *testing.T) {
 			})
 
 			t.Run("mapped from http to https", func(t *testing.T) {
-				replacer, err := urlreplacer.NewReplacer("http://*.localhost.com", "https://api.*.com")
+				replacer, err := urlreplacer.NewReplacer("http://{tenant}.localhost.com", "https://api.{tenant}.com")
 				testutils.CheckNoError(t, err)
 
 				testsCases := []replacerTestCase{
@@ -106,7 +112,7 @@ func TestReplacerV2Replace(t *testing.T) {
 			})
 
 			t.Run("mapped from https to http", func(t *testing.T) {
-				replacer, err := urlreplacer.NewReplacer("https://*.localhost.com", "http://api.*.com")
+				replacer, err := urlreplacer.NewReplacer("https://{tenant}.localhost.com", "http://api.{tenant}.com")
 				testutils.CheckNoError(t, err)
 
 				testsCases := []replacerTestCase{
@@ -182,7 +188,7 @@ func TestReplacerV2Replace(t *testing.T) {
 			}
 
 			t.Run("where schemes are not given", func(t *testing.T) {
-				replacer, err := urlreplacer.NewReplacer("*.localhost.com", "api.*.com")
+				replacer, err := urlreplacer.NewReplacer("{tenant}.localhost.com", "api.{tenant}.com")
 				testutils.CheckNoError(t, err)
 
 				for _, testsCase := range testsCases {
@@ -196,7 +202,7 @@ func TestReplacerV2Replace(t *testing.T) {
 			})
 
 			t.Run("where schemes set as //", func(t *testing.T) {
-				replacer, err := urlreplacer.NewReplacer("//*.localhost.com", "//api.*.com")
+				replacer, err := urlreplacer.NewReplacer("//{tenant}.localhost.com", "//api.{tenant}.com")
 				testutils.CheckNoError(t, err)
 
 				for _, testsCase := range testsCases {
@@ -261,7 +267,7 @@ func TestReplacerIsTargetSecure(t *testing.T) {
 }
 
 func TestReplacerIsMatched(t *testing.T) {
-	replacer, err := urlreplacer.NewReplacer("*.my.cc:3000", "https://*.master-staging.com")
+	replacer, err := urlreplacer.NewReplacer("{tenant}.my.cc:3000", "https://{tenant}.master-staging.com")
 	testutils.CheckNoError(t, err)
 
 	testsCases := []struct {


### PR DESCRIPTION
## Summary

- Replaces anonymous `*` wildcards with named `{key}` placeholders in host mapping patterns (e.g. `http://{client}.local.com → https://{client}.api.com`)
- Replacement is now by **key name**, not positional order — source and target can use the same key in a different position
- `NewReplacer` rejects source patterns with duplicate key names (`ErrDuplicateSourceKey`)
- Helpers work directly on raw URL strings — no `{key}→*→{key}` round-trip

## Changes

| Component | What changed |
|---|---|
| `urlparser` | `ParseWithDefaultScheme` normalises `{key}` → `*` before `url.Parse` (needed for validators and scheme extraction) |
| `urlreplacer/helpers` | `wildCardToRegexp` / `wildCardToReplacePattern` now take a raw string and apply `placeholderRegexp` directly; `extractKeys` + `hasDuplicateKeys` added |
| `urlreplacer/replacer` | `NewReplacer` validates unique source keys; passes raw strings to helpers |
| `docs/Configuration.md` | "Wildcard Mapping" → "Named Placeholder Mapping"; added multi-placeholder by-name example |

## Test plan

- [ ] `go test ./...` passes (all packages green)
- [ ] `{tenant}.localhost.com` → `api.{tenant}.com` mapping replaces correctly
- [ ] `{env}.{service}.local.com` → `{service}.{env}.api.com` substitutes by name in different order
- [ ] `NewReplacer("http://{x}.{x}.com", ...)` returns `ErrDuplicateSourceKey`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)