### PR TITLE
docs: restructure and improve documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -99,23 +99,23 @@ It is enabled per-mapping via the `har.file` config key and is implemented as a
 standalone middleware (`internal/handler/har`).
 
 **Design goals:**
-- **Non-blocking** — the middleware never blocks the request goroutine. Entries
+- **Non-blocking** - the middleware never blocks the request goroutine. Entries
   are sent over a buffered channel (capacity 4096). If the channel is full the
   entry is silently dropped rather than stalling the request.
-- **High throughput writes** — a single background goroutine serialises all
+- **High throughput writes** - a single background goroutine serialises all
   disk I/O. After every new entry it atomically replaces the HAR file using a
   write-to-tmp-then-rename strategy so the file is always in a valid state.
-- **Per-mapping isolation** — each mapping creates its own `Writer` instance and
+- **Per-mapping isolation** - each mapping creates its own `Writer` instance and
   its own output file, so traffic from different mappings can be captured
   independently.
-- **Lifecycle management** — `Writer` implements `io.Closer`. The app registers
+- **Lifecycle management** - `Writer` implements `io.Closer`. The app registers
   each writer via `registerCloser`; on shutdown or config reload it calls
   `Close()` which drains the channel and flushes outstanding entries before
   stopping the background goroutine.
 
 **Configuration:**
 
-The simplest form uses a string shorthand — the value is treated as the output file path:
+The simplest form uses a string shorthand - the value is treated as the output file path:
 
 ```yaml
 mappings:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,9 +1,24 @@
-UNCORS supports two configuration methods: command-line arguments and configuration files. When both are used, CLI arguments take precedence and will override settings defined in the configuration file.
+UNCORS supports two configuration methods: command-line arguments and configuration files. When both are used, CLI arguments take precedence and override settings defined in the configuration file.
 
-The configuration system is built around the concept of host mappings, which translate local domains (defined in your hosts file) to external domains. Configuration settings are organized into two levels:
+The configuration system is built around the concept of host mappings, which translate local domains (defined in your hosts file) to external domains. Settings are organized into two levels:
 
-- **Global Configuration**: Settings that apply to all mappings and control core server behavior
-- **Mapping Configuration**: Settings specific to individual host mappings that determine how requests are handled and responses are generated
+- **Global Configuration** - settings that apply to all mappings and control core server behavior
+- **Mapping Configuration** - settings specific to individual host mappings that determine how requests are handled
+
+## Table of Contents
+
+- [Quick Reference](#quick-reference)
+- [Command-Line Options](#command-line-options)
+- [Configuration File](#configuration-file)
+- [Global Configuration Properties](#global-configuration-properties)
+- [Mapping Configuration](#mapping-configuration)
+  - [OPTIONS Request Handling](#options-request-handling)
+  - [Protocol Scheme Mapping](#protocol-scheme-mapping)
+  - [Named Placeholder Mapping](#named-placeholder-mapping)
+  - [Simplified Syntax](#simplified-syntax)
+- [HAR Recording](#har-recording)
+- [HTTPS Configuration](#https-configuration)
+- [Proxy Configuration](#proxy-configuration)
 
 ## Quick Reference
 
@@ -46,13 +61,13 @@ mappings:
 ```
 
 > [!TIP]
-> For complete working examples, see [Real-World Examples](./Real-World-Examples)
+> For complete working examples, see [Real-World Examples](Real-World-Examples)
 
-# Command-Line Options
+## Command-Line Options
 
 Configure the UNCORS proxy server using the following command-line parameters:
 
-## Mapping Configuration
+### Mapping Configuration
 
 | Parameter | Short | Description                                                                                                                         |
 | --------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------- |
@@ -61,7 +76,7 @@ Configure the UNCORS proxy server using the following command-line parameters:
 
 Multiple `--from`/`--to` pairs can be specified to define additional mappings. Each mapping can use a different port by specifying it in the URL.
 
-## Global Configuration
+### Global Configuration
 
 | Parameter  | Short | Description                                |
 | ---------- | ----- | ------------------------------------------ |
@@ -72,16 +87,16 @@ Multiple `--from`/`--to` pairs can be specified to define additional mappings. E
 > [!NOTE]
 > CLI parameters override configuration file settings.
 
-# Configuration File
+## Configuration File
 
 UNCORS uses YAML format for configuration files. Below is a comprehensive example demonstrating all available options:
 
 ```yaml
-# global configuration
+# Global configuration
 debug: false
 proxy: localhost:8080
 
-# mappings configuration
+# Mappings configuration
 mappings:
   - http://localhost:8080: https://github.com
   - from: http://other.domain.com:3000
@@ -112,17 +127,18 @@ mappings:
           response:WriteString(json.encode({status = "ok", received = data}))
 ```
 
-# Global Configuration Properties
+## Global Configuration Properties
 
-| Property   | Type    | Default | Description                                     |
-| ---------- | ------- | ------- | ----------------------------------------------- |
-| `proxy`    | string  | -       | HTTP/HTTPS proxy URL for upstream requests      |
-| `debug`    | boolean | false   | Enable debug logging output                     |
-| `mappings` | array   | []      | List of host mapping configurations (see below) |
+| Property       | Type    | Default | Description                                                               |
+| -------------- | ------- | ------- | ------------------------------------------------------------------------- |
+| `proxy`        | string  | -       | HTTP/HTTPS proxy URL for upstream requests                                |
+| `debug`        | boolean | `false` | Enable debug logging output                                               |
+| `mappings`     | array   | `[]`    | List of host mapping configurations (see below)                           |
+| `cache-config` | object  | -       | Global cache behavior settings (see [Response Caching](Response-Caching)) |
 
-# Mapping Configuration
+## Mapping Configuration
 
-The `mappings` section defines how UNCORS routes and handles requests. Each mapping entry specifies a source and destination host pair along with optional processing rules:
+The `mappings` section defines how UNCORS routes and handles requests. Each entry specifies a source and destination host pair along with optional processing rules:
 
 ```yaml
 mappings:
@@ -133,7 +149,7 @@ mappings:
     scripts: [...]
 ```
 
-This configuration forwards all requests from `http://localhost:8080` to `https://github.com`. The port is specified in the `from` URL and defaults to 80 for HTTP and 443 for HTTPS if omitted. Additional features like mocking, static file serving, and scripting can be configured per mapping. See [Response Mocking](./Response-Mocking), [Static File Serving](./Static-File-Serving), and [Script Handler](./Script-Handler) for details.
+This configuration forwards all requests from `http://localhost:8080` to `https://github.com`. The port is specified in the `from` URL and defaults to 80 for HTTP and 443 for HTTPS if omitted. Additional features like mocking, static file serving, and scripting can be configured per mapping. See [Response Mocking](Response-Mocking), [Static File Serving](Static-File-Serving), and [Script Handler](Script-Handler) for details.
 
 ### OPTIONS Request Handling
 
@@ -167,7 +183,7 @@ mappings:
 > [!NOTE]
 > UNCORS adds standard CORS headers to all responses. Custom headers specified here will override the defaults.
 
-## Protocol Scheme Mapping
+### Protocol Scheme Mapping
 
 UNCORS supports flexible protocol scheme mapping, allowing requests to be redirected between HTTP and HTTPS or to preserve the original scheme.
 
@@ -179,7 +195,7 @@ mappings:
     to: https://site.com
 ```
 
-or
+**HTTPS to HTTP mapping:**
 
 ```yaml
 mappings:
@@ -210,7 +226,7 @@ mappings:
 > [!NOTE]
 > HTTPS mappings require valid SSL/TLS certificates. See [HTTPS Configuration](#https-configuration) for setup instructions.
 
-## Named Placeholder Mapping
+### Named Placeholder Mapping
 
 UNCORS supports named placeholders in host mappings for flexible domain matching. A placeholder is written as `{name}` and matches any sequence of characters in that hostname segment (excluding `.` and `/`). Using explicit names makes multi-placeholder mappings self-documenting and allows each placeholder to be referenced by name in the target URL.
 
@@ -258,16 +274,16 @@ mappings:
 
 Each placeholder is matched and substituted **by name**, so the order in source and target can differ:
 
-| Local request                             | Target request                        |
-| ----------------------------------------- | ------------------------------------- |
-| `http://prod.auth.local.com`              | `https://auth.prod.api.com`           |
-| `http://prod.auth.local.com/login`        | `https://auth.prod.api.com/login`     |
-| `http://staging.users.local.com`          | `https://users.staging.api.com`       |
+| Local request                      | Target request                    |
+| ---------------------------------- | --------------------------------- |
+| `http://prod.auth.local.com`       | `https://auth.prod.api.com`       |
+| `http://prod.auth.local.com/login` | `https://auth.prod.api.com/login` |
+| `http://staging.users.local.com`   | `https://users.staging.api.com`   |
 
 > [!NOTE]
 > Every placeholder name in a `from` URL must be unique. Using the same name twice (e.g., `{client}.{client}.com`) is a configuration error.
 
-## Simplified Syntax
+### Simplified Syntax
 
 For basic mappings without mocking or static file serving, use the shorthand syntax:
 
@@ -290,13 +306,13 @@ mappings:
 ```
 
 > [!WARNING]
-> Domain mappings only work for hosts defined in your system's hosts file. A placeholder mapping like `http://{name}.local.com` will not intercept all internet traffic—only requests to domains explicitly configured in your hosts file.
+> Domain mappings only work for hosts defined in your system's hosts file. A placeholder mapping like `http://{name}.local.com` will not intercept all internet traffic - only requests to domains explicitly configured in your hosts file.
 
-# HAR Recording
+## HAR Recording
 
 UNCORS can record all proxied traffic to an [HTTP Archive (HAR 1.2)](https://w3c.github.io/web-performance/specs/HAR/Overview.html) file per mapping. The file can be opened in browser DevTools, Postman, or any HAR viewer.
 
-**Shorthand** — pass the output file path as a string:
+**Shorthand** - pass the output file path as a string:
 
 ```yaml
 mappings:
@@ -305,7 +321,7 @@ mappings:
     har: ./recordings/api.har
 ```
 
-**Full form** — use an object for additional control:
+**Full form** - use an object for additional control:
 
 ```yaml
 mappings:
@@ -318,19 +334,19 @@ mappings:
 
 | Property                 | Type    | Default | Description                                                   |
 | ------------------------ | ------- | ------- | ------------------------------------------------------------- |
-| `file`                   | string  | —       | Output `.har` file path. Collector is disabled when empty.    |
-| `capture-secure-headers` | boolean | `false` | Include auth/cookie headers in the recording (see [HAR Collector](./HAR-Collector#secure-headers)). |
+| `file`                   | string  | -       | Output `.har` file path. Collector is disabled when empty.    |
+| `capture-secure-headers` | boolean | `false` | Include auth/cookie headers in the recording (see [HAR Collector](HAR-Collector#secure-headers)). |
 
 > [!WARNING]
 > Enabling `capture-secure-headers` writes tokens and cookies to disk in plain text. Never commit such files to version control.
 
-See [HAR Collector](./HAR-Collector) for the full reference.
+See [HAR Collector](HAR-Collector) for the full reference.
 
-# HTTPS Configuration
+## HTTPS Configuration
 
 UNCORS supports HTTPS for both incoming requests and upstream connections using auto-generated certificates.
 
-## Auto-Generated Certificates
+### Auto-Generated Certificates
 
 UNCORS automatically generates and signs TLS certificates on-the-fly using a local Certificate Authority (CA).
 
@@ -375,11 +391,11 @@ mappings:
 > [!NOTE]
 > HTTPS server functionality is only activated when at least one mapping uses the `https://` scheme. Each mapping specifies its own port in the `from` URL.
 
-# Proxy Configuration
+## Proxy Configuration
 
 UNCORS supports routing upstream requests through an HTTP/HTTPS proxy server.
 
-**Automatic proxy detection:**
+### Automatic Proxy Detection
 
 UNCORS automatically detects and uses system proxy settings from environment variables:
 
@@ -392,7 +408,7 @@ Environment variable values can be specified as:
 - Full URL: `http://proxy.example.com:8080`
 - Host and port: `proxy.example.com:8080` (assumes HTTP)
 
-**Explicit proxy configuration:**
+### Explicit Proxy Configuration
 
 Override system settings using CLI or configuration file:
 

--- a/docs/HAR-Collector.md
+++ b/docs/HAR-Collector.md
@@ -7,7 +7,7 @@ The HAR Collector records every request and response that passes through a mappi
 - Share exact request/response sequences as a single portable file
 - Audit what headers and payloads your frontend actually sends
 
-# Quick Start
+## Quick Start
 
 Add `har` to any mapping with the path to the output file:
 
@@ -20,11 +20,11 @@ mappings:
 
 UNCORS creates the file on the first request and keeps it updated atomically after each subsequent request.
 
-# Configuration
+## Configuration
 
-## Shorthand Syntax
+### Shorthand Syntax
 
-Pass a file path string directly — this is the most concise form:
+Pass a file path string directly - the most concise form:
 
 ```yaml
 mappings:
@@ -33,7 +33,7 @@ mappings:
     har: ./recordings/api.har
 ```
 
-## Full Syntax
+### Full Syntax
 
 Use the object form when you need extra control:
 
@@ -46,14 +46,14 @@ mappings:
       capture-secure-headers: false
 ```
 
-## Configuration Properties
+### Configuration Properties
 
 | Property                 | Type    | Default | Description                                                                     |
 | ------------------------ | ------- | ------- | ------------------------------------------------------------------------------- |
-| `file`                   | string  | —       | Path to the output `.har` file. Collector is disabled when this is empty.       |
+| `file`                   | string  | -       | Path to the output `.har` file. Collector is disabled when this is empty.       |
 | `capture-secure-headers` | boolean | `false` | Include security-sensitive headers (see [Secure Headers](#secure-headers)) in the HAR entry. |
 
-# Secure Headers
+## Secure Headers
 
 To prevent credentials from being written to disk, the following headers are **stripped from HAR entries by default**:
 
@@ -80,7 +80,7 @@ mappings:
 > [!WARNING]
 > HAR files with `capture-secure-headers: true` contain tokens, cookies, and other credentials in plain text. Do not commit them to version control or share them without scrubbing sensitive values first.
 
-# Per-Mapping Isolation
+## Per-Mapping Isolation
 
 Each mapping writes to its own independent HAR file. Traffic from different mappings never mixes:
 
@@ -95,29 +95,29 @@ mappings:
     har: ./recordings/auth.har       # captures auth.local traffic only
 ```
 
-# File Lifecycle
+## File Lifecycle
 
 - **Created** on the first captured request (parent directory must exist).
-- **Updated atomically** after every request — UNCORS writes to a temporary file then renames it, so the `.har` file is always in a valid, complete state even if you open it mid-session.
+- **Updated atomically** after every request - UNCORS writes to a temporary file then renames it, so the `.har` file is always in a valid, complete state even if you open it mid-session.
 - **Flushed and closed** on shutdown or when the configuration is reloaded. All buffered entries are written before the file handle is released.
 
 > [!NOTE]
-> If the internal write buffer (4 096 entries) fills up during a traffic spike, new entries are silently dropped rather than slowing down your requests. This is uncommon in normal development use.
+> If the internal write buffer (4,096 entries) fills up during a traffic spike, new entries are silently dropped rather than slowing down your requests. This is uncommon in normal development use.
 
-# Using Captured HAR Files
+## Viewing Captured HAR Files
 
 Open the generated file with any of these tools:
 
-| Tool | How |
-| ---- | --- |
-| **Chrome / Edge DevTools** | Network tab → Import HAR |
-| **Firefox DevTools** | Network tab → Import HAR |
-| **Postman** | File → Import → select `.har` |
-| **HAR Viewer** (online) | [google.github.io/har-viewer](https://google.github.io/har-viewer/) |
+| Tool                      | How                                                      |
+| ------------------------- | -------------------------------------------------------- |
+| **Chrome / Edge DevTools** | Network tab → Import HAR                                |
+| **Firefox DevTools**      | Network tab → Import HAR                                 |
+| **Postman**               | File → Import → select `.har`                            |
+| **HAR Viewer** (online)   | [google.github.io/har-viewer](https://google.github.io/har-viewer/) |
 
-# Examples
+## Examples
 
-## Record All API Traffic
+### Record All API Traffic
 
 ```yaml
 mappings:
@@ -126,7 +126,7 @@ mappings:
     har: ./recordings/session.har
 ```
 
-## Debug Authentication Flows
+### Debug Authentication Flows
 
 Capture auth headers to see exactly what the browser sends:
 
@@ -140,9 +140,9 @@ mappings:
 ```
 
 > [!WARNING]
-> Delete `auth-debug.har` when done — it contains your credentials in plain text.
+> Delete `auth-debug.har` when done - it contains your credentials in plain text.
 
-## Combine with Other Features
+### Combine with Other Features
 
 HAR recording works alongside mocking, caching, and static file serving:
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -11,7 +11,7 @@
 
 UNCORS is a powerful development tool designed to simplify HTTP/HTTPS proxying and CORS header management during local development. It provides a comprehensive suite of features including HTTPS support, wildcard host mapping, request/response mocking, static file serving, response caching, and full proxy functionality. UNCORS streamlines your development workflow by eliminating common CORS-related obstacles without requiring backend modifications.
 
-## Quick Start (5 minutes)
+## Quick Start
 
 Get UNCORS running in 5 minutes:
 
@@ -72,9 +72,9 @@ That's it! UNCORS is now proxying requests from `api.local` to GitHub's API.
 
 **Next steps:**
 
-- Read [Configuration](./Configuration) for more options
-- Explore [Response Mocking](./Response-Mocking) to add fake endpoints
-- Learn about [Static File Serving](./Static-File-Serving) for local development
+- Read [Configuration](Configuration) for more options
+- Explore [Response Mocking](Response-Mocking) to add fake endpoints
+- Learn about [Static File Serving](Static-File-Serving) for local development
 
 ## Key Terminology
 
@@ -98,30 +98,38 @@ Understanding these terms will help you navigate the documentation more effectiv
 
 ## Documentation
 
-- [Installation](./Installation)
-- [Configuration](./Configuration)
-- [Response mocking](./Response-Mocking)
-- [Static file serving](./Static-File-Serving)
-- [Response caching](./Response-Caching)
-- [Request rewriting](./Request-Rewriting)
-- [Migration guide](./Migration-Guide)
-- [HAR recording](./HAR-Collector)
-- [Script handler](./Script-Handler)
-- [Troubleshooting](./Troubleshooting)
-- [Real-world examples](./Real-World-Examples)
+### Getting Started
 
-## List of core features
+- [Installation](Installation) - package managers, binaries, Docker, and hosts file setup
+- [Configuration](Configuration) - CLI options, YAML reference, HTTPS, and proxy settings
+
+### Features
+
+- [Response Mocking](Response-Mocking) - intercept requests and return predefined responses
+- [Static File Serving](Static-File-Serving) - serve local files, SPA mode
+- [Response Caching](Response-Caching) - cache upstream responses with glob patterns
+- [Request Rewriting](Request-Rewriting) - rewrite paths and hosts before proxying
+- [Script Handler](Script-Handler) - dynamic responses via Lua scripting
+- [HAR Recording](HAR-Collector) - record traffic to HAR files for debugging
+
+### Reference
+
+- [Real-World Examples](Real-World-Examples) - copy-paste ready configurations for common scenarios
+- [Migration Guide](Migration-Guide) - upgrading between versions
+- [Troubleshooting](Troubleshooting) - diagnosing and resolving common issues
+
+## Core Features
 
 - CORS header replacement
-- [HTTPS support](./Configuration#https-configuration)
-- [Wildcard host mapping](./Configuration#wildcard-mapping)
-- [HTTP/HTTPS proxy support](./Configuration#proxy-configuration)
-- [Response mocking](./Response-Mocking)
-- [Script handler](./Script-Handler) (Lua scripting with JSON support)
-- [Static file serving](./Static-File-Serving)
-- [Response caching](./Response-Caching)
-- [Request rewriting](./Request-Rewriting)
-- [HAR traffic recording](./HAR-Collector)
+- [HTTPS support](Configuration#https-configuration)
+- [Wildcard host mapping](Configuration#named-placeholder-mapping)
+- [HTTP/HTTPS proxy support](Configuration#proxy-configuration)
+- [Response mocking](Response-Mocking)
+- [Script handler](Script-Handler) (Lua scripting with JSON support)
+- [Static file serving](Static-File-Serving)
+- [Response caching](Response-Caching)
+- [Request rewriting](Request-Rewriting)
+- [HAR traffic recording](HAR-Collector)
 
 ## Overview
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,47 +1,47 @@
 UNCORS provides multiple installation methods to suit different development environments and preferences. Choose the method that best fits your workflow.
 
-# Package Managers
+## Package Managers
 
-## Homebrew (macOS | Linux)
+### Homebrew (macOS | Linux)
 
-For macOS or Linux users with [Homebrew](https://brew.sh/) installed, UNCORS can be installed using the following command:
+For macOS or Linux users with [Homebrew](https://brew.sh/) installed:
 
 ```bash
 brew install evg4b/tap/uncors
 ```
 
-## Scoop (Windows)
+### Scoop (Windows)
 
-Windows users with [Scoop](https://scoop.sh/) can install UNCORS using these commands:
+Windows users with [Scoop](https://scoop.sh/):
 
 ```bash
 scoop bucket add evg4b https://github.com/evg4b/scoop-bucket.git
 scoop install evg4b/uncors
 ```
 
-## NPM (Cross-platform)
+### NPM (Cross-platform)
 
 UNCORS can be installed as a Node.js package using your preferred package manager:
 
-**Using npm:**
+**npm:**
 
 ```bash
 npm install uncors --save-dev
 ```
 
-**Using yarn:**
+**yarn:**
 
 ```bash
 yarn add uncors --dev
 ```
 
-**Using pnpm:**
+**pnpm:**
 
 ```bash
 pnpm add -D uncors
 ```
 
-## Docker (Cross-platform)
+### Docker (Cross-platform)
 
 Docker images are available on [Docker Hub](https://hub.docker.com/r/evg4b/uncors):
 
@@ -49,17 +49,17 @@ Docker images are available on [Docker Hub](https://hub.docker.com/r/evg4b/uncor
 docker run -p 80:3000 evg4b/uncors --from 'http://local.github.com' --to 'https://github.com'
 ```
 
-# Binary Installation
+## Binary Installation
 
-## Stew (Cross-platform)
+### Stew (Cross-platform)
 
-For users of [Stew](https://github.com/marwanhawari/stew) package manager, install UNCORS with:
+For users of the [Stew](https://github.com/marwanhawari/stew) package manager:
 
 ```bash
 stew install evg4b/uncors
 ```
 
-## Direct Binary Download (Cross-platform)
+### Direct Binary Download (Cross-platform)
 
 Pre-compiled binaries are available for all major platforms on the [UNCORS releases page](https://github.com/evg4b/uncors/releases/latest).
 
@@ -71,12 +71,12 @@ Pre-compiled binaries are available for all major platforms on the [UNCORS relea
 
 **Recommended installation paths:**
 
-- **Linux/macOS:** `/usr/local/bin`
-- **Windows:** Add to a directory included in your system's PATH environment variable
+- **Linux|macOS:** `/usr/local/bin`
+- **Windows:** Add to a directory included in your system's `PATH` environment variable
 
 The binary is self-contained and can be executed from any location without additional dependencies.
 
-# Build from Source
+## Build from Source
 
 **Prerequisites:**
 
@@ -94,15 +94,13 @@ cd uncors
 go install -tags release
 ```
 
-# Post-Installation: Hosts File Setup
+## Post-Installation: Hosts File Setup
 
 UNCORS works by mapping local domains to remote servers. To use UNCORS effectively, you need to configure your system's hosts file to resolve custom domain names to localhost.
 
-## Understanding the Hosts File
+### Understanding the Hosts File
 
 The hosts file is a system file that maps hostnames to IP addresses. UNCORS listens on localhost and requires entries in your hosts file to route traffic through it.
-
-## Configuration Steps
 
 ### macOS and Linux
 
@@ -116,13 +114,9 @@ Or use your preferred editor:
 
 ```bash
 sudo vim /etc/hosts
-# or
-sudo vi /etc/hosts
 ```
 
 **2. Add your domain mappings:**
-
-Add lines mapping your custom domains to localhost (127.0.0.1):
 
 ```
 127.0.0.1 api.local
@@ -152,8 +146,7 @@ echo "127.0.0.1 api.local" | sudo tee -a /etc/hosts
 
 **1. Run Notepad as Administrator:**
 
-- Press `Win` key
-- Type "Notepad"
+- Press `Win` key, type "Notepad"
 - Right-click on "Notepad" and select "Run as administrator"
 
 **2. Open the hosts file:**
@@ -165,40 +158,31 @@ echo "127.0.0.1 api.local" | sudo tee -a /etc/hosts
 
 **3. Add your domain mappings:**
 
-Add lines at the end of the file:
-
 ```
 127.0.0.1 api.local
 127.0.0.1 app.local
 127.0.0.1 admin.local
 ```
 
-**4. Save the file:**
-
-- Click File → Save
-- If you get an access denied error, make sure you opened Notepad as Administrator
+**4. Save the file** (File → Save). If you get an access denied error, ensure Notepad is running as Administrator.
 
 **5. Verify the configuration:**
-
-Open Command Prompt and run:
 
 ```cmd
 ping api.local
 ```
 
-Should respond from 127.0.0.1
+Should respond from 127.0.0.1.
 
 ### Alternative: PowerShell (Windows)
 
-Run PowerShell as Administrator and execute:
+Run PowerShell as Administrator:
 
 ```powershell
 Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "`n127.0.0.1 api.local"
 ```
 
-## Common Domain Patterns
-
-Here are common domain naming patterns for different use cases:
+### Common Domain Patterns
 
 ```
 # API development
@@ -215,7 +199,6 @@ Here are common domain naming patterns for different use cases:
 127.0.0.1 users.local
 127.0.0.1 payments.local
 
-# Wildcard support (requires DNS server)
 # Note: Hosts file does NOT support wildcards
 # Each subdomain must be listed explicitly
 127.0.0.1 sub1.local.com
@@ -223,62 +206,51 @@ Here are common domain naming patterns for different use cases:
 ```
 
 > [!WARNING]
-> The hosts file does not support wildcard entries like `*.local.com`. Each subdomain must be listed individually. However, UNCORS configuration supports wildcard mappings (e.g., `http://*.local.com:8080` → `https://*.example.com`) for domains explicitly listed in your hosts file.
+> The hosts file does not support wildcard entries like `*.local.com`. Each subdomain must be listed individually. However, UNCORS configuration supports named placeholder mappings (e.g., `http://{name}.local.com:8080` → `https://{name}.example.com`) for domains explicitly listed in your hosts file.
 
-## Troubleshooting
+### Troubleshooting Hosts File Changes
 
-### Changes not taking effect
-
-**macOS/Linux:**
+**Changes not taking effect - flush DNS cache:**
 
 ```bash
-# Flush DNS cache
-sudo dscacheutil -flushcache  # macOS
-sudo systemctl restart systemd-resolved  # Linux (systemd)
+# macOS
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+
+# Linux (systemd)
+sudo systemctl restart systemd-resolved
 ```
 
-**Windows:**
-
 ```cmd
+# Windows
 ipconfig /flushdns
 ```
 
-### Permission denied
+**Permission denied:** Ensure you are running your editor with administrator/root privileges.
 
-- Ensure you're running your editor with administrator/root privileges
-- On Unix systems, use `sudo`
-- On Windows, right-click and "Run as administrator"
+**Ping fails or wrong IP:** Check for typos, duplicate entries, extra whitespace, and confirm you are using `127.0.0.1`.
 
-### Ping fails or wrong IP
+**Browser not resolving domain:**
 
-- Check for typos in the hosts file
-- Ensure there are no duplicate entries
-- Verify no extra spaces or tabs
-- Make sure you're using 127.0.0.1 (not 127.0.0.0 or other addresses)
+- Chrome: Visit `chrome://net-internals/#dns` and click "Clear host cache"
+- Firefox: Restart the browser
+- Safari: Close all windows and restart
 
-### Browser not resolving domain
-
-- Clear your browser's DNS cache:
-  - Chrome: Visit `chrome://net-internals/#dns` and click "Clear host cache"
-  - Firefox: Restart the browser
-  - Safari: Close all windows and restart
-
-## Security Considerations
+### Security Considerations
 
 > [!CAUTION]
-> Modifying the hosts file can affect your system's network behavior. Only add entries for domains you control or are using for local development. Never add entries for production domains you don't own, as this could interfere with legitimate services.
+> Modifying the hosts file can affect your system's network behavior. Only add entries for domains you control or are using for local development. Never add entries for production domains you don't own.
 
 **Best practices:**
 
 1. Use `.local` or `.dev` TLDs for development
 2. Document your hosts file changes
-3. Remove entries when you're done with a project
+3. Remove entries when a project is finished
 4. Never commit hosts file changes to version control
 
 ## Next Steps
 
 Once your hosts file is configured:
 
-1. Create an UNCORS configuration file (see [Configuration](./Configuration))
+1. Create an UNCORS configuration file (see [Configuration](Configuration))
 2. Start UNCORS: `uncors --config .uncors.yaml`
 3. Access your mapped domains through your browser or API client

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -1,6 +1,19 @@
-This guide helps you migrate your UNCORS configuration files to the latest version. Breaking changes are documented here with examples showing how to update your configuration.
+This guide helps you migrate your UNCORS configuration files when upgrading between versions. Breaking changes are documented with before/after examples.
+
+## Table of Contents
+
+- [Version 0.5.x to 0.6.x](#version-05x-to-06x)
+  - [TLS Certificate Configuration Changes](#tls-certificate-configuration-changes)
+  - [Port Configuration Changes](#port-configuration-changes)
+  - [Fake Response Feature Removal](#fake-response-feature-removal)
+- [Version 0.4.x to 0.5.x](#version-04x-to-05x)
+- [Older Versions](#older-versions)
+
+---
 
 ## Version 0.5.x to 0.6.x
+
+This is a major version with several breaking changes. Review all three sections before upgrading.
 
 ### TLS Certificate Configuration Changes
 
@@ -8,9 +21,9 @@ This guide helps you migrate your UNCORS configuration files to the latest versi
 
 #### Why This Change?
 
-The previous architecture required all HTTPS mappings to share the same certificate. The new approach uses auto-generated certificates with a local CA, providing greater flexibility and simpler configuration.
+The previous architecture required all HTTPS mappings to share the same certificate. The new approach uses auto-generated certificates with a local CA, providing greater flexibility, SNI support, and simpler configuration.
 
-#### TLS Configuration Migration Steps
+#### Migration Steps
 
 **Old Configuration (v0.5.x and earlier):**
 
@@ -34,26 +47,28 @@ mappings:
     to: https://admin.example.com
 ```
 
-Before using HTTPS mappings, you need to create a local CA:
+Before using HTTPS mappings, generate a local CA once:
 
 ```bash
 uncors generate-certs
 ```
 
-This will create a CA certificate in `~/.config/uncors/ca.crt`. Add this certificate to your system's trusted certificates to avoid browser warnings.
+This creates `~/.config/uncors/ca.crt`. Add this certificate to your system's trusted certificates to avoid browser warnings.
 
 **Key Changes:**
 
-1. **Remove** the global `cert-file` and `key-file` properties from root level
-2. **Generate** a local CA using `uncors generate-certs`
+1. **Remove** the global `cert-file` and `key-file` properties
+2. **Run** `uncors generate-certs` to create a local CA
 3. **Trust** the CA certificate in your system's certificate store
 
 #### Benefits of Auto-Generated Certificates
 
 - Automatic certificate generation for any host
 - No need to manage certificate files
-- Better security through automatic certificate management
-- Support for SNI (Server Name Indication) for multiple hosts on the same port
+- SNI (Server Name Indication) support - multiple hosts on the same port
+- Certificates cached in memory, regenerated only when needed
+
+---
 
 ### Port Configuration Changes
 
@@ -61,9 +76,9 @@ This will create a CA certificate in `~/.config/uncors/ca.crt`. Add this certifi
 
 #### Why This Change?
 
-The previous architecture required all HTTP mappings to share the same port and all HTTPS mappings to share the same port. The new per-mapping port configuration allows each mapping to listen on its own port, providing greater flexibility for complex development setups.
+The previous architecture required all HTTP mappings to share the same port and all HTTPS mappings to share the same port. The new per-mapping port configuration allows each mapping to listen on its own port.
 
-#### Port Configuration Migration Steps
+#### Migration Steps
 
 **Old Configuration (v0.5.x and earlier):**
 
@@ -90,10 +105,10 @@ mappings:
 **Key Changes:**
 
 1. **Remove** the global `http-port` and `https-port` properties
-2. **Add** the port number directly to the `from` URL using the format `protocol://host:port`
-3. If no port is specified, defaults are used (80 for HTTP, 443 for HTTPS)
+2. **Add** the port number directly to the `from` URL: `protocol://host:port`
+3. Ports default to 80 for HTTP and 443 for HTTPS when omitted
 
-#### Multiple Ports Support
+#### Multiple Ports Example
 
 The new architecture enables each mapping to use a different port:
 
@@ -107,27 +122,9 @@ mappings:
     to: https://backend.example.com
 ```
 
-This configuration starts three separate servers:
-
-- HTTP server on port 3000 for `api.local`
-- HTTP server on port 4000 for `admin.local`
-- HTTPS server on port 8443 for `secure.local`
-
-#### Using Default Ports
-
-If you want to use the default ports (80 for HTTP, 443 for HTTPS), you can omit the port number:
-
-```yaml
-mappings:
-  - from: http://localhost
-    to: https://api.example.com
-  - from: https://secure-app
-    to: https://backend.example.com
-```
-
 #### Short Syntax Migration
 
-**Old Configuration:**
+**Old:**
 
 ```yaml
 http-port: 8080
@@ -135,7 +132,7 @@ mappings:
   - http://localhost: https://github.com
 ```
 
-**New Configuration:**
+**New:**
 
 ```yaml
 mappings:
@@ -144,13 +141,13 @@ mappings:
 
 #### Command-Line Arguments Migration
 
-**Old CLI Usage:**
+**Old:**
 
 ```bash
 uncors --http-port 8080 --from http://localhost --to https://api.example.com
 ```
 
-**New CLI Usage:**
+**New:**
 
 ```bash
 uncors --from http://localhost:8080 --to https://api.example.com
@@ -158,7 +155,7 @@ uncors --from http://localhost:8080 --to https://api.example.com
 
 #### Wildcard Mapping Migration
 
-**Old Configuration:**
+**Old:**
 
 ```yaml
 http-port: 8080
@@ -167,7 +164,7 @@ mappings:
     to: https://*.example.com
 ```
 
-**New Configuration:**
+**New:**
 
 ```yaml
 mappings:
@@ -175,13 +172,15 @@ mappings:
     to: https://*.example.com
 ```
 
+---
+
 ### Fake Response Feature Removal
 
 **Breaking Change:** The `fake` field for generating mock responses with fake data has been removed. Use Lua script handlers instead for dynamic response generation.
 
 #### Why This Change?
 
-The Lua script handler provides a more flexible and powerful way to generate dynamic responses, including fake data. It allows for complex logic, external command execution, and better maintainability.
+The Lua script handler provides a more flexible and powerful way to generate dynamic responses. It allows for complex logic, external command execution, and better maintainability.
 
 #### Migration Steps
 
@@ -226,12 +225,10 @@ mappings:
 **Key Changes:**
 
 1. **Remove** the `mocks` section with `fake` and `seed` properties
-2. **Add** a `scripts` section with Lua script handler
-3. **Use** the [fakedata](https://github.com/lucapette/fakedata) command-line tool to generate fake data or any other CLI tool of your choice
+2. **Add** a `scripts` section with a Lua script handler
+3. **Use** the [fakedata](https://github.com/lucapette/fakedata) CLI tool or any other tool of your choice
 
-#### Installing fakedata CLI Tool
-
-To use the fakedata tool for generating fake data:
+#### Installing fakedata
 
 **macOS:**
 
@@ -245,15 +242,9 @@ brew install lucapette/tap/fakedata
 go install github.com/lucapette/fakedata@latest
 ```
 
-**Usage Example:**
-
-```bash
-fakedata --format=ndjson --limit 1 login=email username=username
-```
-
 #### Example: Array of Objects
 
-**Old Configuration:**
+**Old:**
 
 ```yaml
 response:
@@ -270,7 +261,7 @@ response:
     count: 5
 ```
 
-**New Configuration:**
+**New:**
 
 ```yaml
 scripts:
@@ -292,20 +283,22 @@ scripts:
       response:WriteString(result)
 ```
 
-#### Advantages of Script Handler Approach
+#### Advantages of the Script Handler Approach
 
-- **More Flexible**: Execute any command-line tool, not just fake data generation
-- **Better Control**: Use Lua logic for complex data transformations
-- **Reproducible**: Use environment variables or files to control seed values
-- **External Tools**: Leverage existing CLI tools like `fakedata`, `faker-cli`, or custom scripts
-- **Full Programming Language**: Access to Lua's full capabilities for complex scenarios
+- **More flexible**: Execute any command-line tool, not just fake data generation
+- **Better control**: Use Lua logic for complex data transformations
+- **External tools**: Leverage `fakedata`, `faker-cli`, or custom scripts
+- **Full language**: Access to Lua's complete capabilities for complex scenarios
 
-For more information about the Script Handler feature, see the [Script Handler documentation](./Script-Handler).
+For more information, see the [Script Handler documentation](Script-Handler).
+
+---
 
 ## Need Help?
 
-If you encounter issues during migration or have questions:
+If you encounter issues during migration:
 
-1. Check the [Configuration](./Configuration) documentation for detailed information about the new configuration format
+1. Check the [Configuration](Configuration) documentation for the current format
 2. Review the [JSON Schema](https://raw.githubusercontent.com/evg4b/uncors/main/schema.json) for configuration validation
-3. Report issues at [GitHub Issues](https://github.com/evg4b/uncors/issues)
+3. Enable debug mode: `uncors --config .uncors.yaml --debug`
+4. Report issues at [GitHub Issues](https://github.com/evg4b/uncors/issues)

--- a/docs/Real-World-Examples.md
+++ b/docs/Real-World-Examples.md
@@ -4,8 +4,6 @@ This guide provides practical, copy-paste ready examples for common UNCORS use c
 
 **Scenario:** You're developing a React/Vue/Angular app locally that needs to connect to a remote API, but CORS blocks requests.
 
-**Setup:**
-
 **1. Hosts file (`/etc/hosts` or `C:\Windows\System32\drivers\etc\hosts`):**
 
 ```
@@ -53,9 +51,7 @@ fetch("http://app.local:3000/api/users")
 
 ## Microservices Development
 
-**Scenario:** You're working on a microservices architecture with multiple services, and you want to route different paths to different services locally.
-
-**Setup:**
+**Scenario:** You're working on a microservices architecture and want to route different paths to different services locally.
 
 **Hosts file:**
 
@@ -104,6 +100,12 @@ curl http://gateway.local:8000/payments/process
 ## API Mocking for Testing
 
 **Scenario:** You need to test frontend behavior with different API responses without affecting the real backend.
+
+**Hosts file:**
+
+```
+127.0.0.1 api.test
+```
 
 **Configuration:**
 
@@ -172,12 +174,6 @@ mappings:
             }
 ```
 
-**Hosts file:**
-
-```
-127.0.0.1 api.test
-```
-
 **Test scenarios:**
 
 ```bash
@@ -199,6 +195,12 @@ curl "http://api.test:3000/api/posts?page=1"
 ## Local Development with Production APIs
 
 **Scenario:** You want to use production APIs but override specific endpoints with local data for testing.
+
+**Hosts file:**
+
+```
+127.0.0.1 dev.local
+```
 
 **Configuration:**
 
@@ -236,12 +238,6 @@ mappings:
         dir: ~/projects/my-app/local-assets
 ```
 
-**Hosts file:**
-
-```
-127.0.0.1 dev.local
-```
-
 **Usage:**
 
 ```bash
@@ -261,6 +257,12 @@ curl http://dev.local:4000/assets/logo.png
 
 **Scenario:** You're building a Single-Page Application and need both local file serving and API proxying.
 
+**Hosts file:**
+
+```
+127.0.0.1 app.local
+```
+
 **Configuration:**
 
 ```yaml
@@ -272,9 +274,9 @@ mappings:
     statics:
       - path: /
         dir: ~/projects/spa/dist
-        index: index.html # Fallback for client-side routing
+        index: index.html   # Fallback for client-side routing
 
-    # Proxy API requests to backend
+    # Mock health endpoint
     mocks:
       - path: /api/health
         method: GET
@@ -284,16 +286,10 @@ mappings:
             Content-Type: application/json
           raw: '{"status": "ok"}'
 
-    # Cache API responses
+    # Cache static API responses
     cache:
       - /api/config
       - /api/static-data/**
-```
-
-**Hosts file:**
-
-```
-127.0.0.1 app.local
 ```
 
 **Build and run:**
@@ -309,7 +305,7 @@ uncors --config .uncors.yaml
 open http://app.local:3000
 ```
 
-**How it works:**
+**Request routing:**
 
 - `http://app.local:3000/` → Serves `dist/index.html`
 - `http://app.local:3000/dashboard` → Serves `dist/index.html` (SPA routing)
@@ -323,10 +319,16 @@ open http://app.local:3000
 
 **Scenario:** You need to switch between dev, staging, and production APIs easily.
 
-**Configuration:**
+**Hosts file:**
+
+```
+127.0.0.1 api.local
+```
+
+**Configuration files:**
 
 ```yaml
-# .uncors.dev.yaml (Development)
+# .uncors.dev.yaml
 mappings:
   - from: http://api.local:3000
     to: https://api.dev.example.com
@@ -335,15 +337,19 @@ mappings:
         response:
           code: 200
           raw: '{"env": "development"}'
+```
 
-# .uncors.staging.yaml (Staging)
+```yaml
+# .uncors.staging.yaml
 mappings:
   - from: http://api.local:3000
     to: https://api.staging.example.com
     cache:
-      - /api/**  # Cache more aggressively in staging
+      - /api/**
+```
 
-# .uncors.prod.yaml (Production-like)
+```yaml
+# .uncors.prod.yaml
 mappings:
   - from: http://api.local:3000
     to: https://api.example.com
@@ -352,23 +358,12 @@ mappings:
       - /api/metadata/**
 ```
 
-**Hosts file:**
-
-```
-127.0.0.1 api.local
-```
-
 **Usage:**
 
 ```bash
-# Development
-uncors --config .uncors.dev.yaml
-
-# Staging
-uncors --config .uncors.staging.yaml
-
-# Production-like
-uncors --config .uncors.prod.yaml
+uncors --config .uncors.dev.yaml      # Development
+uncors --config .uncors.staging.yaml  # Staging
+uncors --config .uncors.prod.yaml     # Production-like
 ```
 
 **Shell aliases (optional):**
@@ -385,6 +380,12 @@ alias uncors-prod='uncors --config .uncors.prod.yaml'
 ## GraphQL API Development
 
 **Scenario:** You're developing a GraphQL client and need to mock GraphQL responses.
+
+**Hosts file:**
+
+```
+127.0.0.1 graphql.local
+```
 
 **Configuration:**
 
@@ -435,12 +436,6 @@ mappings:
           end
 ```
 
-**Hosts file:**
-
-```
-127.0.0.1 graphql.local
-```
-
 **Usage:**
 
 ```bash
@@ -461,18 +456,18 @@ curl -X POST http://graphql.local:4000/graphql \
 
 **Scenario:** You need to proxy WebSocket connections during development.
 
+**Hosts file:**
+
+```
+127.0.0.1 ws.local
+```
+
 **Configuration:**
 
 ```yaml
 mappings:
   - from: http://ws.local:8080
     to: https://websocket.production.com
-```
-
-**Hosts file:**
-
-```
-127.0.0.1 ws.local
 ```
 
 **Client code:**
@@ -491,7 +486,7 @@ ws.onmessage = (event) => {
 ```
 
 > [!NOTE]
-> UNCORS transparently proxies WebSocket upgrade requests. No special configuration needed beyond the standard HTTP mapping.
+> UNCORS transparently proxies WebSocket upgrade requests. No special configuration is needed beyond the standard HTTP mapping.
 
 ---
 
@@ -517,12 +512,12 @@ mappings:
     to: https://api.staging.company.com
 
     mocks:
-      # Mock slow endpoints for better DX
+      # Mock slow endpoints for better developer experience
       - path: /api/reports/generate
         method: POST
         response:
           code: 202
-          delay: 100ms # Instant instead of 30s
+          delay: 100ms
           headers:
             Content-Type: application/json
           raw: '{"job_id": "mock-job-123", "status": "processing"}'
@@ -568,19 +563,19 @@ cd my-project
 
 ---
 
-## Best Practices from Examples
+## Best Practices
 
-1. **Use descriptive domain names:** `app.local`, `api.local`, not `test1.local`
-2. **Document hosts file entries:** Keep a README with required entries
-3. **Version control configuration:** Commit `.uncors.yaml` to git
-4. **Environment-specific configs:** Use separate files for dev/staging/prod
-5. **Mock slow endpoints:** Improve developer experience with instant responses
-6. **Cache static data:** Reduce upstream load and improve speed
-7. **Use scripts for complex logic:** Keep configuration files simple
+1. **Use descriptive domain names** - `app.local`, `api.local`, not `test1.local`
+2. **Document hosts file entries** - keep a README with required entries
+3. **Version control configuration** - commit `.uncors.yaml` to git
+4. **Environment-specific configs** - use separate files for dev/staging/prod
+5. **Mock slow endpoints** - improve developer experience with instant responses
+6. **Cache static data** - reduce upstream load and improve speed
+7. **Use scripts for complex logic** - keep configuration files simple
 
 ---
 
-## Templates
+## Configuration Templates
 
 ### Basic Proxy
 
@@ -623,7 +618,6 @@ mappings:
 debug: false
 cache-config:
   expiration-time: 10m
-  clear-time: 1h
 
 mappings:
   - from: http://[YOUR-DOMAIN]:3000
@@ -654,7 +648,9 @@ mappings:
 
 For more details on any of these features, see:
 
-- [Configuration](./Configuration)
-- [Response Mocking](./Response-Mocking)
-- [Static File Serving](./Static-File-Serving)
-- [Script Handler](./Script-Handler)
+- [Configuration](Configuration)
+- [Response Mocking](Response-Mocking)
+- [Static File Serving](Static-File-Serving)
+- [Script Handler](Script-Handler)
+- [Request Rewriting](Request-Rewriting)
+- [Response Caching](Response-Caching)

--- a/docs/Request-Rewriting.md
+++ b/docs/Request-Rewriting.md
@@ -1,4 +1,4 @@
-Request rewriting allows you to transform request paths and hosts before they're forwarded to the upstream server. This is useful for:
+Request rewriting allows you to transform request paths and hosts before they are forwarded to the upstream server. This is useful for:
 
 - Adapting client URLs to match server API structure
 - Routing requests to different backend services
@@ -31,8 +31,6 @@ mappings:
 
 Capture parts of the URL using `{variable}` syntax and reference them in the target path:
 
-**Example:**
-
 ```yaml
 mappings:
   - from: http://localhost:3000
@@ -42,11 +40,7 @@ mappings:
         to: /api/v1/{resource}/list
 ```
 
-**How it works:**
-
-The `{resource}` placeholder captures part of the incoming path and inserts it into the rewritten path.
-
-**Request transformations:**
+The `{resource}` placeholder captures part of the incoming path and inserts it into the rewritten path:
 
 | Incoming Request | Rewritten Request       |
 | ---------------- | ----------------------- |
@@ -103,9 +97,11 @@ mappings:
 
 - `GET /auth/login` → `GET https://auth-service.example.com/v1/login`
 - `POST /payment/process` → `POST https://payment-service.example.com/v2/process`
-- `GET /users` → `GET https://primary-api.example.com/users` (no rewrite)
+- `GET /users` → `GET https://primary-api.example.com/users` (no rewrite applied)
 
 ### Combining Rewrites with Other Features
+
+Rewrites, mocks, and caching can be used together in a single mapping:
 
 ```yaml
 mappings:

--- a/docs/Response-Caching.md
+++ b/docs/Response-Caching.md
@@ -20,17 +20,17 @@ mappings:
       - /api/users/**
 ```
 
-# Pattern Syntax
+## Pattern Syntax
 
 Cache patterns use glob syntax to match URL paths. The following special characters are supported:
 
-| Special Terms | Meaning                                                                                                   |
+| Special Term  | Meaning                                                                                                   |
 | ------------- | --------------------------------------------------------------------------------------------------------- |
-| `*`           | matches any sequence of non-path-separators                                                               |
-| `/**/`        | matches zero or more directories                                                                          |
-| `?`           | matches any single non-path-separator character                                                           |
-| `[class]`     | matches any single non-path-separator character against a class of characters ([see "character classes"]) |
-| `{alt1,...}`  | matches a sequence of characters if one of the comma-separated alternatives matches                       |
+| `*`           | Matches any sequence of non-path-separators                                                               |
+| `/**/`        | Matches zero or more directories                                                                          |
+| `?`           | Matches any single non-path-separator character                                                           |
+| `[class]`     | Matches any single non-path-separator character against a class of characters (see [Character Classes](#character-classes)) |
+| `{alt1,...}`  | Matches a sequence of characters if one of the comma-separated alternatives matches                       |
 
 **Important notes:**
 
@@ -39,18 +39,18 @@ Cache patterns use glob syntax to match URL paths. The following special charact
 - Incorrect: `path/to/**.txt` (acts like `path/to/*.txt`)
 - Correct: `path/to/**/*.txt` (matches files in subdirectories)
 
-## Character Classes
+### Character Classes
 
 Character classes match single characters against a set or range:
 
 | Class      | Meaning                                                       |
 | ---------- | ------------------------------------------------------------- |
-| `[abc]`    | matches any single character within the set                   |
-| `[a-z]`    | matches any single character in the range                     |
-| `[^class]` | matches any single character which does _not_ match the class |
-| `[!class]` | same as `^`: negates the class                                |
+| `[abc]`    | Matches any single character within the set                   |
+| `[a-z]`    | Matches any single character in the range                     |
+| `[^class]` | Matches any single character which does _not_ match the class |
+| `[!class]` | Same as `^`: negates the class                                |
 
-# Global Cache Configuration
+## Global Cache Configuration
 
 Configure caching behavior globally using the `cache-config` section:
 
@@ -61,13 +61,13 @@ cache-config:
   max-size: 104857600
 ```
 
-## Configuration Properties
+### Configuration Properties
 
-| Property          | Type     | Default      | Description                                        |
-| ----------------- | -------- | ------------ | -------------------------------------------------- |
-| `methods`         | array    | `[GET]`      | HTTP methods to cache (e.g., `GET`, `POST`, `PUT`) |
-| `expiration-time` | duration | `30m`        | Time until a cached response is evicted            |
-| `max-size`        | integer  | `104857600`  | Maximum total cache size in bytes (default 100 MB) |
+| Property          | Type     | Default     | Description                                        |
+| ----------------- | -------- | ----------- | -------------------------------------------------- |
+| `methods`         | array    | `[GET]`     | HTTP methods to cache (e.g., `GET`, `POST`, `PUT`) |
+| `expiration-time` | duration | `30m`       | Time until a cached response is evicted            |
+| `max-size`        | integer  | `104857600` | Maximum total cache size in bytes (default 100 MB) |
 
 **Duration format:** `<number><unit>` where unit is `s` (seconds), `m` (minutes), or `h` (hours)
 
@@ -78,11 +78,11 @@ cache-config:
 - `2h` - 2 hours
 - `1h 30m` - 1 hour 30 minutes
 
-## Cache Lifecycle
+### Cache Lifecycle
 
-1. **Hit**: Response is returned immediately from cache
-2. **Miss**: Request is forwarded to the upstream server and the response is stored in cache
-3. **Evicted** (after `expiration-time` or when `max-size` is reached): Cache entry is removed; the next request fetches fresh data from upstream
+1. **Hit** - Response is returned immediately from cache
+2. **Miss** - Request is forwarded to the upstream server; response is stored in cache
+3. **Evicted** (after `expiration-time` or when `max-size` is reached) - Cache entry is removed; next request fetches fresh data from upstream
 
 ## Examples
 
@@ -103,7 +103,7 @@ cache-config:
   max-size: 52428800
 ```
 
-### Cache Multiple Methods
+### Cache Multiple HTTP Methods
 
 ```yaml
 cache-config:

--- a/docs/Response-Mocking.md
+++ b/docs/Response-Mocking.md
@@ -2,11 +2,11 @@ The mocking system allows you to simulate API responses for specific endpoints d
 
 **Key features:**
 
-- **Path-based matching**: Define which URLs to intercept
-- **Method-specific**: Target specific HTTP methods (GET, POST, etc.)
-- **Query parameter filtering**: Match requests with specific query strings
-- **Header matching**: Filter by HTTP headers
-- **Configurable responses**: Control status codes, headers, delays, and content
+- **Path-based matching** - define which URLs to intercept
+- **Method-specific** - target specific HTTP methods (GET, POST, etc.)
+- **Query parameter filtering** - match requests with specific query strings
+- **Header matching** - filter by HTTP headers
+- **Configurable responses** - control status codes, headers, delays, and content
 
 **Configuration structure:**
 
@@ -27,15 +27,14 @@ mappings:
           headers:
             Content-Type: application/json
           delay: 10s
-          raw: `{ "ok": true }`
-          file: /path/to/file.json
+          raw: '{ "ok": true }'
 ```
 
-# Request Matching
+## Request Matching
 
-Configure which requests should be intercepted by the mock:
+Configure which requests should be intercepted by the mock.
 
-## Path (Required)
+### Path (Required)
 
 Defines the URL path to mock. Supports static paths and variable segments.
 
@@ -49,7 +48,7 @@ path: /posts/{postId}/comments/{commentId}  # Multiple variables
 
 Variable segments (e.g., `{id}`) match any value in that position. A request to `/users/123` matches `/users/{id}`.
 
-## Method (Optional)
+### Method (Optional)
 
 Specifies the HTTP method to match.
 
@@ -59,7 +58,7 @@ Specifies the HTTP method to match.
 
 If omitted, the mock matches all HTTP methods.
 
-## Query Parameters (Optional)
+### Query Parameters (Optional)
 
 Match requests with specific query string parameters.
 
@@ -71,7 +70,7 @@ queries:
 
 If omitted, all query parameter combinations are matched.
 
-## Headers (Optional)
+### Headers (Optional)
 
 Match requests with specific HTTP headers.
 
@@ -83,15 +82,15 @@ headers:
 
 If omitted, all header combinations are matched.
 
-# Response Configuration
+## Response Configuration
 
 Define the response returned when a mock is triggered.
 
-## Response Properties
+### Response Properties
 
 | Property  | Type    | Required      | Default | Description                                |
 | --------- | ------- | ------------- | ------- | ------------------------------------------ |
-| `code`    | integer | No            | 200     | HTTP status code (e.g., 200, 404, 500)     |
+| `code`    | integer | No            | `200`   | HTTP status code (e.g., 200, 404, 500)     |
 | `headers` | object  | No            | -       | Custom HTTP headers to include in response |
 | `delay`   | string  | No            | -       | Response delay (e.g., `1m 30s`, `500ms`)   |
 | `raw`     | string  | Conditional\* | -       | Raw response content                       |
@@ -99,14 +98,14 @@ Define the response returned when a mock is triggered.
 
 **\*One of `raw` or `file` must be specified.**
 
-## Status Code
+### Status Code
 
 ```yaml
 response:
   code: 201
 ```
 
-## Headers
+### Headers
 
 Add or override response headers:
 
@@ -117,18 +116,20 @@ response:
     X-Custom-Header: value
 ```
 
-## Delay
+### Delay
 
 Simulate network latency or slow endpoints. Format: `<number><unit> [<number><unit> ...]`
 
 **Supported units:**
 
-- `ns` - nanoseconds
-- `us` or `µs` - microseconds
-- `ms` - milliseconds
-- `s` - seconds
-- `m` - minutes
-- `h` - hours
+| Unit       | Meaning      |
+| ---------- | ------------ |
+| `ns`       | Nanoseconds  |
+| `us`/`µs`  | Microseconds |
+| `ms`       | Milliseconds |
+| `s`        | Seconds      |
+| `m`        | Minutes      |
+| `h`        | Hours        |
 
 **Examples:**
 
@@ -138,28 +139,24 @@ delay: 1m 30s         # 1 minute 30 seconds
 delay: 2s 500ms       # 2.5 seconds
 ```
 
-## Response Content
+### Response Content
 
 Choose one of two methods to provide response content:
 
-### Raw Content
-
-Inline text or JSON:
+**Raw content** - inline text or JSON:
 
 ```yaml
 response:
   raw: '{"message": "Success", "id": 123}'
 ```
 
-### File Content
-
-Load response from a file:
+**File content** - load response from a file:
 
 ```yaml
 response:
   file: ~/mocks/users-response.json
 ```
 
-## Script Handler
+## Dynamic Responses
 
-For dynamic responses including fake data generation, use the Script Handler feature (see [Script Handler documentation](./Script-Handler) for details).
+For dynamic responses including request-dependent data, use the Script Handler (see [Script Handler documentation](Script-Handler) for details).

--- a/docs/Script-Handler.md
+++ b/docs/Script-Handler.md
@@ -1,6 +1,20 @@
-The script handler allows you to implement custom request handling logic using scripts. This provides maximum flexibility for generating dynamic responses, implementing custom business logic, or creating complex API simulations during development and testing.
+The script handler allows you to implement custom request handling logic using Lua scripts. This provides maximum flexibility for generating dynamic responses, implementing custom business logic, or creating complex API simulations during development and testing.
 
-**Key features:**
+## Table of Contents
+
+- [Key Features](#key-features)
+- [Request Matching](#request-matching)
+- [Script Configuration](#script-configuration)
+- [Request Object](#request-object)
+- [Response Object](#response-object)
+- [Available Libraries](#available-libraries)
+- [Complete Examples](#complete-examples)
+- [CORS Headers](#cors-headers)
+- [Error Handling](#error-handling)
+- [Tips and Best Practices](#tips-and-best-practices)
+- [Comparison with Mock Handler](#comparison-with-mock-handler)
+
+## Key Features
 
 - **Inline or file-based scripts**: Define script code directly in configuration or load from external files
 - **Request access**: Full access to request properties (method, URL, headers, body, query parameters)
@@ -31,11 +45,11 @@ mappings:
         file: /path/to/script.lua # Alternative to inline script
 ```
 
-# Request Matching
+## Request Matching
 
 Configure which requests should be handled by the script:
 
-## Path (Required)
+### Path (Required)
 
 Defines the URL path to handle. Supports static paths and variable segments.
 
@@ -49,7 +63,7 @@ path: /posts/{postId}/data    # Multiple variables
 
 Variable segments (e.g., `{id}`) match any value in that position. A request to `/users/123` matches `/users/{id}`.
 
-## Method (Optional)
+### Method (Optional)
 
 Specifies the HTTP method to match.
 
@@ -59,7 +73,7 @@ Specifies the HTTP method to match.
 
 If omitted, the script matches all HTTP methods.
 
-## Query Parameters (Optional)
+### Query Parameters (Optional)
 
 Match requests with specific query string parameters.
 
@@ -71,7 +85,7 @@ queries:
 
 If omitted, all query parameter combinations are matched.
 
-## Headers (Optional)
+### Headers (Optional)
 
 Match requests with specific HTTP headers.
 
@@ -83,11 +97,11 @@ headers:
 
 If omitted, all header combinations are matched.
 
-# Script Configuration
+## Script Configuration
 
 Define the script to execute when a request is matched.
 
-## Script Properties
+### Script Properties
 
 | Property | Type   | Required      | Description                    |
 | -------- | ------ | ------------- | ------------------------------ |
@@ -96,7 +110,7 @@ Define the script to execute when a request is matched.
 
 **\*Either `script` or `file` must be specified, but not both.**
 
-## Inline Script
+### Inline Script
 
 Define script code directly in the configuration:
 
@@ -111,7 +125,7 @@ scripts:
       response:WriteString('{"message": "Hello, ' .. name .. '"}')
 ```
 
-## File-based Script
+### File-based Script
 
 Load script code from an external file:
 
@@ -137,11 +151,11 @@ response:WriteHeader(200)
 response:WriteString('{"result": ' .. result .. '}')
 ```
 
-# Request Object
+## Request Object
 
 The `request` object provides access to incoming HTTP request properties.
 
-## Request Properties
+### Request Properties
 
 | Property       | Type   | Description                                     | Example                             |
 | -------------- | ------ | ----------------------------------------------- | ----------------------------------- |
@@ -156,9 +170,9 @@ The `request` object provides access to incoming HTTP request properties.
 | `query_params` | table  | Parsed query parameters                         | `request.query_params["id"]`        |
 | `path_params`  | table  | Path parameters from route                      | `request.path_params["id"]`         |
 
-## Accessing Request Data
+### Accessing Request Data
 
-### HTTP Method
+#### HTTP Method
 
 ```lua
 if request.method == "GET" then
@@ -166,13 +180,13 @@ if request.method == "GET" then
 end
 ```
 
-### URL and Path
+#### URL and Path
 
 ```lua
 response:WriteString("You accessed: " .. request.path)
 ```
 
-### Headers
+#### Headers
 
 ```lua
 local contentType = request.headers["Content-Type"]
@@ -181,7 +195,7 @@ local userAgent = request.headers["User-Agent"]
 response:WriteString("Content-Type: " .. (contentType or "not set"))
 ```
 
-### Query Parameters
+#### Query Parameters
 
 ```lua
 local id = request.query_params["id"]
@@ -195,7 +209,7 @@ else
 end
 ```
 
-### Path Parameters
+#### Path Parameters
 
 Path parameters are extracted from the URL route pattern using wildcards (`{param}`). For example, if your route is `/users/{id}/posts/{postId}`, you can access these parameters:
 
@@ -225,7 +239,7 @@ scripts:
       response:WriteString('{"user": "' .. userId .. '", "post": "' .. postId .. '"}')
 ```
 
-### Request Body
+#### Request Body
 
 ```lua
 local body = request.body
@@ -241,7 +255,7 @@ else
 end
 ```
 
-### Host Information
+#### Host Information
 
 ```lua
 if request.host == "api.example.com" then
@@ -251,11 +265,11 @@ else
 end
 ```
 
-# Response Object
+## Response Object
 
 The `response` object controls the HTTP response returned to the client.
 
-## Response Properties
+### Response Properties
 
 | Property  | Type  | Access     | Description                                      |
 | --------- | ----- | ---------- | ------------------------------------------------ |
@@ -266,7 +280,7 @@ The `response` object controls the HTTP response returned to the client.
 - Use `response:WriteHeader(code)` to set status
 - Use `response:Write(data)` or `response:WriteString(str)` to write body
 
-## Response API
+### Response API
 
 The script handler provides a method-based API that mirrors Go's `http.ResponseWriter` interface:
 
@@ -287,7 +301,7 @@ response:WriteString('{"message": "Hello"}')
 - **Status & Body**: Method-based only (`response:WriteHeader()`, `response:Write()`, `response:WriteString()`)
 - **Cannot read**: `response.status` and `response.body` return `nil` if read
 
-### Internal Architecture
+#### Internal Architecture
 
 **ZERO BUFFERING - Direct Write to HTTP Connection:**
 
@@ -309,14 +323,14 @@ response:Write("data")    → writer.Write(...) → HTTP Connection
 response:WriteHeader(200) → writer.WriteHeader() → HTTP Headers Sent
 ```
 
-### Important Notes
+#### Important Notes
 
 ⚠️ **No direct assignment**: Cannot assign to `response.status` or `response.body` (silently ignored)
 ⚠️ **Cannot read**: `response.status` and `response.body` return `nil` if read
 ⚠️ **Order matters**: Call methods in correct HTTP order or behavior is undefined
 ⚠️ **Auto-header**: If you write body without calling `WriteHeader()`, status 200 is sent automatically
 
-## Go-style Methods
+### Go-style Methods
 
 | Method                       | Description                    | Example                                      |
 | ---------------------------- | ------------------------------ | -------------------------------------------- |
@@ -325,7 +339,7 @@ response:WriteHeader(200) → writer.WriteHeader() → HTTP Headers Sent
 | `response:WriteString(str)`  | Append string to response body | `response:WriteString("World")`              |
 | `response:Header()`          | Get headers object             | `response:Header():Set("X-Custom", "value")` |
 
-### Header Methods
+#### Header Methods
 
 The `response:Header()` method returns a headers object with these methods:
 
@@ -334,7 +348,7 @@ The `response:Header()` method returns a headers object with these methods:
 | `Set(key, value)` | Set a header value | `response:Header():Set("Content-Type", "application/json")` |
 | `Get(key)`        | Get a header value | `local ct = response:Header():Get("Content-Type")`          |
 
-### Go-style Examples
+#### Go-style Examples
 
 **Basic response:**
 
@@ -412,9 +426,9 @@ response:Header():Set("X-Custom", "value")  -- Headers already sent!
 response:WriteHeader(404)  -- Ignored! Header already sent
 ```
 
-## Setting Response Properties
+### Setting Response Properties
 
-### Status Code
+#### Status Code
 
 ```lua
 response:WriteHeader(201)  -- Created
@@ -422,7 +436,7 @@ response:WriteHeader(404)  -- Not Found
 response:WriteHeader(500)  -- Internal Server Error
 ```
 
-### Response Body
+#### Response Body
 
 ```lua
 -- Simple text
@@ -436,7 +450,7 @@ local name = "Alice"
 response:WriteString('{"name": "' .. name .. '"}')
 ```
 
-### Response Headers
+#### Response Headers
 
 ```lua
 -- Set Content-Type
@@ -450,7 +464,7 @@ response.headers["X-Request-ID"] = "12345"
 response.headers["Cache-Control"] = "no-cache"
 ```
 
-### Complete Example
+#### Complete Example
 
 ```lua
 local math = require("math")
@@ -471,11 +485,11 @@ response:WriteHeader(200)
 response:WriteString('{"random": ' .. random .. ', "min": ' .. min .. ', "max": ' .. max .. '}')
 ```
 
-# Available Libraries
+## Available Libraries
 
 The script handler provides access to standard libraries:
 
-## Math Library
+### Math Library
 
 Mathematical functions for calculations.
 
@@ -499,7 +513,7 @@ local pi = math.pi
 local huge = math.huge
 ```
 
-## String Library
+### String Library
 
 String manipulation and formatting.
 
@@ -524,7 +538,7 @@ local len = string.len("Hello")         -- 5
 local formatted = string.format("Value: %d", 42)
 ```
 
-## Table Library
+### Table Library
 
 Table (array/dictionary) operations.
 
@@ -543,7 +557,7 @@ local joined = table.concat(items, ", ") -- "banana, cherry, date"
 table.sort(items)
 ```
 
-## OS Library
+### OS Library
 
 Limited OS and time functions.
 
@@ -560,7 +574,7 @@ local components = os.date("*t")
 -- components.year, components.month, components.day, etc.
 ```
 
-## JSON Library
+### JSON Library
 
 JSON encoding and decoding for working with JSON data.
 
@@ -626,9 +640,9 @@ response:WriteHeader(200)
 response:WriteString(json.encode({received = result}))
 ```
 
-# Complete Examples
+## Complete Examples
 
-## Simple API Endpoint
+### Simple API Endpoint
 
 ```yaml
 scripts:
@@ -640,7 +654,7 @@ scripts:
       response:WriteString('{"status": "healthy", "timestamp": "' .. os.date("%Y-%m-%d %H:%M:%S") .. '"}')
 ```
 
-## Dynamic User API
+### Dynamic User API
 
 ```yaml
 scripts:
@@ -658,7 +672,7 @@ scripts:
       '}')
 ```
 
-## Calculator API
+### Calculator API
 
 ```yaml
 scripts:
@@ -692,7 +706,7 @@ scripts:
       end
 ```
 
-## Request Echo Service
+### Request Echo Service
 
 ```yaml
 scripts:
@@ -709,7 +723,7 @@ scripts:
       '}')
 ```
 
-## Conditional Response Based on Headers
+### Conditional Response Based on Headers
 
 ```yaml
 scripts:
@@ -730,7 +744,7 @@ scripts:
       end
 ```
 
-## JSON API with Request Body Processing
+### JSON API with Request Body Processing
 
 ```yaml
 scripts:
@@ -774,7 +788,7 @@ scripts:
       response:WriteString(json.encode(responseData))
 ```
 
-# CORS Headers
+## CORS Headers
 
 CORS headers are automatically added to all script responses. You can override them by setting custom header values in your script:
 
@@ -785,7 +799,7 @@ response.headers["Access-Control-Allow-Methods"] = "GET, POST"
 response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
 ```
 
-# Error Handling
+## Error Handling
 
 If your script encounters an error, the handler will return a 500 Internal Server Error response automatically. Common errors include:
 
@@ -819,7 +833,7 @@ if not success then
 end
 ```
 
-# Tips and Best Practices
+## Tips and Best Practices
 
 1. **Keep scripts simple**: scripts are executed for each request, so keep logic lightweight
 2. **Use file-based scripts for complex logic**: Easier to test and maintain
@@ -835,7 +849,7 @@ end
 12. **Streaming-ready**: Every write goes directly to network - perfect for streaming responses
 13. **Performance**: Zero buffering means minimal memory usage and immediate data transmission
 
-# Comparison with Mock Handler
+## Comparison with Mock Handler
 
 | Feature             | Script Handler                                | Mock Handler                         |
 | ------------------- | --------------------------------------------- | ------------------------------------ |

--- a/docs/Static-File-Serving.md
+++ b/docs/Static-File-Serving.md
@@ -27,21 +27,21 @@ mappings:
 | `dir`    | string | Yes      | Local directory path containing files to serve                  |
 | `index`  | string | No       | Fallback file when requested file not found (relative to `dir`) |
 
-**Behavior:**
+**Request handling behavior:**
 
 - Requests matching the `path` prefix are served from the local `dir`
-- If a file exists locally, it's served immediately
-- If a file doesn't exist and `index` is set, the index file is served (SPA mode)
-- If a file doesn't exist and `index` is not set, the request is forwarded upstream (proxy mode)
+- If a file exists locally, it is served immediately
+- If a file does not exist and `index` is set, the index file is served (SPA mode)
+- If a file does not exist and `index` is not set, the request is forwarded upstream (proxy mode)
 
-# SPA Mode
+## SPA Mode
 
 Single-Page Application (SPA) mode serves a fallback file for all unmatched requests. This is essential for client-side routing frameworks like React Router, Vue Router, or Angular Router.
 
 **How it works:**
 
 1. Requests matching the `path` prefix are checked against local files
-2. If a file exists (e.g., `/app/bundle.js`), it's served directly
+2. If a file exists (e.g., `/app/bundle.js`), it is served directly
 3. If no file exists (e.g., `/app/users/123`), the `index` file is returned
 4. The SPA's JavaScript router handles the URL and renders the appropriate view
 
@@ -59,19 +59,19 @@ mappings:
 
 **Use cases:**
 
-- Serving a built React/Vue/Angular application
+- Serving a built React, Vue, or Angular application
 - Local development with client-side routing
 - Testing production builds locally
 
-# Proxy Mode
+## Proxy Mode
 
 Proxy mode serves local files when they exist, but forwards unmatched requests to the upstream server or mock handlers.
 
 **How it works:**
 
 1. Requests matching the `path` prefix are checked against local files
-2. If a file exists locally, it's served from the `dir`
-3. If no file exists, the request passes to the next handler (mock or upstream server)
+2. If a file exists locally, it is served from `dir`
+3. If no file exists, the request passes to the next handler (mock or upstream)
 
 **Configuration:**
 
@@ -127,6 +127,6 @@ mappings:
 
 In this configuration:
 
-- SPA files are served from `/`
-- API health endpoint is mocked
-- Other `/api/*` requests are proxied to `https://api.example.com`
+- SPA files are served from the root path `/`
+- The `/api/health` endpoint is mocked
+- All other `/api/*` requests are proxied to `https://api.example.com`

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -10,29 +10,22 @@ Before diving into specific issues, verify these basics:
 - [ ] Your browser/client is not using a proxy that bypasses localhost
 - [ ] CORS errors are actually UNCORS-related (check browser console)
 
-## Common Issues
+---
 
-### Connection Refused or Cannot Connect
+## Connection Refused or Cannot Connect
 
 **Symptoms:**
 
 - Browser shows "Connection refused" or "Cannot connect"
 - `curl` returns "Failed to connect to [domain]"
 
-**Causes and Solutions:**
-
 **1. UNCORS is not running**
-
-Check if UNCORS is running:
 
 ```bash
 # Check for UNCORS process
 ps aux | grep uncors
-```
 
-Start UNCORS if not running:
-
-```bash
+# Start UNCORS if not running
 uncors --config .uncors.yaml
 ```
 
@@ -41,13 +34,10 @@ uncors --config .uncors.yaml
 Verify the port matches your configuration:
 
 ```yaml
-# Configuration file
 mappings:
-  - from: http://api.local:3000 # Port 3000
+  - from: http://api.local:3000  # Port 3000
     to: https://api.example.com
 ```
-
-Access URL must match:
 
 ```bash
 curl http://api.local:3000/  # Correct
@@ -66,33 +56,28 @@ cat /etc/hosts | grep api.local
 Get-Content C:\Windows\System32\drivers\etc\hosts | Select-String api.local
 ```
 
-Should show:
-
-```
-127.0.0.1 api.local
-```
-
-If missing, add it (see [Installation](./Installation#post-installation-hosts-file-setup)).
+Expected output: `127.0.0.1 api.local`. If missing, see [Installation → Hosts File Setup](Installation#post-installation-hosts-file-setup).
 
 **4. DNS cache not flushed**
 
-Flush DNS cache after modifying hosts file:
+After modifying the hosts file, flush the DNS cache:
 
 ```bash
 # macOS
-sudo dscacheutil -flushcache
-sudo killall -HUP mDNSResponder
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
 
 # Linux (systemd)
 sudo systemctl restart systemd-resolved
+```
 
+```cmd
 # Windows
 ipconfig /flushdns
 ```
 
 ---
 
-### HTTPS Certificate Errors
+## HTTPS Certificate Errors
 
 **Symptoms:**
 
@@ -100,29 +85,19 @@ ipconfig /flushdns
 - "SSL certificate problem" in curl
 - "Unable to verify the first certificate"
 
-**Causes and Solutions:**
-
 **1. CA certificate not generated**
-
-Generate the local CA certificate:
 
 ```bash
 uncors generate-certs
 ```
 
-This creates CA files in `~/.config/uncors/`:
-
-- `ca.crt` - CA certificate
-- `ca.key` - CA private key
+This creates `~/.config/uncors/ca.crt` and `~/.config/uncors/ca.key`.
 
 **2. CA certificate not trusted**
-
-Add the CA certificate to your system's trusted certificates:
 
 **macOS:**
 
 ```bash
-# Open Keychain Access
 open ~/.config/uncors/ca.crt
 # Set to "Always Trust" in Keychain Access
 ```
@@ -137,85 +112,67 @@ sudo update-ca-certificates
 **Windows:**
 
 ```powershell
-# Import via Certificate Manager
 certutil -addstore -user "Root" %USERPROFILE%\.config\uncors\ca.crt
 ```
 
 **3. Browser not using system certificates**
 
-Some browsers maintain their own certificate stores. For Firefox:
+Firefox maintains its own certificate store:
 
 1. Settings → Privacy & Security → Certificates → View Certificates
-2. Import `~/.config/uncors/ca.crt` under "Authorities" tab
+2. Import `~/.config/uncors/ca.crt` under the "Authorities" tab
 
 **4. CA certificate expired**
 
-Check CA certificate validity:
-
 ```bash
+# Check expiry
 openssl x509 -in ~/.config/uncors/ca.crt -noout -dates
-```
 
-If expired, regenerate:
-
-```bash
+# Regenerate if expired
 uncors generate-certs --force
 ```
 
-Then re-trust the new CA certificate.
+Then re-trust the new certificate.
 
-**5. Development bypass (not recommended)**
-
-For quick testing only:
-
-**curl:** Use `-k` flag to ignore certificate errors:
+**5. Development bypass (not recommended for regular use)**
 
 ```bash
+# curl: ignore certificate errors
 curl -k https://api.local:8443/
 ```
 
-**Browser:** Accept the certificate warning (not recommended for regular development)
-
 ---
 
-### CORS Errors Still Appearing
+## CORS Errors Still Appearing
 
 **Symptoms:**
 
 - Browser console shows CORS errors despite using UNCORS
-- "Access-Control-Allow-Origin" errors
-
-**Causes and Solutions:**
+- "Access-Control-Allow-Origin" header errors
 
 **1. Request not going through UNCORS**
 
-Verify request is routed through UNCORS:
-
-Check UNCORS logs (use `--debug` flag):
+Enable debug logging and verify requests appear in the output:
 
 ```bash
 uncors --config .uncors.yaml --debug
 ```
 
-You should see log entries for each request.
-
 **2. OPTIONS request being forwarded instead of handled**
 
-By default, UNCORS handles OPTIONS requests locally. If disabled, upstream server must handle them.
-
-Check your configuration:
+By default, UNCORS handles OPTIONS requests locally. If disabled, the upstream server must handle them:
 
 ```yaml
 mappings:
   - from: http://api.local:3000
     to: https://api.example.com
     options-handling:
-      disabled: false # Should be false (default)
+      disabled: false  # Must be false (default) for UNCORS to handle preflight
 ```
 
 **3. Custom headers overriding CORS headers**
 
-If you've set custom CORS headers in mocks or scripts, ensure they're correct:
+If you've set custom CORS headers in mocks or scripts, verify they're correct:
 
 ```yaml
 mocks:
@@ -223,22 +180,18 @@ mocks:
     response:
       code: 200
       headers:
-        Access-Control-Allow-Origin: "*" # Must include this
+        Access-Control-Allow-Origin: "*"
         Access-Control-Allow-Methods: "GET, POST, OPTIONS"
       raw: "test"
 ```
 
 **4. Browser cache contains old CORS responses**
 
-Clear browser cache and reload:
-
-- Chrome: Ctrl+Shift+Delete (Windows/Linux) or Cmd+Shift+Delete (macOS)
-- Firefox: Ctrl+Shift+Delete (Windows/Linux) or Cmd+Shift+Delete (macOS)
-- Or use incognito/private mode
+Clear browser cache (Chrome: `Ctrl+Shift+Delete`, macOS: `Cmd+Shift+Delete`) or use an incognito/private window.
 
 ---
 
-### Configuration File Not Loading
+## Configuration File Not Loading
 
 **Symptoms:**
 
@@ -246,18 +199,14 @@ Clear browser cache and reload:
 - "No mappings configured" error
 - Configuration changes not taking effect
 
-**Causes and Solutions:**
-
 **1. Wrong configuration file path**
-
-Verify file path is correct:
 
 ```bash
 ls -l .uncors.yaml  # Should exist
 uncors --config .uncors.yaml --debug
 ```
 
-Use absolute path if relative path fails:
+Use an absolute path if a relative path fails:
 
 ```bash
 uncors --config /absolute/path/to/.uncors.yaml
@@ -268,11 +217,7 @@ uncors --config /absolute/path/to/.uncors.yaml
 Validate YAML syntax:
 
 ```bash
-# Using Python
-python -c "import yaml; yaml.safe_load(open('.uncors.yaml'))"
-
-# Using Ruby
-ruby -ryaml -e "YAML.load_file('.uncors.yaml')"
+python3 -c "import yaml; yaml.safe_load(open('.uncors.yaml'))"
 ```
 
 Common YAML mistakes:
@@ -283,42 +228,30 @@ Common YAML mistakes:
 
 **3. Configuration not reloaded after changes**
 
-UNCORS doesn't auto-reload configuration. Restart after changes:
+UNCORS does not auto-reload configuration. Restart after changes:
 
 ```bash
-# Stop UNCORS (Ctrl+C)
-# Then restart
+# Stop UNCORS with Ctrl+C, then restart
 uncors --config .uncors.yaml
 ```
 
 ---
 
-### Mocks Not Working
+## Mocks Not Working
 
 **Symptoms:**
 
 - Mock responses not returned
-- Requests still going to upstream server
+- Requests still going to the upstream server
 
-**Causes and Solutions:**
-
-**1. Path doesn't match**
-
-Verify path matches exactly:
+**1. Path doesn't match exactly**
 
 ```yaml
 mocks:
-  - path: /api/users # Must match request path exactly
+  - path: /api/users   # Matches /api/users but NOT /api/users/
     response:
       code: 200
       raw: "mock response"
-```
-
-Test:
-
-```bash
-curl http://api.local:3000/api/users   # Matches
-curl http://api.local:3000/api/users/  # Doesn't match (trailing slash)
 ```
 
 Use path variables for flexibility:
@@ -331,32 +264,25 @@ mocks:
       raw: '{"id": "123"}'
 ```
 
-**2. HTTP method doesn't match**
+**2. HTTP method filter too restrictive**
 
-Specify method if needed:
+If you specify a method, only that method is matched:
 
 ```yaml
 mocks:
   - path: /api/users
-    method: POST # Only matches POST requests
-    response:
-      code: 201
-      raw: "created"
+    method: POST   # Only matches POST requests; GET requests pass through
 ```
 
 **3. Mock file not found**
-
-For file-based mocks:
 
 ```yaml
 mocks:
   - path: /api/data
     response:
       code: 200
-      file: ./mock-data.json # Verify this file exists
+      file: ./mock-data.json   # Verify this file exists
 ```
-
-Check file exists:
 
 ```bash
 ls -l ./mock-data.json
@@ -364,34 +290,30 @@ ls -l ./mock-data.json
 
 ---
 
-### Static Files Not Serving
+## Static Files Not Serving
 
 **Symptoms:**
 
 - 404 errors when accessing static files
 - Files not loaded from local directory
 
-**Causes and Solutions:**
-
 **1. Directory path incorrect**
-
-Verify directory exists:
 
 ```bash
 ls -la ~/project/dist
 ```
 
-Use absolute path in configuration:
+Use an absolute path in the configuration if needed:
 
 ```yaml
 statics:
   - path: /assets
-    dir: /absolute/path/to/assets # Use absolute path
+    dir: /absolute/path/to/assets
 ```
 
 **2. Path prefix doesn't match**
 
-Configuration:
+With the configuration below, the URL must include the `/assets` prefix:
 
 ```yaml
 statics:
@@ -399,94 +321,73 @@ statics:
     dir: ~/project/dist
 ```
 
-File access must include prefix:
-
 ```bash
-curl http://api.local:3000/assets/style.css  # Correct
-curl http://api.local:3000/style.css         # Wrong - won't find file
+curl http://api.local:3000/assets/style.css   # Correct
+curl http://api.local:3000/style.css          # Wrong - prefix missing
 ```
 
-**3. Index file not configured for SPA**
-
-For Single-Page Applications:
+**3. Missing index file for SPA routing**
 
 ```yaml
 statics:
   - path: /
     dir: ~/project/build
-    index: index.html # Add this for client-side routing
+    index: index.html   # Required for client-side routing
 ```
 
 ---
 
-### High Memory or CPU Usage
+## High Memory or CPU Usage
 
 **Symptoms:**
 
 - UNCORS process consuming excessive resources
 - System slowdown when UNCORS is running
 
-**Causes and Solutions:**
-
 **1. Cache growing too large**
 
-Configure cache expiration:
+Configure a shorter expiration time or smaller max size:
 
 ```yaml
 cache-config:
   expiration-time: 5m
-  clear-time: 30m
+  max-size: 52428800   # 50 MB
 ```
 
-Or disable caching:
-
-```yaml
-mappings:
-  - from: http://api.local:3000
-    to: https://api.example.com
-    # Don't include 'cache:' section
-```
+Or disable caching for this mapping by omitting the `cache:` section entirely.
 
 **2. Debug logging enabled**
 
-Disable debug mode in production:
-
 ```yaml
-debug: false # Set to false
+debug: false
 ```
-
-Or remove `--debug` flag from command line.
 
 **3. Large response bodies being cached**
 
-Avoid caching large responses by excluding specific paths:
+Only cache paths that return small responses:
 
 ```yaml
 cache:
   - /api/small-responses/**
-  # Don't cache /api/large-files/**
+  # Avoid caching /api/large-files/**
 ```
 
 ---
 
-### Proxy Not Working
+## Proxy Not Working
 
 **Symptoms:**
 
 - Requests fail with proxy errors
 - "Proxy connection failed"
 
-**Causes and Solutions:**
-
-**1. Proxy configuration incorrect**
-
-Verify proxy URL format:
+**1. Proxy URL format incorrect**
 
 ```yaml
-proxy: http://proxy.example.com:8080 # Correct format
+proxy: http://proxy.example.com:8080   # Correct format
 ```
 
-Test proxy connectivity:
+Test connectivity:
 
 ```bash
 curl -x http://proxy.example.com:8080 https://google.com
@@ -494,24 +395,19 @@ curl -x http://proxy.example.com:8080 https://google.com
 
 **2. Environment variables conflicting**
 
-UNCORS uses system proxy environment variables by default. Unset if needed:
+UNCORS reads system proxy environment variables by default. Unset them if needed:
 
 ```bash
-unset HTTP_PROXY
-unset HTTPS_PROXY
-unset http_proxy
-unset https_proxy
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
 ```
 
-Or override in configuration:
+Or override in the configuration:
 
 ```yaml
-proxy: "" # Disable proxy
+proxy: ""   # Disable proxy
 ```
 
-**3. Proxy authentication required**
-
-If proxy requires authentication:
+**3. Proxy requires authentication**
 
 ```yaml
 proxy: http://username:password@proxy.example.com:8080
@@ -521,18 +417,11 @@ proxy: http://username:password@proxy.example.com:8080
 
 ## Script Handler Issues
 
-### Script Not Executing
+**Script Not Executing**
 
-**Symptoms:**
+**Symptoms:** Script handler not running; default response returned instead.
 
-- Script handler not running
-- Default response instead of script response
-
-**Causes and Solutions:**
-
-**1. Path or method doesn't match**
-
-Verify path matches:
+**1. Path or method filter doesn't match**
 
 ```yaml
 scripts:
@@ -543,27 +432,23 @@ scripts:
       response:WriteString("Hello")
 ```
 
+Verify the path and method match your request exactly.
+
 **2. Script syntax error**
 
-Test Lua syntax separately:
+Enable debug logging to see script errors:
 
 ```bash
-lua -e 'print("test")'
+uncors --config .uncors.yaml --debug
 ```
 
-Check UNCORS logs with `--debug` for script errors.
-
 **3. File-based script not found**
-
-For file-based scripts:
 
 ```yaml
 scripts:
   - path: /api/custom
-    file: ~/scripts/handler.lua # Verify file exists
+    file: ~/scripts/handler.lua   # Verify file exists
 ```
-
-Check file exists:
 
 ```bash
 ls -l ~/scripts/handler.lua
@@ -573,11 +458,9 @@ ls -l ~/scripts/handler.lua
 
 ## Performance Issues
 
-### Slow Response Times
+**Slow response times:**
 
-**Causes and Solutions:**
-
-**1. Enable caching for frequently accessed resources**
+1. Enable caching for frequently accessed resources
 
 ```yaml
 cache-config:
@@ -591,25 +474,19 @@ mappings:
       - /api/**
 ```
 
-**2. Reduce upstream server latency**
-
-Check upstream server response time:
+2. Check upstream server response time directly
 
 ```bash
 time curl https://api.example.com/endpoint
 ```
 
-**3. Use compression**
-
-Ensure upstream server supports compression (gzip, br).
+3. Ensure the upstream server supports compression (gzip, br)
 
 ---
 
 ## Getting More Help
 
 ### Enable Debug Logging
-
-Run with debug flag for detailed logs:
 
 ```bash
 uncors --config .uncors.yaml --debug
@@ -623,58 +500,31 @@ uncors --version
 
 ### Report Issues
 
-If you've tried the above and still have issues:
+If you've tried the above and still have problems, create an issue at [GitHub Issues](https://github.com/evg4b/uncors/issues) with:
 
-1. Check [GitHub Issues](https://github.com/evg4b/uncors/issues) for similar problems
-2. Create a new issue with:
-   - UNCORS version
-   - Operating system
-   - Configuration file (sanitized)
-   - Debug logs
-   - Steps to reproduce
+- UNCORS version (`uncors --version`)
+- Operating system
+- Configuration file (with sensitive values removed)
+- Debug logs
+- Steps to reproduce
 
 ### Community Resources
 
 - [GitHub Repository](https://github.com/evg4b/uncors)
-- [Documentation](https://github.com/evg4b/uncors/wiki)
 - [Issue Tracker](https://github.com/evg4b/uncors/issues)
 
 ---
 
 ## Prevention Best Practices
 
-**1. Always use debug mode during development:**
+1. **Always use debug mode during initial setup** to see what requests are being handled
+2. **Validate your YAML** before starting - syntax errors produce confusing startup behavior
+3. **Keep UNCORS updated:**
 
 ```bash
-uncors --config .uncors.yaml --debug
+brew upgrade evg4b/tap/uncors   # Homebrew
+npm update -g uncors            # NPM
 ```
 
-**2. Validate configuration before deploying:**
-
-```bash
-# Test with minimal configuration first
-# Then gradually add features
-```
-
-**3. Keep UNCORS updated:**
-
-```bash
-# Homebrew
-brew upgrade evg4b/tap/uncors
-
-# NPM
-npm update -g uncors
-```
-
-**4. Document your setup:**
-
-- Keep notes on custom configurations
-- Document hosts file entries
-- Track certificate locations
-
-**5. Use version control for configuration:**
-
-```bash
-git add .uncors.yaml
-git commit -m "Add UNCORS configuration"
-```
+4. **Document your setup** - note hosts file entries, certificate locations, and config paths
+5. **Version control your configuration** - commit `.uncors.yaml` alongside your project


### PR DESCRIPTION
## Summary

- **Added H1 page titles** to all 12 documentation files — none had one before, making wiki navigation confusing
- **Added table of contents** to the three longest pages: `Configuration.md`, `Migration-Guide.md`, and `Script-Handler.md`
- **Extended Migration Guide** with a v0.4.x → v0.5.x section (no breaking changes; notes the new `options-handling` feature)
- **Fixed incorrect `clear-time` property** in `Real-World-Examples.md` and `Troubleshooting.md` — it is present in `schema.json` but not implemented in the Go config struct (`CacheConfig` only has `expiration-time` and `max-size`)
- **Reorganized Home.md** documentation index into three groups: *Getting Started*, *Features*, and *Reference* for easier orientation
- **Fixed heading hierarchy** in `Script-Handler.md` — internal sections were H1 (`#`) which conflicted with the new page title; demoted to H2/H3/H4
- **Standardized formatting** across all files: consistent admonition usage (`> [!NOTE]`, `> [!WARNING]`), table alignment, and cross-reference style

## Test plan

- [ ] Verify all 12 files render correctly in GitHub Wiki or Markdown viewer
- [ ] Confirm table of contents anchor links resolve correctly in Configuration.md, Migration-Guide.md, and Script-Handler.md
- [ ] Confirm `clear-time` no longer appears in example configurations (Real-World-Examples.md, Troubleshooting.md)
- [ ] Confirm Migration Guide covers v0.4.x → v0.5.x and v0.5.x → v0.6.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)