### PR TITLE
Refactor pkg/urlt: standalone functions, remove wrapper types

### DIFF
--- a/pkg/urlt/README.md
+++ b/pkg/urlt/README.md
@@ -1,10 +1,87 @@
 # urlt
 
-This package is a fork of the Go standard library [net/url](https://pkg.go.dev/net/url) package.
+A fork of the Go standard library [net/url](https://pkg.go.dev/net/url) package. Operates directly on `*net/url.URL` and exposes URL functionality as standalone functions rather than methods.
 
-Modifications from the original:
-- Package renamed from `url` to `urlt`
-- Removed functionality gated behind `godebug` settings
-- Removed `//go:linkname` functions
+## API
+
+### Parsing
+
+```go
+u, err := urlt.Parse("https://user:pass@example.com/path?q=1#frag")
+u, err := urlt.ParseRequestURI("https://example.com/path")
+```
+
+### Stringification
+
+```go
+urlt.URL_String(u)           // reassemble URL into a string
+urlt.URL_RequestURI(u)       // encoded path?query for HTTP requests
+urlt.Redacted(u)             // like URL_String but masks the password
+```
+
+### Path and fragment
+
+```go
+urlt.URL_EscapedPath(u)      // percent-encoded form of u.Path
+urlt.URL_EscapedFragment(u)  // percent-encoded form of u.Fragment
+urlt.URL_JoinPath(u, elem...) // new URL with path elements appended
+urlt.JoinPath(base, elem...)  // same, starting from a raw URL string
+
+urlt.PathEscape(s)
+urlt.PathUnescape(s)
+```
+
+### Query
+
+```go
+urlt.URL_Query(u)            // parses u.RawQuery, silently drops errors
+urlt.ParseQuery(query)       // parses a query string, returns errors
+urlt.Encode(values)          // encodes net/url.Values to query string
+
+urlt.QueryEscape(s)
+urlt.QueryUnescape(s)
+```
+
+### Host
+
+```go
+urlt.URL_Hostname(u)         // host without port
+urlt.URL_Port(u)             // port without leading colon
+```
+
+### Reference resolution
+
+```go
+urlt.URL_ResolveReference(base, ref)  // resolve ref against base per RFC 3986
+urlt.URL_Parse(base, ref)             // parse ref then resolve against base
+```
+
+### URLT type
+
+`URLT` is a defined type over `net/url.URL` with custom binary marshaling. It serializes using `URL_String` and deserializes using `Parse`, instead of the standard library implementations.
+
+```go
+type MyConfig struct {
+    Endpoint urlt.URLT
+}
+```
+
+## Differences from net/url
+
+**Functions instead of methods** — URL operations are standalone functions with a `URL_` prefix rather than methods on a `URL` type. Use `urlt.URL_String(u)` instead of `u.String()`, `urlt.URL_Query(u)` instead of `u.Query()`, etc.
+
+**Works with `*net/url.URL` directly** — there is no custom `URL` struct. Parse returns a `*net/url.URL` and all functions accept one.
+
+**No `Userinfo` or `Values` types** — uses `net/url.Userinfo` and `net/url.Values` from the standard library.
+
+**No custom error types** — `EscapeError`, `InvalidHostError`, and `Error` are not re-exported; errors returned are the `net/url` equivalents.
+
+**`URL.IsAbs()` removed** — check `u.Scheme != ""` directly.
+
+**`URLT` type added** — `type URLT net/url.URL` with `MarshalBinary`/`UnmarshalBinary` that use `URL_String`/`Parse` instead of the standard library implementations.
+
+**No `godebug`-gated behaviour or `//go:linkname` functions.**
+
+---
 
 Original code copyright 2009 The Go Authors. Licensed under the BSD-style license — see [LICENSE](LICENSE).

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -763,47 +763,6 @@ func (u *URL) Redacted() string {
 	return ru.String()
 }
 
-// Values maps a string key to a list of values.
-// It is typically used for query parameters and form values.
-// Unlike in the http.Header map, the keys in a Values map
-// are case-sensitive.
-type Values map[string][]string
-
-// Get gets the first value associated with the given key.
-// If there are no values associated with the key, Get returns
-// the empty string. To access multiple values, use the map
-// directly.
-func (v Values) Get(key string) string {
-	vs := v[key]
-	if len(vs) == 0 {
-		return ""
-	}
-	return vs[0]
-}
-
-// Set sets the key to value. It replaces any existing
-// values.
-func (v Values) Set(key, value string) {
-	v[key] = []string{value}
-}
-
-// Add adds the value to key. It appends to any existing
-// values associated with key.
-func (v Values) Add(key, value string) {
-	v[key] = append(v[key], value)
-}
-
-// Del deletes the values associated with key.
-func (v Values) Del(key string) {
-	delete(v, key)
-}
-
-// Has checks whether a given key is set.
-func (v Values) Has(key string) bool {
-	_, ok := v[key]
-	return ok
-}
-
 // ParseQuery parses the URL-encoded query string and returns
 // a map listing the values specified for each key.
 // ParseQuery always returns a non-nil map containing all the
@@ -814,13 +773,13 @@ func (v Values) Has(key string) bool {
 // A setting without an equals sign is interpreted as a key set to an empty
 // value.
 // Settings containing a non-URL-encoded semicolon are considered invalid.
-func ParseQuery(query string) (Values, error) {
-	m := make(Values)
+func ParseQuery(query string) (base_url.Values, error) {
+	m := make(base_url.Values)
 	err := parseQuery(m, query)
 	return m, err
 }
 
-func parseQuery(m Values, query string) (err error) {
+func parseQuery(m base_url.Values, query string) (err error) {
 	for query != "" {
 		var key string
 		key, query, _ = strings.Cut(query, "&")
@@ -853,7 +812,7 @@ func parseQuery(m Values, query string) (err error) {
 
 // Encode encodes the values into “URL encoded” form
 // ("bar=baz&foo=quux") sorted by key.
-func (v Values) Encode() string {
+func Encode(v base_url.Values) string {
 	if len(v) == 0 {
 		return ""
 	}
@@ -1013,7 +972,7 @@ func (u *URL) ResolveReference(ref *URL) *URL {
 // Query parses RawQuery and returns the corresponding values.
 // It silently discards malformed value pairs.
 // To check errors use [ParseQuery].
-func (u *URL) Query() Values {
+func (u *URL) Query() base_url.Values {
 	v, _ := ParseQuery(u.RawQuery)
 	return v
 }

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -19,35 +19,11 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	base_url "net/url"
 	"path"
 	"slices"
-	"strconv"
 	"strings"
 )
-
-// Error reports an error and the operation and URL that caused it.
-type Error struct {
-	Op  string
-	URL string
-	Err error
-}
-
-func (e *Error) Unwrap() error { return e.Err }
-func (e *Error) Error() string { return fmt.Sprintf("%s %q: %s", e.Op, e.URL, e.Err) }
-
-func (e *Error) Timeout() bool {
-	t, ok := e.Err.(interface {
-		Timeout() bool
-	})
-	return ok && t.Timeout()
-}
-
-func (e *Error) Temporary() bool {
-	t, ok := e.Err.(interface {
-		Temporary() bool
-	})
-	return ok && t.Temporary()
-}
 
 const upperhex = "0123456789ABCDEF"
 
@@ -58,18 +34,6 @@ func ishex(c byte) bool {
 // Precondition: ishex(c) is true.
 func unhex(c byte) byte {
 	return 9*(c>>6) + (c & 15)
-}
-
-type EscapeError string
-
-func (e EscapeError) Error() string {
-	return "invalid URL escape " + strconv.Quote(string(e))
-}
-
-type InvalidHostError string
-
-func (e InvalidHostError) Error() string {
-	return "invalid character " + strconv.Quote(string(e)) + " in host name"
 }
 
 // See the reference implementation in gen_encoding_table.go.
@@ -112,7 +76,7 @@ func unescape(s string, mode encoding) (string, error) {
 				if len(s) > 3 {
 					s = s[:3]
 				}
-				return "", EscapeError(s)
+				return "", base_url.EscapeError(s)
 			}
 			// Per https://tools.ietf.org/html/rfc3986#page-21
 			// in the host component %-encoding can only be used
@@ -121,7 +85,7 @@ func unescape(s string, mode encoding) (string, error) {
 			// introduces %25 being allowed to escape a percent sign
 			// in IPv6 scoped-address literals. Yay.
 			if mode == encodeHost && unhex(s[i+1]) < 8 && s[i:i+3] != "%25" {
-				return "", EscapeError(s[i : i+3])
+				return "", base_url.EscapeError(s[i : i+3])
 			}
 			if mode == encodeZone {
 				// RFC 6874 says basically "anything goes" for zone identifiers
@@ -133,7 +97,7 @@ func unescape(s string, mode encoding) (string, error) {
 				// But Windows puts spaces here! Yay.
 				v := unhex(s[i+1])<<4 | unhex(s[i+2])
 				if s[i:i+3] != "%25" && v != ' ' && shouldEscape(v, encodeHost) {
-					return "", EscapeError(s[i : i+3])
+					return "", base_url.EscapeError(s[i : i+3])
 				}
 			}
 			i += 3
@@ -142,7 +106,7 @@ func unescape(s string, mode encoding) (string, error) {
 			i++
 		default:
 			if (mode == encodeHost || mode == encodeZone) && s[i] < 0x80 && shouldEscape(s[i], mode) {
-				return "", InvalidHostError(s[i : i+1])
+				return "", base_url.InvalidHostError(s[i : i+1])
 			}
 			i++
 		}
@@ -397,13 +361,13 @@ func Parse(rawURL string) (*URL, error) {
 	u, frag, _ := strings.Cut(rawURL, "#")
 	url, err := parse(u, false)
 	if err != nil {
-		return nil, &Error{"parse", u, err}
+		return nil, &base_url.Error{Op: "parse", URL: u, Err: err}
 	}
 	if frag == "" {
 		return url, nil
 	}
 	if err = url.setFragment(frag); err != nil {
-		return nil, &Error{"parse", rawURL, err}
+		return nil, &base_url.Error{Op: "parse", URL: rawURL, Err: err}
 	}
 	return url, nil
 }
@@ -416,7 +380,7 @@ func Parse(rawURL string) (*URL, error) {
 func ParseRequestURI(rawURL string) (*URL, error) {
 	url, err := parse(rawURL, true)
 	if err != nil {
-		return nil, &Error{"parse", rawURL, err}
+		return nil, &base_url.Error{Op: "parse", URL: rawURL, Err: err}
 	}
 	return url, nil
 }

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -234,10 +234,6 @@ func getScheme(rawURL string) (scheme, path string, err error) {
 	return "", rawURL, nil
 }
 
-// URL is an alias for net/url.URL, provided so package consumers can use
-// urlt.URL in struct literals and type assertions without importing net/url.
-type URL = base_url.URL
-
 // URLT is a defined type over net/url.URL that provides custom binary
 // marshaling using [URL_String] and [Parse] instead of the standard library
 // implementations.
@@ -855,12 +851,6 @@ func resolvePath(base, ref string) string {
 		r = r[1:]
 	}
 	return r
-}
-
-// URL_IsAbs reports whether the [URL] is absolute.
-// Absolute means that it has a non-empty scheme.
-func URL_IsAbs(u *base_url.URL) bool {
-	return u.Scheme != ""
 }
 
 // URL_Parse parses a [URL] in the context of the receiver. The provided URL

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -231,7 +231,7 @@ func escape(s string, mode encoding) string {
 // the original encoding of Path. The Fragment field is also stored in decoded form,
 // use [URL_EscapedFragment] to retrieve the original encoding.
 //
-// The [URL.String] method uses [URL_EscapedPath] to obtain the path.
+// The [URL_String] function uses [URL_EscapedPath] to obtain the path.
 type URL struct {
 	Scheme   string
 	Opaque   string             // encoded opaque data
@@ -291,6 +291,8 @@ func getScheme(rawURL string) (scheme, path string, err error) {
 	}
 	return "", rawURL, nil
 }
+
+type URLT = URL
 
 // Parse parses a raw url into a [URL] structure.
 //
@@ -564,7 +566,7 @@ func setPath(u *URL, p string) error {
 // URL_EscapedPath returns u.RawPath when it is a valid escaping of u.Path.
 // Otherwise URL_EscapedPath ignores u.RawPath and computes an escaped
 // form on its own.
-// The [URL.String] and [URL.RequestURI] methods use URL_EscapedPath to construct
+// The [URL_String] and [URL_RequestURI] functions use URL_EscapedPath to construct
 // their results.
 // In general, code should call URL_EscapedPath instead of
 // reading u.RawPath directly.
@@ -628,7 +630,7 @@ func setFragment(u *URL, f string) error {
 // EscapedFragment returns u.RawFragment when it is a valid escaping of u.Fragment.
 // Otherwise EscapedFragment ignores u.RawFragment and computes an escaped
 // form on its own.
-// The [URL.String] method uses EscapedFragment to construct its result.
+// The [URL_String] function uses EscapedFragment to construct its result.
 // In general, code should call EscapedFragment instead of
 // reading u.RawFragment directly.
 func URL_EscapedFragment(u *URL) string {
@@ -658,16 +660,16 @@ func validOptionalPort(port string) bool {
 	return true
 }
 
-// String reassembles the [URL] into a valid URL string.
+// URL_String reassembles the [URL] into a valid URL string.
 // The general form of the result is one of:
 //
 //	scheme:opaque?query#fragment
 //	scheme://userinfo@host/path?query#fragment
 //
-// If u.Opaque is non-empty, String uses the first form;
+// If u.Opaque is non-empty, URL_String uses the first form;
 // otherwise it uses the second form.
 // Any non-ASCII characters in host are escaped.
-// To obtain the path, String uses u.EscapedPath().
+// To obtain the path, URL_String uses URL_EscapedPath(u).
 //
 // In the second form, the following rules apply:
 //   - if u.Scheme is empty, scheme: is omitted.
@@ -679,7 +681,7 @@ func validOptionalPort(port string) bool {
 //     the form host/path does not add its own /.
 //   - if u.RawQuery is empty, ?query is omitted.
 //   - if u.Fragment is empty, #fragment is omitted.
-func (u *URL) String() string {
+func URL_String(u *URL) string {
 	var buf strings.Builder
 
 	n := len(u.Scheme)
@@ -759,7 +761,7 @@ func Redacted(u *URL) string {
 	if _, has := ru.User.Password(); has {
 		ru.User = base_url.UserPassword(ru.User.Username(), "xxxxx")
 	}
-	return ru.String()
+	return URL_String(&ru)
 }
 
 // ParseQuery parses the URL-encoded query string and returns
@@ -906,30 +908,30 @@ func resolvePath(base, ref string) string {
 	return r
 }
 
-// IsAbs reports whether the [URL] is absolute.
+// URL_IsAbs reports whether the [URL] is absolute.
 // Absolute means that it has a non-empty scheme.
-func (u *URL) IsAbs() bool {
+func URL_IsAbs(u *URL) bool {
 	return u.Scheme != ""
 }
 
-// Parse parses a [URL] in the context of the receiver. The provided URL
-// may be relative or absolute. Parse returns nil, err on parse
-// failure, otherwise its return value is the same as [URL.ResolveReference].
-func (u *URL) Parse(ref string) (*URL, error) {
+// URL_Parse parses a [URL] in the context of the receiver. The provided URL
+// may be relative or absolute. URL_Parse returns nil, err on parse
+// failure, otherwise its return value is the same as [URL_ResolveReference].
+func URL_Parse(u *URL, ref string) (*URL, error) {
 	refURL, err := Parse(ref)
 	if err != nil {
 		return nil, err
 	}
-	return u.ResolveReference(refURL), nil
+	return URL_ResolveReference(u, refURL), nil
 }
 
-// ResolveReference resolves a URI reference to an absolute URI from
+// URL_ResolveReference resolves a URI reference to an absolute URI from
 // an absolute base URI u, per RFC 3986 Section 5.2. The URI reference
-// may be relative or absolute. ResolveReference always returns a new
+// may be relative or absolute. URL_ResolveReference always returns a new
 // [URL] instance, even if the returned URL is identical to either the
-// base or reference. If ref is an absolute URL, then ResolveReference
+// base or reference. If ref is an absolute URL, then URL_ResolveReference
 // ignores base and returns a copy of ref.
-func (u *URL) ResolveReference(ref *URL) *URL {
+func URL_ResolveReference(u *URL, ref *URL) *URL {
 	url := *ref
 	if ref.Scheme == "" {
 		url.Scheme = u.Scheme
@@ -968,17 +970,17 @@ func (u *URL) ResolveReference(ref *URL) *URL {
 	return &url
 }
 
-// Query parses RawQuery and returns the corresponding values.
+// URL_Query parses RawQuery and returns the corresponding values.
 // It silently discards malformed value pairs.
 // To check errors use [ParseQuery].
-func (u *URL) Query() base_url.Values {
+func URL_Query(u *URL) base_url.Values {
 	v, _ := ParseQuery(u.RawQuery)
 	return v
 }
 
-// RequestURI returns the encoded path?query or opaque?query
+// URL_RequestURI returns the encoded path?query or opaque?query
 // string that would be used in an HTTP request for u.
-func (u *URL) RequestURI() string {
+func URL_RequestURI(u *URL) string {
 	result := u.Opaque
 	if result == "" {
 		result = URL_EscapedPath(u)
@@ -996,19 +998,19 @@ func (u *URL) RequestURI() string {
 	return result
 }
 
-// Hostname returns u.Host, stripping any valid port number if present.
+// URL_Hostname returns u.Host, stripping any valid port number if present.
 //
 // If the result is enclosed in square brackets, as literal IPv6 addresses are,
 // the square brackets are removed from the result.
-func (u *URL) Hostname() string {
+func URL_Hostname(u *URL) string {
 	host, _ := splitHostPort(u.Host)
 	return host
 }
 
-// Port returns the port part of u.Host, without the leading colon.
+// URL_Port returns the port part of u.Host, without the leading colon.
 //
-// If u.Host doesn't contain a valid numeric port, Port returns an empty string.
-func (u *URL) Port() string {
+// If u.Host doesn't contain a valid numeric port, URL_Port returns an empty string.
+func URL_Port(u *URL) string {
 	_, port := splitHostPort(u.Host)
 	return port
 }
@@ -1034,15 +1036,15 @@ func splitHostPort(hostPort string) (host, port string) {
 // Marshaling interface implementations.
 // Would like to implement MarshalText/UnmarshalText but that will change the JSON representation of URLs.
 
-func (u *URL) MarshalBinary() (text []byte, err error) {
+func (u *URLT) MarshalBinary() (text []byte, err error) {
 	return u.AppendBinary(nil)
 }
 
-func (u *URL) AppendBinary(b []byte) ([]byte, error) {
-	return append(b, u.String()...), nil
+func (u *URLT) AppendBinary(b []byte) ([]byte, error) {
+	return append(b, URL_String(u)...), nil
 }
 
-func (u *URL) UnmarshalBinary(text []byte) error {
+func (u *URLT) UnmarshalBinary(text []byte) error {
 	u1, err := Parse(string(text))
 	if err != nil {
 		return err
@@ -1051,11 +1053,11 @@ func (u *URL) UnmarshalBinary(text []byte) error {
 	return nil
 }
 
-// JoinPath returns a new [URL] with the provided path elements joined to
+// URL_JoinPath returns a new [URL] with the provided path elements joined to
 // any existing path and the resulting path cleaned of any ./ or ../ elements.
 // Any sequences of multiple / characters will be reduced to a single /.
 // Path elements must already be in escaped form, as produced by [PathEscape].
-func (u *URL) JoinPath(elem ...string) *URL {
+func URL_JoinPath(u *URL, elem ...string) *URL {
 	url, _ := joinPath(u, elem...)
 	return url
 }
@@ -1146,5 +1148,5 @@ func JoinPath(base string, elem ...string) (result string, err error) {
 	if err != nil {
 		return "", err
 	}
-	return res.String(), nil
+	return URL_String(res), nil
 }

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -235,11 +235,11 @@ func escape(s string, mode encoding) string {
 // The [URL.String] method uses the [URL.EscapedPath] method to obtain the path.
 type URL struct {
 	Scheme   string
-	Opaque   string    // encoded opaque data
-	User     *Userinfo // username and password information
-	Host     string    // "host" or "host:port" (see Hostname and Port methods)
-	Path     string    // path (relative paths may omit leading slash)
-	Fragment string    // fragment for references (without '#')
+	Opaque   string             // encoded opaque data
+	User     *base_url.Userinfo // username and password information
+	Host     string             // "host" or "host:port" (see Hostname and Port methods)
+	Path     string             // path (relative paths may omit leading slash)
+	Fragment string             // fragment for references (without '#')
 
 	// RawQuery contains the encoded query values, without the initial '?'.
 	// Use URL.Query to decode the query.
@@ -264,63 +264,6 @@ type URL struct {
 	// OmitHost indicates the URL has an empty host (authority).
 	// When set, the String method will not include the host when it is empty.
 	OmitHost bool
-}
-
-// User returns a [Userinfo] containing the provided username
-// and no password set.
-func User(username string) *Userinfo {
-	return &Userinfo{username, "", false}
-}
-
-// UserPassword returns a [Userinfo] containing the provided username
-// and password.
-//
-// This functionality should only be used with legacy web sites.
-// RFC 2396 warns that interpreting Userinfo this way
-// “is NOT RECOMMENDED, because the passing of authentication
-// information in clear text (such as URI) has proven to be a
-// security risk in almost every case where it has been used.”
-func UserPassword(username, password string) *Userinfo {
-	return &Userinfo{username, password, true}
-}
-
-// The Userinfo type is an immutable encapsulation of username and
-// password details for a [URL]. An existing Userinfo value is guaranteed
-// to have a username set (potentially empty, as allowed by RFC 2396),
-// and optionally a password.
-type Userinfo struct {
-	username    string
-	password    string
-	passwordSet bool
-}
-
-// Username returns the username.
-func (u *Userinfo) Username() string {
-	if u == nil {
-		return ""
-	}
-	return u.username
-}
-
-// Password returns the password in case it is set, and whether it is set.
-func (u *Userinfo) Password() (string, bool) {
-	if u == nil {
-		return "", false
-	}
-	return u.password, u.passwordSet
-}
-
-// String returns the encoded userinfo information in the standard form
-// of "username[:password]".
-func (u *Userinfo) String() string {
-	if u == nil {
-		return ""
-	}
-	s := escape(u.username, encodeUserPassword)
-	if u.passwordSet {
-		s += ":" + escape(u.password, encodeUserPassword)
-	}
-	return s
 }
 
 // Maybe rawURL is of the form scheme:path.
@@ -469,7 +412,7 @@ func parse(rawURL string, viaRequest bool) (*URL, error) {
 	return url, nil
 }
 
-func parseAuthority(scheme, authority string) (user *Userinfo, host string, err error) {
+func parseAuthority(scheme, authority string) (user *base_url.Userinfo, host string, err error) {
 	i := strings.LastIndex(authority, "@")
 	if i < 0 {
 		host, err = parseHost(scheme, authority)
@@ -490,7 +433,7 @@ func parseAuthority(scheme, authority string) (user *Userinfo, host string, err 
 		if userinfo, err = unescape(userinfo, encodeUserPassword); err != nil {
 			return nil, "", err
 		}
-		user = User(userinfo)
+		user = base_url.User(userinfo)
 	} else {
 		username, password, _ := strings.Cut(userinfo, ":")
 		if username, err = unescape(username, encodeUserPassword); err != nil {
@@ -499,7 +442,7 @@ func parseAuthority(scheme, authority string) (user *Userinfo, host string, err 
 		if password, err = unescape(password, encodeUserPassword); err != nil {
 			return nil, "", err
 		}
-		user = UserPassword(username, password)
+		user = base_url.UserPassword(username, password)
 	}
 	return user, host, nil
 }
@@ -815,7 +758,7 @@ func (u *URL) Redacted() string {
 
 	ru := *u
 	if _, has := ru.User.Password(); has {
-		ru.User = UserPassword(ru.User.Username(), "xxxxx")
+		ru.User = base_url.UserPassword(ru.User.Username(), "xxxxx")
 	}
 	return ru.String()
 }

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -1056,11 +1056,11 @@ func (u *URL) UnmarshalBinary(text []byte) error {
 // Any sequences of multiple / characters will be reduced to a single /.
 // Path elements must already be in escaped form, as produced by [PathEscape].
 func (u *URL) JoinPath(elem ...string) *URL {
-	url, _ := u.joinPath(elem...)
+	url, _ := joinPath(u, elem...)
 	return url
 }
 
-func (u *URL) joinPath(elem ...string) (*URL, error) {
+func joinPath(u *URL, elem ...string) (*URL, error) {
 	elem = append([]string{u.EscapedPath()}, elem...)
 	var p string
 	if !strings.HasPrefix(elem[0], "/") {
@@ -1142,7 +1142,7 @@ func JoinPath(base string, elem ...string) (result string, err error) {
 	if err != nil {
 		return
 	}
-	res, err := url.joinPath(elem...)
+	res, err := joinPath(url, elem...)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -207,64 +207,6 @@ func escape(s string, mode encoding) string {
 	return string(t)
 }
 
-// A URL represents a parsed URL (technically, a URI reference).
-//
-// The general form represented is:
-//
-//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
-//
-// URLs that do not start with a slash after the scheme are interpreted as:
-//
-//	scheme:opaque[?query][#fragment]
-//
-// The Host field contains the host and port subcomponents of the URL.
-// When the port is present, it is separated from the host with a colon.
-// When the host is an IPv6 address, it must be enclosed in square brackets:
-// "[fe80::1]:80". The [net.JoinHostPort] function combines a host and port
-// into a string suitable for the Host field, adding square brackets to
-// the host when necessary.
-//
-// Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
-// A consequence is that it is impossible to tell which slashes in the Path were
-// slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, the code should use [URL_EscapedPath], which preserves
-// the original encoding of Path. The Fragment field is also stored in decoded form,
-// use [URL_EscapedFragment] to retrieve the original encoding.
-//
-// The [URL_String] function uses [URL_EscapedPath] to obtain the path.
-type URL struct {
-	Scheme   string
-	Opaque   string             // encoded opaque data
-	User     *base_url.Userinfo // username and password information
-	Host     string             // "host" or "host:port" (see Hostname and Port methods)
-	Path     string             // path (relative paths may omit leading slash)
-	Fragment string             // fragment for references (without '#')
-
-	// RawQuery contains the encoded query values, without the initial '?'.
-	// Use URL.Query to decode the query.
-	RawQuery string
-
-	// RawPath is an optional field containing an encoded path hint.
-	// See [URL_EscapedPath] for more details.
-	//
-	// In general, code should call URL_EscapedPath instead of reading RawPath.
-	RawPath string
-
-	// RawFragment is an optional field containing an encoded fragment hint.
-	// See [URL_EscapedFragment] for more details.
-	//
-	// In general, code should call URL_EscapedFragment instead of reading RawFragment.
-	RawFragment string
-
-	// ForceQuery indicates whether the original URL contained a query ('?') character.
-	// When set, the String method will include a trailing '?', even when RawQuery is empty.
-	ForceQuery bool
-
-	// OmitHost indicates the URL has an empty host (authority).
-	// When set, the String method will not include the host when it is empty.
-	OmitHost bool
-}
-
 // Maybe rawURL is of the form scheme:path.
 // (Scheme must be [a-zA-Z][a-zA-Z0-9+.-]*)
 // If so, return scheme, path; else return "", rawURL.
@@ -292,7 +234,14 @@ func getScheme(rawURL string) (scheme, path string, err error) {
 	return "", rawURL, nil
 }
 
-type URLT = URL
+// URL is an alias for net/url.URL, provided so package consumers can use
+// urlt.URL in struct literals and type assertions without importing net/url.
+type URL = base_url.URL
+
+// URLT is a defined type over net/url.URL that provides custom binary
+// marshaling using [URL_String] and [Parse] instead of the standard library
+// implementations.
+type URLT base_url.URL
 
 // Parse parses a raw url into a [URL] structure.
 //
@@ -300,7 +249,7 @@ type URLT = URL
 // (starting with a scheme). Trying to parse a hostname and path
 // without a scheme is invalid but may not necessarily return an
 // error, due to parsing ambiguities.
-func Parse(rawURL string) (*URL, error) {
+func Parse(rawURL string) (*base_url.URL, error) {
 	// Cut off #frag
 	u, frag, _ := strings.Cut(rawURL, "#")
 	url, err := parse(u, false)
@@ -321,7 +270,7 @@ func Parse(rawURL string) (*URL, error) {
 // only as an absolute URI or an absolute path.
 // The string url is assumed not to have a #fragment suffix.
 // (Web browsers strip #fragment before sending the URL to a web server.)
-func ParseRequestURI(rawURL string) (*URL, error) {
+func ParseRequestURI(rawURL string) (*base_url.URL, error) {
 	url, err := parse(rawURL, true)
 	if err != nil {
 		return nil, &base_url.Error{Op: "parse", URL: rawURL, Err: err}
@@ -333,7 +282,7 @@ func ParseRequestURI(rawURL string) (*URL, error) {
 // viaRequest is true, the URL is assumed to have arrived via an HTTP request,
 // in which case only absolute URLs or path-absolute relative URLs are allowed.
 // If viaRequest is false, all forms of relative URLs are allowed.
-func parse(rawURL string, viaRequest bool) (*URL, error) {
+func parse(rawURL string, viaRequest bool) (*base_url.URL, error) {
 	var rest string
 	var err error
 
@@ -344,7 +293,7 @@ func parse(rawURL string, viaRequest bool) (*URL, error) {
 	if rawURL == "" && viaRequest {
 		return nil, errors.New("empty url")
 	}
-	url := new(URL)
+	url := new(base_url.URL)
 
 	if rawURL == "*" {
 		url.Path = "*"
@@ -546,7 +495,7 @@ func parseHost(scheme, host string) (string, error) {
 // - setPath("/foo%2fbar") will set Path="/foo/bar" and RawPath="/foo%2fbar"
 // setPath will return an error only if the provided path contains an invalid
 // escaping.
-func setPath(u *URL, p string) error {
+func setPath(u *base_url.URL, p string) error {
 	path, err := unescape(p, encodePath)
 	if err != nil {
 		return err
@@ -570,7 +519,7 @@ func setPath(u *URL, p string) error {
 // their results.
 // In general, code should call URL_EscapedPath instead of
 // reading u.RawPath directly.
-func URL_EscapedPath(u *URL) string {
+func URL_EscapedPath(u *base_url.URL) string {
 	if u.RawPath != "" && validEncoded(u.RawPath, encodePath) {
 		p, err := unescape(u.RawPath, encodePath)
 		if err == nil && p == u.Path {
@@ -610,7 +559,7 @@ func validEncoded(s string, mode encoding) bool {
 }
 
 // setFragment is like setPath but for Fragment/RawFragment.
-func setFragment(u *URL, f string) error {
+func setFragment(u *base_url.URL, f string) error {
 	frag, err := unescape(f, encodeFragment)
 	if err != nil {
 		return err
@@ -633,7 +582,7 @@ func setFragment(u *URL, f string) error {
 // The [URL_String] function uses EscapedFragment to construct its result.
 // In general, code should call EscapedFragment instead of
 // reading u.RawFragment directly.
-func URL_EscapedFragment(u *URL) string {
+func URL_EscapedFragment(u *base_url.URL) string {
 	if u.RawFragment != "" && validEncoded(u.RawFragment, encodeFragment) {
 		f, err := unescape(u.RawFragment, encodeFragment)
 		if err == nil && f == u.Fragment {
@@ -681,7 +630,7 @@ func validOptionalPort(port string) bool {
 //     the form host/path does not add its own /.
 //   - if u.RawQuery is empty, ?query is omitted.
 //   - if u.Fragment is empty, #fragment is omitted.
-func URL_String(u *URL) string {
+func URL_String(u *base_url.URL) string {
 	var buf strings.Builder
 
 	n := len(u.Scheme)
@@ -752,7 +701,7 @@ func URL_String(u *URL) string {
 
 // Redacted is like [URL.String] but replaces any password with "xxxxx".
 // Only the password in u.User is redacted.
-func Redacted(u *URL) string {
+func Redacted(u *base_url.URL) string {
 	if u == nil {
 		return ""
 	}
@@ -910,14 +859,14 @@ func resolvePath(base, ref string) string {
 
 // URL_IsAbs reports whether the [URL] is absolute.
 // Absolute means that it has a non-empty scheme.
-func URL_IsAbs(u *URL) bool {
+func URL_IsAbs(u *base_url.URL) bool {
 	return u.Scheme != ""
 }
 
 // URL_Parse parses a [URL] in the context of the receiver. The provided URL
 // may be relative or absolute. URL_Parse returns nil, err on parse
 // failure, otherwise its return value is the same as [URL_ResolveReference].
-func URL_Parse(u *URL, ref string) (*URL, error) {
+func URL_Parse(u *base_url.URL, ref string) (*base_url.URL, error) {
 	refURL, err := Parse(ref)
 	if err != nil {
 		return nil, err
@@ -931,7 +880,7 @@ func URL_Parse(u *URL, ref string) (*URL, error) {
 // [URL] instance, even if the returned URL is identical to either the
 // base or reference. If ref is an absolute URL, then URL_ResolveReference
 // ignores base and returns a copy of ref.
-func URL_ResolveReference(u *URL, ref *URL) *URL {
+func URL_ResolveReference(u *base_url.URL, ref *base_url.URL) *base_url.URL {
 	url := *ref
 	if ref.Scheme == "" {
 		url.Scheme = u.Scheme
@@ -973,14 +922,14 @@ func URL_ResolveReference(u *URL, ref *URL) *URL {
 // URL_Query parses RawQuery and returns the corresponding values.
 // It silently discards malformed value pairs.
 // To check errors use [ParseQuery].
-func URL_Query(u *URL) base_url.Values {
+func URL_Query(u *base_url.URL) base_url.Values {
 	v, _ := ParseQuery(u.RawQuery)
 	return v
 }
 
 // URL_RequestURI returns the encoded path?query or opaque?query
 // string that would be used in an HTTP request for u.
-func URL_RequestURI(u *URL) string {
+func URL_RequestURI(u *base_url.URL) string {
 	result := u.Opaque
 	if result == "" {
 		result = URL_EscapedPath(u)
@@ -1002,7 +951,7 @@ func URL_RequestURI(u *URL) string {
 //
 // If the result is enclosed in square brackets, as literal IPv6 addresses are,
 // the square brackets are removed from the result.
-func URL_Hostname(u *URL) string {
+func URL_Hostname(u *base_url.URL) string {
 	host, _ := splitHostPort(u.Host)
 	return host
 }
@@ -1010,7 +959,7 @@ func URL_Hostname(u *URL) string {
 // URL_Port returns the port part of u.Host, without the leading colon.
 //
 // If u.Host doesn't contain a valid numeric port, URL_Port returns an empty string.
-func URL_Port(u *URL) string {
+func URL_Port(u *base_url.URL) string {
 	_, port := splitHostPort(u.Host)
 	return port
 }
@@ -1041,7 +990,7 @@ func (u *URLT) MarshalBinary() (text []byte, err error) {
 }
 
 func (u *URLT) AppendBinary(b []byte) ([]byte, error) {
-	return append(b, URL_String(u)...), nil
+	return append(b, URL_String((*base_url.URL)(u))...), nil
 }
 
 func (u *URLT) UnmarshalBinary(text []byte) error {
@@ -1049,7 +998,7 @@ func (u *URLT) UnmarshalBinary(text []byte) error {
 	if err != nil {
 		return err
 	}
-	*u = *u1
+	*u = URLT(*u1)
 	return nil
 }
 
@@ -1057,12 +1006,12 @@ func (u *URLT) UnmarshalBinary(text []byte) error {
 // any existing path and the resulting path cleaned of any ./ or ../ elements.
 // Any sequences of multiple / characters will be reduced to a single /.
 // Path elements must already be in escaped form, as produced by [PathEscape].
-func URL_JoinPath(u *URL, elem ...string) *URL {
+func URL_JoinPath(u *base_url.URL, elem ...string) *base_url.URL {
 	url, _ := joinPath(u, elem...)
 	return url
 }
 
-func joinPath(u *URL, elem ...string) (*URL, error) {
+func joinPath(u *base_url.URL, elem ...string) (*base_url.URL, error) {
 	elem = append([]string{URL_EscapedPath(u)}, elem...)
 	var p string
 	if !strings.HasPrefix(elem[0], "/") {

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -5,15 +5,14 @@
 
 //go:generate go run gen_encoding_table.go
 
-// Package url parses URLs and implements query escaping.
+// Package urlt parses URLs and implements query escaping.
+// It is a fork of the Go standard library's net/url package with modifications
+// for use in uncors (no Userinfo struct, simplified API).
 //
 // See RFC 3986. This package generally follows RFC 3986, except where
 // it deviates for compatibility reasons.
 // RFC 6874 followed for IPv6 zone literals.
 package urlt
-
-// When sending changes, first  search old issues for history on decisions.
-// Unit tests should also contain references to issue numbers with details.
 
 import (
 	"errors"

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -231,7 +231,7 @@ func escape(s string, mode encoding) string {
 // the original encoding of Path. The Fragment field is also stored in decoded form,
 // use [URL.EscapedFragment] to retrieve the original encoding.
 //
-// The [URL.String] method uses the [URL.EscapedPath] method to obtain the path.
+// The [URL.String] method uses [URL_EscapedPath] to obtain the path.
 type URL struct {
 	Scheme   string
 	Opaque   string             // encoded opaque data
@@ -559,16 +559,16 @@ func setPath(u *URL, p string) error {
 	return nil
 }
 
-// EscapedPath returns the escaped form of u.Path.
+// URL_EscapedPath returns the escaped form of u.Path.
 // In general there are multiple possible escaped forms of any path.
-// EscapedPath returns u.RawPath when it is a valid escaping of u.Path.
-// Otherwise EscapedPath ignores u.RawPath and computes an escaped
+// URL_EscapedPath returns u.RawPath when it is a valid escaping of u.Path.
+// Otherwise URL_EscapedPath ignores u.RawPath and computes an escaped
 // form on its own.
-// The [URL.String] and [URL.RequestURI] methods use EscapedPath to construct
+// The [URL.String] and [URL.RequestURI] methods use URL_EscapedPath to construct
 // their results.
-// In general, code should call EscapedPath instead of
+// In general, code should call URL_EscapedPath instead of
 // reading u.RawPath directly.
-func (u *URL) EscapedPath() string {
+func URL_EscapedPath(u *URL) string {
 	if u.RawPath != "" && validEncoded(u.RawPath, encodePath) {
 		p, err := unescape(u.RawPath, encodePath)
 		if err == nil && p == u.Path {
@@ -720,7 +720,7 @@ func (u *URL) String() string {
 				}
 			}
 		}
-		path := u.EscapedPath()
+		path := URL_EscapedPath(u)
 		if path != "" && path[0] != '/' && u.Host != "" {
 			buf.WriteByte('/')
 		}
@@ -938,7 +938,7 @@ func (u *URL) ResolveReference(ref *URL) *URL {
 		// The "absoluteURI" or "net_path" cases.
 		// We can ignore the error from setPath since we know we provided a
 		// validly-escaped path.
-		setPath(&url, resolvePath(ref.EscapedPath(), ""))
+		setPath(&url, resolvePath(URL_EscapedPath(ref), ""))
 		return &url
 	}
 	if ref.Opaque != "" {
@@ -964,7 +964,7 @@ func (u *URL) ResolveReference(ref *URL) *URL {
 	// The "abs_path" or "rel_path" cases.
 	url.Host = u.Host
 	url.User = u.User
-	setPath(&url, resolvePath(u.EscapedPath(), ref.EscapedPath()))
+	setPath(&url, resolvePath(URL_EscapedPath(u), URL_EscapedPath(ref)))
 	return &url
 }
 
@@ -981,7 +981,7 @@ func (u *URL) Query() base_url.Values {
 func (u *URL) RequestURI() string {
 	result := u.Opaque
 	if result == "" {
-		result = u.EscapedPath()
+		result = URL_EscapedPath(u)
 		if result == "" {
 			result = "/"
 		}
@@ -1061,7 +1061,7 @@ func (u *URL) JoinPath(elem ...string) *URL {
 }
 
 func joinPath(u *URL, elem ...string) (*URL, error) {
-	elem = append([]string{u.EscapedPath()}, elem...)
+	elem = append([]string{URL_EscapedPath(u)}, elem...)
 	var p string
 	if !strings.HasPrefix(elem[0], "/") {
 		// Return a relative path if u is relative,

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -308,7 +308,7 @@ func Parse(rawURL string) (*URL, error) {
 	if frag == "" {
 		return url, nil
 	}
-	if err = url.setFragment(frag); err != nil {
+	if err = setFragment(url, frag); err != nil {
 		return nil, &base_url.Error{Op: "parse", URL: rawURL, Err: err}
 	}
 	return url, nil
@@ -608,7 +608,7 @@ func validEncoded(s string, mode encoding) bool {
 }
 
 // setFragment is like setPath but for Fragment/RawFragment.
-func (u *URL) setFragment(f string) error {
+func setFragment(u *URL, f string) error {
 	frag, err := unescape(f, encodeFragment)
 	if err != nil {
 		return err

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -227,7 +227,7 @@ func escape(s string, mode encoding) string {
 // Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
 // A consequence is that it is impossible to tell which slashes in the Path were
 // slashes in the raw URL and which were %2f. This distinction is rarely important,
-// but when it is, the code should use the [URL.EscapedPath] method, which preserves
+// but when it is, the code should use [URL_EscapedPath], which preserves
 // the original encoding of Path. The Fragment field is also stored in decoded form,
 // use [URL.EscapedFragment] to retrieve the original encoding.
 //
@@ -245,9 +245,9 @@ type URL struct {
 	RawQuery string
 
 	// RawPath is an optional field containing an encoded path hint.
-	// See the EscapedPath method for more details.
+	// See [URL_EscapedPath] for more details.
 	//
-	// In general, code should call EscapedPath instead of reading RawPath.
+	// In general, code should call URL_EscapedPath instead of reading RawPath.
 	RawPath string
 
 	// RawFragment is an optional field containing an encoded fragment hint.
@@ -631,7 +631,7 @@ func setFragment(u *URL, f string) error {
 // The [URL.String] method uses EscapedFragment to construct its result.
 // In general, code should call EscapedFragment instead of
 // reading u.RawFragment directly.
-func (u *URL) EscapedFragment() string {
+func URL_EscapedFragment(u *URL) string {
 	if u.RawFragment != "" && validEncoded(u.RawFragment, encodeFragment) {
 		f, err := unescape(u.RawFragment, encodeFragment)
 		if err == nil && f == u.Fragment {
@@ -743,7 +743,7 @@ func (u *URL) String() string {
 	}
 	if u.Fragment != "" {
 		buf.WriteByte('#')
-		buf.WriteString(u.EscapedFragment())
+		buf.WriteString(URL_EscapedFragment(u))
 	}
 	return buf.String()
 }

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -229,7 +229,7 @@ func escape(s string, mode encoding) string {
 // slashes in the raw URL and which were %2f. This distinction is rarely important,
 // but when it is, the code should use [URL_EscapedPath], which preserves
 // the original encoding of Path. The Fragment field is also stored in decoded form,
-// use [URL.EscapedFragment] to retrieve the original encoding.
+// use [URL_EscapedFragment] to retrieve the original encoding.
 //
 // The [URL.String] method uses [URL_EscapedPath] to obtain the path.
 type URL struct {
@@ -251,9 +251,9 @@ type URL struct {
 	RawPath string
 
 	// RawFragment is an optional field containing an encoded fragment hint.
-	// See the EscapedFragment method for more details.
+	// See [URL_EscapedFragment] for more details.
 	//
-	// In general, code should call EscapedFragment instead of reading RawFragment.
+	// In general, code should call URL_EscapedFragment instead of reading RawFragment.
 	RawFragment string
 
 	// ForceQuery indicates whether the original URL contained a query ('?') character.
@@ -750,7 +750,7 @@ func (u *URL) String() string {
 
 // Redacted is like [URL.String] but replaces any password with "xxxxx".
 // Only the password in u.User is redacted.
-func (u *URL) Redacted() string {
+func Redacted(u *URL) string {
 	if u == nil {
 		return ""
 	}

--- a/pkg/urlt/url.go
+++ b/pkg/urlt/url.go
@@ -405,7 +405,7 @@ func parse(rawURL string, viaRequest bool) (*URL, error) {
 	// RawPath is a hint of the encoding of Path. We don't want to set it if
 	// the default escaping of Path is equivalent, to help make sure that people
 	// don't rely on it in general.
-	if err := url.setPath(rest); err != nil {
+	if err := setPath(url, rest); err != nil {
 		return nil, err
 	}
 	return url, nil
@@ -544,7 +544,7 @@ func parseHost(scheme, host string) (string, error) {
 // - setPath("/foo%2fbar") will set Path="/foo/bar" and RawPath="/foo%2fbar"
 // setPath will return an error only if the provided path contains an invalid
 // escaping.
-func (u *URL) setPath(p string) error {
+func setPath(u *URL, p string) error {
 	path, err := unescape(p, encodePath)
 	if err != nil {
 		return err
@@ -938,7 +938,7 @@ func (u *URL) ResolveReference(ref *URL) *URL {
 		// The "absoluteURI" or "net_path" cases.
 		// We can ignore the error from setPath since we know we provided a
 		// validly-escaped path.
-		url.setPath(resolvePath(ref.EscapedPath(), ""))
+		setPath(&url, resolvePath(ref.EscapedPath(), ""))
 		return &url
 	}
 	if ref.Opaque != "" {
@@ -964,7 +964,7 @@ func (u *URL) ResolveReference(ref *URL) *URL {
 	// The "abs_path" or "rel_path" cases.
 	url.Host = u.Host
 	url.User = u.User
-	url.setPath(resolvePath(u.EscapedPath(), ref.EscapedPath()))
+	setPath(&url, resolvePath(u.EscapedPath(), ref.EscapedPath()))
 	return &url
 }
 
@@ -1077,7 +1077,7 @@ func (u *URL) joinPath(elem ...string) (*URL, error) {
 		p += "/"
 	}
 	url := *u
-	err := url.setPath(p)
+	err := setPath(&url, p)
 	return &url, err
 }
 

--- a/pkg/urlt/url_test.go
+++ b/pkg/urlt/url_test.go
@@ -1981,8 +1981,8 @@ func TestJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if URL_String(u1) != URL_String(u) {
-		t.Errorf("json decoded to: %s\nwant: %s\n", URL_String(u1), URL_String(u))
+	if URL_String((*base_url.URL)(u1)) != URL_String(u) {
+		t.Errorf("json decoded to: %s\nwant: %s\n", URL_String((*base_url.URL)(u1)), URL_String(u))
 	}
 }
 
@@ -2002,8 +2002,8 @@ func TestGob(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if URL_String(u1) != URL_String(u) {
-		t.Errorf("gob decoded to: %s\nwant: %s\n", URL_String(u1), URL_String(u))
+	if URL_String((*base_url.URL)(u1)) != URL_String(u) {
+		t.Errorf("gob decoded to: %s\nwant: %s\n", URL_String((*base_url.URL)(u1)), URL_String(u))
 	}
 }
 

--- a/pkg/urlt/url_test.go
+++ b/pkg/urlt/url_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	base_url "net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -948,27 +949,27 @@ var unescapeTests = []EscapeTest{
 	{
 		"%", // not enough characters after %
 		"",
-		EscapeError("%"),
+		base_url.EscapeError("%"),
 	},
 	{
 		"%a", // not enough characters after %
 		"",
-		EscapeError("%a"),
+		base_url.EscapeError("%a"),
 	},
 	{
 		"%1", // not enough characters after %
 		"",
-		EscapeError("%1"),
+		base_url.EscapeError("%1"),
 	},
 	{
 		"123%45%6", // not enough characters after %
 		"",
-		EscapeError("%6"),
+		base_url.EscapeError("%6"),
 	},
 	{
 		"%zzzzz", // invalid hex digits
 		"",
-		EscapeError("%zz"),
+		base_url.EscapeError("%zz"),
 	},
 	{
 		"a+b",
@@ -1859,39 +1860,39 @@ var netErrorTests = []struct {
 	timeout   bool
 	temporary bool
 }{{
-	err:       &Error{"Get", "http://google.com/", &timeoutError{timeout: true}},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: &timeoutError{timeout: true}},
 	timeout:   true,
 	temporary: false,
 }, {
-	err:       &Error{"Get", "http://google.com/", &timeoutError{timeout: false}},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: &timeoutError{timeout: false}},
 	timeout:   false,
 	temporary: false,
 }, {
-	err:       &Error{"Get", "http://google.com/", &temporaryError{temporary: true}},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: &temporaryError{temporary: true}},
 	timeout:   false,
 	temporary: true,
 }, {
-	err:       &Error{"Get", "http://google.com/", &temporaryError{temporary: false}},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: &temporaryError{temporary: false}},
 	timeout:   false,
 	temporary: false,
 }, {
-	err:       &Error{"Get", "http://google.com/", &timeoutTemporaryError{timeoutError{timeout: true}, temporaryError{temporary: true}}},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: &timeoutTemporaryError{timeoutError{timeout: true}, temporaryError{temporary: true}}},
 	timeout:   true,
 	temporary: true,
 }, {
-	err:       &Error{"Get", "http://google.com/", &timeoutTemporaryError{timeoutError{timeout: false}, temporaryError{temporary: true}}},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: &timeoutTemporaryError{timeoutError{timeout: false}, temporaryError{temporary: true}}},
 	timeout:   false,
 	temporary: true,
 }, {
-	err:       &Error{"Get", "http://google.com/", &timeoutTemporaryError{timeoutError{timeout: true}, temporaryError{temporary: false}}},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: &timeoutTemporaryError{timeoutError{timeout: true}, temporaryError{temporary: false}}},
 	timeout:   true,
 	temporary: false,
 }, {
-	err:       &Error{"Get", "http://google.com/", &timeoutTemporaryError{timeoutError{timeout: false}, temporaryError{temporary: false}}},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: &timeoutTemporaryError{timeoutError{timeout: false}, temporaryError{temporary: false}}},
 	timeout:   false,
 	temporary: false,
 }, {
-	err:       &Error{"Get", "http://google.com/", io.EOF},
+	err:       &base_url.Error{Op: "Get", URL: "http://google.com/", Err: io.EOF},
 	timeout:   false,
 	temporary: false,
 }}

--- a/pkg/urlt/url_test.go
+++ b/pkg/urlt/url_test.go
@@ -1111,12 +1111,6 @@ func TestPathEscape(t *testing.T) {
 	}
 }
 
-//var userinfoTests = []UserinfoTest{
-//	{"user", "password", "user:password"},
-//	{"foo:bar", "~!@#$%^&*()_+{}|[]\\-=`:;'\"<>?,./",
-//		"foo%3Abar:~!%40%23$%25%5E&*()_+%7B%7D%7C%5B%5D%5C-=%60%3A;'%22%3C%3E?,.%2F"},
-//}
-
 type EncodeQueryTest struct {
 	m        base_url.Values
 	expected string
@@ -1897,7 +1891,7 @@ var netErrorTests = []struct {
 	temporary: false,
 }}
 
-// Test that url.Error implements net.Error and that it forwards
+// Test that base_url.Error implements net.Error and that it forwards
 func TestURLErrorImplementsNetError(t *testing.T) {
 	for i, tt := range netErrorTests {
 		err, ok := tt.err.(net.Error)
@@ -2009,7 +2003,7 @@ func TestGob(t *testing.T) {
 		t.Fatal(err)
 	}
 	if u1.String() != u.String() {
-		t.Errorf("json decoded to: %s\nwant: %s\n", u1, u)
+		t.Errorf("gob decoded to: %s\nwant: %s\n", u1, u)
 	}
 }
 

--- a/pkg/urlt/url_test.go
+++ b/pkg/urlt/url_test.go
@@ -677,7 +677,7 @@ func BenchmarkString(b *testing.B) {
 		b.StartTimer()
 		var g string
 		for i := 0; i < b.N; i++ {
-			g = u.String()
+			g = URL_String(u)
 		}
 		b.StopTimer()
 		if w := tt.roundtrip; b.N > 0 && g != w {
@@ -830,14 +830,14 @@ func TestURLString(t *testing.T) {
 		if tt.roundtrip != "" {
 			expected = tt.roundtrip
 		}
-		s := u.String()
+		s := URL_String(u)
 		if s != expected {
 			t.Errorf("Parse(%q).String() == %q (expected %q)", tt.in, s, expected)
 		}
 	}
 
 	for _, tt := range stringURLTests {
-		if got := tt.url.String(); got != tt.want {
+		if got := URL_String(&tt.url); got != tt.want {
 			t.Errorf("%+v.String() = %q; want %q", tt.url, got, tt.want)
 		}
 	}
@@ -1338,31 +1338,31 @@ func TestResolveReference(t *testing.T) {
 	for _, test := range resolveReferenceTests {
 		base := mustParse(test.base)
 		rel := mustParse(test.rel)
-		url := base.ResolveReference(rel)
-		if got := url.String(); got != test.expected {
+		url := URL_ResolveReference(base, rel)
+		if got := URL_String(url); got != test.expected {
 			t.Errorf("URL(%q).ResolveReference(%q)\ngot  %q\nwant %q", test.base, test.rel, got, test.expected)
 		}
 		// Ensure that new instances are returned.
 		if base == url {
-			t.Errorf("Expected URL.ResolveReference to return new URL instance.")
+			t.Errorf("Expected URL_ResolveReference to return new URL instance.")
 		}
 		// Test the convenience wrapper too.
-		url, err := base.Parse(test.rel)
+		url, err := URL_Parse(base, test.rel)
 		if err != nil {
 			t.Errorf("URL(%q).Parse(%q) failed: %v", test.base, test.rel, err)
-		} else if got := url.String(); got != test.expected {
+		} else if got := URL_String(url); got != test.expected {
 			t.Errorf("URL(%q).Parse(%q)\ngot  %q\nwant %q", test.base, test.rel, got, test.expected)
 		} else if base == url {
 			// Ensure that new instances are returned for the wrapper too.
-			t.Errorf("Expected URL.Parse to return new URL instance.")
+			t.Errorf("Expected URL_Parse to return new URL instance.")
 		}
 		// Ensure Opaque resets the URL.
-		url = base.ResolveReference(opaque)
+		url = URL_ResolveReference(base, opaque)
 		if *url != *opaque {
 			t.Errorf("ResolveReference failed to resolve opaque URL:\ngot  %#v\nwant %#v", url, opaque)
 		}
 		// Test the convenience wrapper with an opaque URL too.
-		url, err = base.Parse("scheme:opaque")
+		url, err = URL_Parse(base, "scheme:opaque")
 		if err != nil {
 			t.Errorf(`URL(%q).Parse("scheme:opaque") failed: %v`, test.base, err)
 		} else if *url != *opaque {
@@ -1376,7 +1376,7 @@ func TestResolveReference(t *testing.T) {
 
 func TestQueryValues(t *testing.T) {
 	u, _ := Parse("http://x.com?foo=bar&bar=1&bar=2&baz")
-	v := u.Query()
+	v := URL_Query(u)
 	if len(v) != 3 {
 		t.Errorf("got %d keys in Query values, want 3", len(v))
 	}
@@ -1663,7 +1663,7 @@ var requritests = []RequestURITest{
 
 func TestRequestURI(t *testing.T) {
 	for _, tt := range requritests {
-		s := tt.url.RequestURI()
+		s := URL_RequestURI(tt.url)
 		if s != tt.out {
 			t.Errorf("%#v.RequestURI() == %q (expected %q)", tt.url, s, tt.out)
 		}
@@ -1753,7 +1753,7 @@ func TestStarRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := u.RequestURI(), "*"; got != want {
+	if got, want := URL_RequestURI(u), "*"; got != want {
 		t.Errorf("RequestURI = %q; want %q", got, want)
 	}
 }
@@ -1943,7 +1943,7 @@ func TestURLHostnameAndPort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		u := &URL{Host: tt.in}
-		host, port := u.Hostname(), u.Port()
+		host, port := URL_Hostname(u), URL_Port(u)
 		if host != tt.host {
 			t.Errorf("Hostname for Host %q = %q; want %q", tt.in, host, tt.host)
 		}
@@ -1954,9 +1954,9 @@ func TestURLHostnameAndPort(t *testing.T) {
 }
 
 var (
-	_ encodingPkg.BinaryMarshaler   = (*URL)(nil)
-	_ encodingPkg.BinaryUnmarshaler = (*URL)(nil)
-	_ encodingPkg.BinaryAppender    = (*URL)(nil)
+	_ encodingPkg.BinaryMarshaler   = (*URLT)(nil)
+	_ encodingPkg.BinaryUnmarshaler = (*URLT)(nil)
+	_ encodingPkg.BinaryAppender    = (*URLT)(nil)
 )
 
 func TestJSON(t *testing.T) {
@@ -1976,13 +1976,13 @@ func TestJSON(t *testing.T) {
 	// 	t.Errorf("json encoding: %s\nwant: %s\n", js, strconv.Quote(u.String()))
 	// }
 
-	u1 := new(URL)
+	u1 := new(URLT)
 	err = json.Unmarshal(js, u1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if u1.String() != u.String() {
-		t.Errorf("json decoded to: %s\nwant: %s\n", u1, u)
+	if URL_String(u1) != URL_String(u) {
+		t.Errorf("json decoded to: %s\nwant: %s\n", URL_String(u1), URL_String(u))
 	}
 }
 
@@ -1997,13 +1997,13 @@ func TestGob(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	u1 := new(URL)
+	u1 := new(URLT)
 	err = gob.NewDecoder(&w).Decode(u1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if u1.String() != u.String() {
-		t.Errorf("gob decoded to: %s\nwant: %s\n", u1, u)
+	if URL_String(u1) != URL_String(u) {
+		t.Errorf("gob decoded to: %s\nwant: %s\n", URL_String(u1), URL_String(u))
 	}
 }
 
@@ -2304,7 +2304,7 @@ func TestJoinPath(t *testing.T) {
 			// URL.JoinPath doesn't return an error, so leave it unchanged
 			tt.out = tt.base
 		}
-		out = u.JoinPath(tt.elem...).String()
+		out = URL_String(URL_JoinPath(u, tt.elem...))
 		if out != tt.out {
 			t.Errorf("Parse(%q).JoinPath(%q) = %q, want %q", tt.base, tt.elem, out, tt.out)
 		}

--- a/pkg/urlt/url_test.go
+++ b/pkg/urlt/url_test.go
@@ -902,7 +902,7 @@ func TestURLRedacted(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			if g, w := tt.url.Redacted(), tt.want; g != w {
+			if g, w := Redacted(tt.url), tt.want; g != w {
 				t.Fatalf("got: %q\nwant: %q", g, w)
 			}
 		})

--- a/pkg/urlt/url_test.go
+++ b/pkg/urlt/url_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 )
 
+type URL = base_url.URL
+
 type URLTest struct {
 	in        string
 	out       *URL   // expected parse
@@ -1981,8 +1983,8 @@ func TestJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if URL_String((*base_url.URL)(u1)) != URL_String(u) {
-		t.Errorf("json decoded to: %s\nwant: %s\n", URL_String((*base_url.URL)(u1)), URL_String(u))
+	if URL_String((*URL)(u1)) != URL_String(u) {
+		t.Errorf("json decoded to: %s\nwant: %s\n", URL_String((*URL)(u1)), URL_String(u))
 	}
 }
 
@@ -2002,8 +2004,8 @@ func TestGob(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if URL_String((*base_url.URL)(u1)) != URL_String(u) {
-		t.Errorf("gob decoded to: %s\nwant: %s\n", URL_String((*base_url.URL)(u1)), URL_String(u))
+	if URL_String((*URL)(u1)) != URL_String(u) {
+		t.Errorf("gob decoded to: %s\nwant: %s\n", URL_String((*URL)(u1)), URL_String(u))
 	}
 }
 

--- a/pkg/urlt/url_test.go
+++ b/pkg/urlt/url_test.go
@@ -1118,21 +1118,21 @@ func TestPathEscape(t *testing.T) {
 //}
 
 type EncodeQueryTest struct {
-	m        Values
+	m        base_url.Values
 	expected string
 }
 
 var encodeQueryTests = []EncodeQueryTest{
 	{nil, ""},
-	{Values{}, ""},
-	{Values{"q": {"puppies"}, "oe": {"utf8"}}, "oe=utf8&q=puppies"},
-	{Values{"q": {"dogs", "&", "7"}}, "q=dogs&q=%26&q=7"},
-	{Values{
+	{base_url.Values{}, ""},
+	{base_url.Values{"q": {"puppies"}, "oe": {"utf8"}}, "oe=utf8&q=puppies"},
+	{base_url.Values{"q": {"dogs", "&", "7"}}, "q=dogs&q=%26&q=7"},
+	{base_url.Values{
 		"a": {"a1", "a2", "a3"},
 		"b": {"b1", "b2", "b3"},
 		"c": {"c1", "c2", "c3"},
 	}, "a=a1&a=a2&a=a3&b=b1&b=b2&b=b3&c=c1&c=c2&c=c3"},
-	{Values{
+	{base_url.Values{
 		"a": {"a"},
 		"b": {"b"},
 		"c": {"c"},
@@ -1419,94 +1419,94 @@ func TestQueryValues(t *testing.T) {
 
 type parseTest struct {
 	query string
-	out   Values
+	out   base_url.Values
 	ok    bool
 }
 
 var parseTests = []parseTest{
 	{
 		query: "a=1",
-		out:   Values{"a": []string{"1"}},
+		out:   base_url.Values{"a": []string{"1"}},
 		ok:    true,
 	},
 	{
 		query: "a=1&b=2",
-		out:   Values{"a": []string{"1"}, "b": []string{"2"}},
+		out:   base_url.Values{"a": []string{"1"}, "b": []string{"2"}},
 		ok:    true,
 	},
 	{
 		query: "a=1&a=2&a=banana",
-		out:   Values{"a": []string{"1", "2", "banana"}},
+		out:   base_url.Values{"a": []string{"1", "2", "banana"}},
 		ok:    true,
 	},
 	{
 		query: "ascii=%3Ckey%3A+0x90%3E",
-		out:   Values{"ascii": []string{"<key: 0x90>"}},
+		out:   base_url.Values{"ascii": []string{"<key: 0x90>"}},
 		ok:    true,
 	},
 	{
 		query: "a=1;b=2",
-		out:   Values{},
+		out:   base_url.Values{},
 		ok:    false,
 	},
 	{
 		query: "a;b=1",
-		out:   Values{},
+		out:   base_url.Values{},
 		ok:    false,
 	},
 	{
 		query: "a=%3B", // hex encoding for semicolon
-		out:   Values{"a": []string{";"}},
+		out:   base_url.Values{"a": []string{";"}},
 		ok:    true,
 	},
 	{
 		query: "a%3Bb=1",
-		out:   Values{"a;b": []string{"1"}},
+		out:   base_url.Values{"a;b": []string{"1"}},
 		ok:    true,
 	},
 	{
 		query: "a=1&a=2;a=banana",
-		out:   Values{"a": []string{"1"}},
+		out:   base_url.Values{"a": []string{"1"}},
 		ok:    false,
 	},
 	{
 		query: "a;b&c=1",
-		out:   Values{"c": []string{"1"}},
+		out:   base_url.Values{"c": []string{"1"}},
 		ok:    false,
 	},
 	{
 		query: "a=1&b=2;a=3&c=4",
-		out:   Values{"a": []string{"1"}, "c": []string{"4"}},
+		out:   base_url.Values{"a": []string{"1"}, "c": []string{"4"}},
 		ok:    false,
 	},
 	{
 		query: "a=1&b=2;c=3",
-		out:   Values{"a": []string{"1"}},
+		out:   base_url.Values{"a": []string{"1"}},
 		ok:    false,
 	},
 	{
 		query: ";",
-		out:   Values{},
+		out:   base_url.Values{},
 		ok:    false,
 	},
 	{
 		query: "a=1;",
-		out:   Values{},
+		out:   base_url.Values{},
 		ok:    false,
 	},
 	{
 		query: "a=1&;",
-		out:   Values{"a": []string{"1"}},
+		out:   base_url.Values{"a": []string{"1"}},
 		ok:    false,
 	},
 	{
 		query: ";a=1&b=2",
-		out:   Values{"b": []string{"2"}},
+		out:   base_url.Values{"b": []string{"2"}},
 		ok:    false,
 	},
 	{
 		query: "a=1&b=2;",
-		out:   Values{"a": []string{"1"}},
+		out:   base_url.Values{"a": []string{"1"}},
 		ok:    false,
 	},
 }

--- a/pkg/urlt/url_test.go
+++ b/pkg/urlt/url_test.go
@@ -72,7 +72,7 @@ var urltests = []URLTest{
 		"ftp://webmaster@www.google.com/",
 		&URL{
 			Scheme: "ftp",
-			User:   User("webmaster"),
+			User:   base_url.User("webmaster"),
 			Host:   "www.google.com",
 			Path:   "/",
 		},
@@ -83,7 +83,7 @@ var urltests = []URLTest{
 		"ftp://john%20doe@www.google.com/",
 		&URL{
 			Scheme: "ftp",
-			User:   User("john doe"),
+			User:   base_url.User("john doe"),
 			Host:   "www.google.com",
 			Path:   "/",
 		},
@@ -204,7 +204,7 @@ var urltests = []URLTest{
 	{
 		"//user@foo/path?a=b",
 		&URL{
-			User:     User("user"),
+			User:     base_url.User("user"),
 			Host:     "foo",
 			Path:     "/path",
 			RawQuery: "a=b",
@@ -227,7 +227,7 @@ var urltests = []URLTest{
 		"http://user:password@google.com",
 		&URL{
 			Scheme: "http",
-			User:   UserPassword("user", "password"),
+			User:   base_url.UserPassword("user", "password"),
 			Host:   "google.com",
 		},
 		"http://user:password@google.com",
@@ -237,7 +237,7 @@ var urltests = []URLTest{
 		"http://j@ne:password@google.com",
 		&URL{
 			Scheme: "http",
-			User:   UserPassword("j@ne", "password"),
+			User:   base_url.UserPassword("j@ne", "password"),
 			Host:   "google.com",
 		},
 		"http://j%40ne:password@google.com",
@@ -247,7 +247,7 @@ var urltests = []URLTest{
 		"http://jane:p@ssword@google.com",
 		&URL{
 			Scheme: "http",
-			User:   UserPassword("jane", "p@ssword"),
+			User:   base_url.UserPassword("jane", "p@ssword"),
 			Host:   "google.com",
 		},
 		"http://jane:p%40ssword@google.com",
@@ -256,7 +256,7 @@ var urltests = []URLTest{
 		"http://j@ne:password@google.com/p@th?q=@go",
 		&URL{
 			Scheme:   "http",
-			User:     UserPassword("j@ne", "password"),
+			User:     base_url.UserPassword("j@ne", "password"),
 			Host:     "google.com",
 			Path:     "/p@th",
 			RawQuery: "q=@go",
@@ -339,7 +339,7 @@ var urltests = []URLTest{
 		"http://%3Fam:pa%3Fsword@google.com",
 		&URL{
 			Scheme: "http",
-			User:   UserPassword("?am", "pa?sword"),
+			User:   base_url.UserPassword("?am", "pa?sword"),
 			Host:   "google.com",
 		},
 		"",
@@ -631,7 +631,7 @@ var urltests = []URLTest{
 		"mongodb://user:password@host1:1,host2:2,host3:3",
 		&URL{
 			Scheme: "mongodb",
-			User:   UserPassword("user", "password"),
+			User:   base_url.UserPassword("user", "password"),
 			Host:   "host1:1,host2:2,host3:3",
 			Path:   "",
 		},
@@ -641,7 +641,7 @@ var urltests = []URLTest{
 		"mongodb+srv://user:password@host1:1,host2:2,host3:3",
 		&URL{
 			Scheme: "mongodb+srv",
-			User:   UserPassword("user", "password"),
+			User:   base_url.UserPassword("user", "password"),
 			Host:   "host1:1,host2:2,host3:3",
 			Path:   "",
 		},
@@ -855,7 +855,7 @@ func TestURLRedacted(t *testing.T) {
 				Scheme: "http",
 				Host:   "host.tld",
 				Path:   "this:that",
-				User:   UserPassword("user", "password"),
+				User:   base_url.UserPassword("user", "password"),
 			},
 			want: "http://user:xxxxx@host.tld/this:that",
 		},
@@ -865,7 +865,7 @@ func TestURLRedacted(t *testing.T) {
 				Scheme: "http",
 				Host:   "host.tld",
 				Path:   "this:that",
-				User:   User("user"),
+				User:   base_url.User("user"),
 			},
 			want: "http://user@host.tld/this:that",
 		},
@@ -875,7 +875,7 @@ func TestURLRedacted(t *testing.T) {
 				Scheme: "http",
 				Host:   "host.tld",
 				Path:   "this:that",
-				User:   UserPassword("", "password"),
+				User:   base_url.UserPassword("", "password"),
 			},
 			want: "http://:xxxxx@host.tld/this:that",
 		},


### PR DESCRIPTION
## Summary

- Removed the custom `URL`, `Userinfo`, and `Values` types; the package now operates directly on `*net/url.URL`, `net/url.Userinfo`, and `net/url.Values`
- Converted all `URL` methods to standalone package-level functions with a `URL_` prefix (`URL_String`, `URL_EscapedPath`, `URL_EscapedFragment`, `URL_Query`, `URL_RequestURI`, `URL_Hostname`, `URL_Port`, `URL_JoinPath`, `URL_Parse`, `URL_ResolveReference`, `Redacted`, `Encode`)
- Removed custom error types (`Error`, `EscapeError`, `InvalidHostError`); errors are now returned as their `net/url` equivalents
- Added `URLT` — a defined type over `net/url.URL` with `MarshalBinary`/`UnmarshalBinary` using `URL_String`/`Parse`
- Removed `URL.IsAbs()` and `godebug`-gated behaviour
- Updated package doc comment and README to describe the current API and differences from `net/url`

## Test plan

- [ ] `go test ./pkg/urlt/...` passes
- [ ] No callers of the old method-based API remain broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)