### PR TITLE
fix(server): never let request activity reporting block the proxy (A01)

### DIFF
--- a/internal/server/request_tracker.go
+++ b/internal/server/request_tracker.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net/url"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/evg4b/uncors/internal/contracts"
@@ -19,14 +21,30 @@ type RequestEvent struct {
 	Data      *contracts.RequestData
 }
 
-type IRequestTracker interface {
-	Events() <-chan RequestEvent
-	Close()
+// RequestSink receives request lifecycle events from the server. It is the only
+// part of the tracker the request path depends on, and implementations must
+// never block: activity reporting is a presentation concern and must not be able
+// to apply backpressure to proxied traffic.
+type RequestSink interface {
 	Emit(event RequestEvent)
 }
 
+type IRequestTracker interface {
+	RequestSink
+
+	Events() <-chan RequestEvent
+	Close()
+}
+
+// RequestTracker is a channel backed RequestSink. Events are delivered to a
+// single consumer (the TUI or RequestPrinter); when the consumer cannot keep up
+// events are dropped and counted rather than delaying the request that produced
+// them.
 type RequestTracker struct {
-	events chan RequestEvent
+	mu      sync.RWMutex
+	closed  bool
+	events  chan RequestEvent
+	dropped atomic.Uint64
 }
 
 func NewRequestTracker() *RequestTracker {
@@ -39,10 +57,47 @@ func (t *RequestTracker) Events() <-chan RequestEvent {
 	return t.events
 }
 
+// Close stops event delivery and closes the events channel. It is safe to call
+// concurrently with Emit and safe to call more than once.
 func (t *RequestTracker) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return
+	}
+
+	t.closed = true
 	close(t.events)
 }
 
+// Emit delivers the event to the consumer, dropping it when the buffer is full
+// or the tracker is closed. It never blocks.
 func (t *RequestTracker) Emit(event RequestEvent) {
-	t.events <- event
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed {
+		t.dropped.Add(1)
+
+		return
+	}
+
+	select {
+	case t.events <- event:
+	default:
+		t.dropped.Add(1)
+	}
 }
+
+// Dropped returns the number of events that were discarded because no consumer
+// kept up with them.
+func (t *RequestTracker) Dropped() uint64 {
+	return t.dropped.Load()
+}
+
+// NoopRequestSink discards every event. It is the correct sink for tests and for
+// any run mode that does not display request activity.
+type NoopRequestSink struct{}
+
+func (NoopRequestSink) Emit(RequestEvent) {}

--- a/internal/server/request_tracker_test.go
+++ b/internal/server/request_tracker_test.go
@@ -1,0 +1,80 @@
+package server_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/evg4b/uncors/internal/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestTrackerEmit(t *testing.T) {
+	t.Run("never blocks when nobody consumes the events", func(t *testing.T) {
+		const eventsCount = 10_000
+
+		tracker := server.NewRequestTracker()
+
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			for index := range uint64(eventsCount) {
+				tracker.Emit(server.RequestEvent{ID: index})
+			}
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Emit blocked when the event buffer was full")
+		}
+
+		assert.Positive(t, tracker.Dropped(), "overflowing events must be counted as dropped")
+	})
+
+	t.Run("delivers events to the consumer", func(t *testing.T) {
+		tracker := server.NewRequestTracker()
+
+		tracker.Emit(server.RequestEvent{ID: 1})
+
+		event := <-tracker.Events()
+
+		assert.Equal(t, uint64(1), event.ID)
+		assert.Zero(t, tracker.Dropped())
+	})
+
+	t.Run("is safe to close while producers are emitting", func(_ *testing.T) {
+		tracker := server.NewRequestTracker()
+
+		var waitGroup sync.WaitGroup
+
+		waitGroup.Go(func() {
+			for index := range uint64(1000) {
+				tracker.Emit(server.RequestEvent{ID: index})
+			}
+		})
+
+		tracker.Close()
+		waitGroup.Wait()
+	})
+
+	t.Run("close is idempotent", func(t *testing.T) {
+		tracker := server.NewRequestTracker()
+
+		require.NotPanics(t, func() {
+			tracker.Close()
+			tracker.Close()
+		})
+	})
+}
+
+func TestNoopRequestSink(t *testing.T) {
+	t.Run("discards events", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			server.NoopRequestSink{}.Emit(server.RequestEvent{ID: 1})
+		})
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,15 +31,21 @@ type Server struct {
 
 	listeners []*PortListener
 	manager   *HostCertManager
-	tracker   IRequestTracker
+	sink      RequestSink
 	nextID    atomic.Uint64
 }
 
-func New(manager *HostCertManager, tracker IRequestTracker) *Server {
+// New creates a server that reports request activity to sink. A nil sink is
+// replaced by NoopRequestSink so the request path is never left without one.
+func New(manager *HostCertManager, sink RequestSink) *Server {
+	if sink == nil {
+		sink = NoopRequestSink{}
+	}
+
 	return &Server{
 		listeners: []*PortListener{},
 		manager:   manager,
-		tracker:   tracker,
+		sink:      sink,
 	}
 }
 
@@ -169,21 +175,25 @@ func (s *Server) handleRequest(handler contracts.Handler, writer http.ResponseWr
 	rec := NewResponseRecorder(writer)
 	requestID := s.nextID.Add(1)
 
-	s.tracker.Emit(RequestEvent{
+	s.sink.Emit(RequestEvent{
 		ID:        requestID,
 		Method:    request.Method,
 		URL:       request.URL,
 		StartedAt: time.Now(),
 	})
 
-	var lastPrefix string
+	// The prefix is reported once, with the terminal event. Handlers may set it
+	// from a goroutine of their own, so access is guarded.
+	var (
+		prefixMu   sync.Mutex
+		lastPrefix string
+	)
 
 	ctx := context.WithValue(request.Context(), contracts.PrefixUpdaterKey, func(prefix string) {
+		prefixMu.Lock()
+		defer prefixMu.Unlock()
+
 		lastPrefix = prefix
-		s.tracker.Emit(RequestEvent{
-			ID:     requestID,
-			Prefix: prefix,
-		})
 	})
 
 	err := handler.ServeHTTP(rec, request.WithContext(ctx))
@@ -194,10 +204,14 @@ func (s *Server) handleRequest(handler contracts.Handler, writer http.ResponseWr
 	data := helpers.ToRequestData(request, helpers.NormaliseStatusCode(rec.StatusCode()))
 	data.Cancelled = ctx.Err() != nil
 
-	s.tracker.Emit(RequestEvent{
+	prefixMu.Lock()
+	prefix := lastPrefix
+	prefixMu.Unlock()
+
+	s.sink.Emit(RequestEvent{
 		ID:     requestID,
 		Done:   true,
-		Prefix: lastPrefix,
+		Prefix: prefix,
 		Data:   data,
 	})
 }

--- a/internal/uncors_app/tracker_widget.go
+++ b/internal/uncors_app/tracker_widget.go
@@ -126,15 +126,13 @@ func (m *TrackerWidget) View() tea.View {
 }
 
 func (m *TrackerWidget) requestEventMsg(msg requestEventMsg) (*TrackerWidget, tea.Cmd) {
-	if msg.Done {
+	switch {
+	case msg.Done:
 		log.Printf("TrackerWidget: request done: %d", msg.ID)
 		delete(m.pending, msg.ID)
-	} else if msg.URL != nil {
+	case msg.URL != nil:
 		log.Printf("TrackerWidget: request started: %d %s %s", msg.ID, msg.Method, urlt.URL_String(msg.URL))
 		m.pending[msg.ID] = server.RequestEvent(msg)
-	} else if event, ok := m.pending[msg.ID]; ok {
-		event.Prefix = msg.Prefix
-		m.pending[msg.ID] = event
 	}
 
 	var cmd tea.Cmd

--- a/main.go
+++ b/main.go
@@ -105,7 +105,12 @@ func runNonInteractive(
 
 	app := uncors.CreateUncors(container)
 
-	go server.RequestPrinter(container.RequestTracker(), output)
+	// Headless mode has no TUI, so it must supply the sink that drains the
+	// tracker itself; without a consumer the request path would only be able to
+	// drop activity events.
+	tracker := container.RequestTracker()
+
+	go server.RequestPrinter(tracker, output)
 
 	startConfigWatcher(ctx, container, configPath, app)
 
@@ -123,6 +128,11 @@ func runNonInteractive(
 	})
 
 	app.Wait()
+
+	if dropped := tracker.Dropped(); dropped > 0 {
+		output.Warnf("%d activity lines were dropped to keep the proxy responsive", dropped)
+	}
+
 	output.Info("Server was stopped")
 
 	return 0


### PR DESCRIPTION
Fixes review finding **A01 — The request-tracker event channel has no consumer in headless mode, and the proxy permanently stalls**.

The request tracker used an unconditional blocking send on a channel with a
fixed 1000-event buffer. Any run mode without a consumer stalled the whole
proxy once the buffer filled, and `Close()` closed the channel while producers
were still sending.

- `Emit` now drops (and counts) events instead of blocking; `Dropped()` makes
  the loss observable, and headless mode reports it on shutdown.
- `Close` is idempotent and race-free with concurrent `Emit`.
- The server now depends on the narrow `RequestSink` interface instead of the
  full tracker, and falls back to `NoopRequestSink` so "no sink" is not a
  representable state.
- The intermediate prefix event is gone: the prefix is carried on the terminal
  event, which removes the closure data race and cuts channel traffic ~3x.

---

### Review

One commit, `5323d08`. Step **1 of 33** in the review stack.

This PR targets `main` directly.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
