### PR TITLE
fix(di): scope config-derived resources to a configuration generation (A02)

### DIFF
--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/evg4b/uncors/internal/commands"
-	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/helpers"
 	"github.com/evg4b/uncors/internal/server"
@@ -22,7 +21,6 @@ type Container struct {
 	generateCertsCommand factory[*commands.GenerateCertsCommand]
 	hostCertManager      factory[*server.HostCertManager]
 	server               factory[*server.Server]
-	cache                factory1[contracts.Cache, *config.CacheConfig]
 
 	closers []io.Closer
 }
@@ -62,7 +60,6 @@ func NewContainer(options ...ContainerOption) *Container {
 	container.generateCertsCommand = newFactory(container.newGenerateCertsCommand)
 	container.hostCertManager = newFactory(container.newHostCertManager)
 	container.server = newFactory(container.newServer)
-	container.cache = newFactory1(container.newCache)
 
 	return container
 }

--- a/internal/di/factories.go
+++ b/internal/di/factories.go
@@ -2,9 +2,7 @@ package di
 
 import (
 	"github.com/evg4b/uncors/internal/commands"
-	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/contracts"
-	"github.com/evg4b/uncors/internal/handler/cache"
 	"github.com/evg4b/uncors/internal/server"
 	"github.com/evg4b/uncors/internal/tui"
 )
@@ -30,11 +28,4 @@ func (c *Container) newCliOutput() contracts.Output {
 
 func (c *Container) newServer() *server.Server {
 	return server.New(c.HostCertManager(), c.RequestTracker())
-}
-
-func (c *Container) newCache(cfs *config.CacheConfig) contracts.Cache {
-	instance := cache.NewRistrettoCache(cfs.MaxSize, cfs.ExpirationTime)
-	c.closers = append(c.closers, instance)
-
-	return instance
 }

--- a/internal/di/factory.go
+++ b/internal/di/factory.go
@@ -20,22 +20,3 @@ func (f *factory[T]) GetOrBuild() T {
 func newFactory[T any](factoryFunc func() T) factory[T] {
 	return factory[T]{factory: factoryFunc}
 }
-
-type factory1[T any, D comparable] struct {
-	once sync.Once
-
-	cache   T
-	factory func(arg D) T
-}
-
-func (f *factory1[T, D]) GetOrBuild(arg D) T {
-	f.once.Do(func() {
-		f.cache = f.factory(arg)
-	})
-
-	return f.cache
-}
-
-func newFactory1[T any, D comparable](factoryFunc func(arg D) T) factory1[T, D] {
-	return factory1[T, D]{factory: factoryFunc}
-}

--- a/internal/di/public_api.go
+++ b/internal/di/public_api.go
@@ -7,13 +7,10 @@ import (
 	"github.com/evg4b/uncors/internal/commands"
 	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/contracts"
-	"github.com/evg4b/uncors/internal/handler/cache"
-	"github.com/evg4b/uncors/internal/handler/har"
 	"github.com/evg4b/uncors/internal/handler/mock"
 	"github.com/evg4b/uncors/internal/handler/options"
 	"github.com/evg4b/uncors/internal/handler/proxy"
 	"github.com/evg4b/uncors/internal/handler/rewrite"
-	"github.com/evg4b/uncors/internal/handler/router"
 	"github.com/evg4b/uncors/internal/handler/script"
 	"github.com/evg4b/uncors/internal/handler/static"
 	"github.com/evg4b/uncors/internal/infra"
@@ -81,21 +78,6 @@ func (c *Container) VersionChecker(proxy string) *version.Checker {
 	)
 }
 
-func (c *Container) Cache(cfs *config.CacheConfig) contracts.Cache {
-	return c.cache.GetOrBuild(cfs)
-}
-
-func (c *Container) CacheMiddleware(cfg *config.CacheConfig, globs config.CacheGlobs) contracts.Middleware {
-	return infra.NewPrefixedMiddleware(
-		cache.NewMiddleware(
-			cache.WithMethods(cfg.Methods),
-			cache.WithCacheStorage(c.Cache(cfg)),
-			cache.WithGlobs(globs),
-		),
-		styles.CacheStyle.Render("CACHE"),
-	)
-}
-
 func (c *Container) MockHandler(response *config.Response) contracts.Handler {
 	prefix := styles.MockStyle.Render("MOCK")
 
@@ -124,16 +106,6 @@ func (c *Container) RewriteMiddleware(rewriting *config.RewritingOption) contrac
 	)
 }
 
-func (c *Container) HARMiddleware(harConfig *config.HARConfig) contracts.Middleware {
-	w := har.NewWriter(harConfig.File)
-	c.closers = append(c.closers, w)
-
-	return har.NewMiddleware(
-		har.WithWriter(w),
-		har.WithCaptureSecureHeaders(harConfig.CaptureSecureHeaders),
-	)
-}
-
 func (c *Container) ProxyHandler(mappings config.Mappings, proxyURL string) contracts.Handler {
 	prefix := styles.ProxyStyle.Render("PROXY")
 	output := c.CliOutput()
@@ -143,21 +115,4 @@ func (c *Container) ProxyHandler(mappings config.Mappings, proxyURL string) cont
 		proxy.WithHTTPClient(infra.MakeHTTPClient(proxyURL)),
 		proxy.WithOutput(output.NewPrefixOutput(prefix)),
 	))
-}
-
-func (c *Container) Router(
-	mappings config.Mappings,
-	cacheConfig *config.CacheConfig,
-	proxyURL string,
-) (contracts.Handler, error) {
-	router, err := router.NewRouter(
-		mappings,
-		router.WithDiContainer(c),
-		router.ForRouterWithDefaultHandler(c.ProxyHandler(mappings, proxyURL)),
-		router.ForRouterWithCacheMiddlewareFactory(func(globs config.CacheGlobs) contracts.Middleware {
-			return c.CacheMiddleware(cacheConfig, globs)
-		}),
-	)
-
-	return infra.CastToContractsHandler(router), err
 }

--- a/internal/di/public_api_test.go
+++ b/internal/di/public_api_test.go
@@ -3,7 +3,6 @@ package di_test
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/evg4b/uncors/internal/commands"
 	"github.com/evg4b/uncors/internal/config"
@@ -126,30 +125,6 @@ func TestContainer(t *testing.T) {
 		assert.IsType(t, &version.Checker{}, checker)
 	})
 
-	t.Run("cache", func(t *testing.T) {
-		cfg := &config.CacheConfig{MaxSize: 100, ExpirationTime: time.Minute}
-		c := container.Cache(cfg)
-
-		assert.NotNil(t, c)
-		assert.Implements(t, (*contracts.Cache)(nil), c)
-	})
-
-	t.Run("cache singleton", func(t *testing.T) {
-		cfg := &config.CacheConfig{MaxSize: 100, ExpirationTime: time.Minute}
-		c1 := container.Cache(cfg)
-		c2 := container.Cache(cfg)
-
-		assert.Same(t, c1, c2)
-	})
-
-	t.Run("cache middleware", func(t *testing.T) {
-		cfg := &config.CacheConfig{MaxSize: 100, ExpirationTime: time.Minute}
-		middleware := container.CacheMiddleware(cfg, config.CacheGlobs{"*.json"})
-
-		assert.NotNil(t, middleware)
-		assert.Implements(t, (*contracts.Middleware)(nil), middleware)
-	})
-
 	t.Run("mock handler", func(t *testing.T) {
 		response := &config.Response{Code: 200, Raw: "ok"}
 		handler := container.MockHandler(response)
@@ -177,14 +152,6 @@ func TestContainer(t *testing.T) {
 		assert.Implements(t, (*contracts.Middleware)(nil), middleware)
 	})
 
-	t.Run("HAR middleware", func(t *testing.T) {
-		harConfig := &config.HARConfig{File: "/tmp/test.har"}
-		middleware := container.HARMiddleware(harConfig)
-
-		assert.NotNil(t, middleware)
-		assert.Implements(t, (*contracts.Middleware)(nil), middleware)
-	})
-
 	t.Run("proxy handler", func(t *testing.T) {
 		mappings := config.Mappings{
 			{From: hosts.Localhost.HTTP(), To: hosts.Localhost.HTTPS()},
@@ -193,41 +160,6 @@ func TestContainer(t *testing.T) {
 
 		assert.NotNil(t, handler)
 		assert.Implements(t, (*contracts.Handler)(nil), handler)
-	})
-
-	t.Run("router", func(t *testing.T) {
-		mappings := config.Mappings{
-			{From: hosts.Localhost.HTTP(), To: hosts.Localhost.HTTPS()},
-		}
-		handler, err := container.Router(mappings, &config.CacheConfig{MaxSize: 100, ExpirationTime: time.Minute}, "")
-
-		require.NoError(t, err)
-		assert.NotNil(t, handler)
-		assert.Implements(t, (*contracts.Handler)(nil), handler)
-	})
-
-	t.Run("router with cache globs invokes cache middleware factory", func(t *testing.T) {
-		cacheContainer := di.NewContainer()
-		defer testutils.Close(t, cacheContainer)
-
-		mappings := config.Mappings{
-			{
-				From:  hosts.Localhost.HTTP(),
-				To:    hosts.Localhost.HTTPS(),
-				Cache: config.CacheGlobs{"*.json"},
-				Mocks: config.Mocks{
-					{
-						Matcher:  config.RequestMatcher{Path: "/data.json"},
-						Response: config.Response{Code: 200, Raw: "{}"},
-					},
-				},
-			},
-		}
-
-		handler, err := cacheContainer.Router(mappings, &config.CacheConfig{MaxSize: 100, ExpirationTime: time.Minute}, "")
-
-		require.NoError(t, err)
-		assert.NotNil(t, handler)
 	})
 
 	t.Run("singleton behavior", func(t *testing.T) {
@@ -289,25 +221,6 @@ func TestContainerOverride(t *testing.T) {
 func TestContainerClose(t *testing.T) {
 	t.Run("close with no closers succeeds", func(t *testing.T) {
 		container := di.NewContainer()
-		err := container.Close()
-
-		require.NoError(t, err)
-	})
-
-	t.Run("close with cache closer succeeds", func(t *testing.T) {
-		container := di.NewContainer()
-		cfg := &config.CacheConfig{MaxSize: 100, ExpirationTime: time.Minute}
-		_ = container.Cache(cfg)
-
-		err := container.Close()
-
-		require.NoError(t, err)
-	})
-
-	t.Run("close with HAR writer closer succeeds", func(t *testing.T) {
-		container := di.NewContainer()
-		_ = container.HARMiddleware(&config.HARConfig{File: "/test.har"})
-
 		err := container.Close()
 
 		require.NoError(t, err)

--- a/internal/di/runtime.go
+++ b/internal/di/runtime.go
@@ -1,0 +1,170 @@
+package di
+
+import (
+	"errors"
+	"io"
+	"net"
+	"slices"
+	"strconv"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/evg4b/uncors/internal/handler/cache"
+	"github.com/evg4b/uncors/internal/handler/har"
+	"github.com/evg4b/uncors/internal/handler/router"
+	"github.com/evg4b/uncors/internal/infra"
+	"github.com/evg4b/uncors/internal/server"
+	"github.com/evg4b/uncors/internal/tui/styles"
+)
+
+const baseAddress = "127.0.0.1"
+
+// Runtime owns everything derived from a single UncorsConfig: the response
+// cache, the HAR writers, the routers built from the mappings and the server
+// targets that serve them.
+//
+// Those resources have a configuration lifetime, not a process lifetime: a hot
+// reload replaces all of them. Closing a Runtime releases exactly the resources
+// that generation created, which is what keeps reloads from leaking goroutines
+// and from leaving several HAR writers racing over the same file.
+type Runtime struct {
+	container   *Container
+	cacheConfig *config.CacheConfig
+	cacheStore  contracts.Cache
+
+	targets []server.Target
+	closers []io.Closer
+}
+
+// BuildRuntime materialises a configuration generation. The caller owns the
+// result and must Close it once the generation stops being current.
+func (c *Container) BuildRuntime(uncorsConfig *config.UncorsConfig) (*Runtime, error) {
+	runtime := &Runtime{
+		container:   c,
+		cacheConfig: &uncorsConfig.CacheConfig,
+	}
+
+	targets, err := runtime.buildTargets(uncorsConfig)
+	if err != nil {
+		return nil, errors.Join(err, runtime.Close())
+	}
+
+	runtime.targets = targets
+
+	return runtime, nil
+}
+
+// Targets returns the server targets this generation should be served on.
+func (r *Runtime) Targets() []server.Target {
+	return r.targets
+}
+
+// Close releases every resource created for this generation, in reverse
+// creation order. It is safe to call more than once.
+func (r *Runtime) Close() error {
+	errs := make([]error, 0, len(r.closers))
+
+	for _, closer := range slices.Backward(r.closers) {
+		err := closer.Close()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	r.closers = nil
+	r.cacheStore = nil
+
+	return errors.Join(errs...)
+}
+
+// Cache lazily creates the response cache for this generation, so that a config
+// without caching never allocates one and a reload always picks up the current
+// cache-config.
+func (r *Runtime) Cache() contracts.Cache {
+	if r.cacheStore == nil {
+		r.cacheStore = register(r, cache.NewRistrettoCache(r.cacheConfig.MaxSize, r.cacheConfig.ExpirationTime))
+	}
+
+	return r.cacheStore
+}
+
+func (r *Runtime) CacheMiddleware(globs config.CacheGlobs) contracts.Middleware {
+	return infra.NewPrefixedMiddleware(
+		cache.NewMiddleware(
+			cache.WithMethods(r.cacheConfig.Methods),
+			cache.WithCacheStorage(r.Cache()),
+			cache.WithGlobs(globs),
+		),
+		styles.CacheStyle.Render("CACHE"),
+	)
+}
+
+func (r *Runtime) HARMiddleware(harConfig *config.HARConfig) contracts.Middleware {
+	writer := register(r, har.NewWriter(harConfig.File))
+
+	return har.NewMiddleware(
+		har.WithWriter(writer),
+		har.WithCaptureSecureHeaders(harConfig.CaptureSecureHeaders),
+	)
+}
+
+func (r *Runtime) StaticMiddleware(path string, dir config.StaticDirectory) contracts.Middleware {
+	return r.container.StaticMiddleware(path, dir)
+}
+
+func (r *Runtime) RewriteMiddleware(rewriting *config.RewritingOption) contracts.Middleware {
+	return r.container.RewriteMiddleware(rewriting)
+}
+
+func (r *Runtime) OptionsMiddleware(cfg config.OptionsHandling) contracts.Middleware {
+	return r.container.OptionsMiddleware(cfg)
+}
+
+func (r *Runtime) MockHandler(response *config.Response) contracts.Handler {
+	return r.container.MockHandler(response)
+}
+
+func (r *Runtime) ScriptHandler(scriptConfig *config.Script) contracts.Handler {
+	return r.container.ScriptHandler(scriptConfig)
+}
+
+func (r *Runtime) buildTargets(uncorsConfig *config.UncorsConfig) ([]server.Target, error) {
+	groupedMappings := uncorsConfig.Mappings.GroupByPort()
+	targets := make([]server.Target, 0, len(groupedMappings))
+	errs := make([]error, 0, len(groupedMappings))
+
+	for _, group := range groupedMappings {
+		handler, err := r.router(group.Mappings, uncorsConfig.Proxy)
+		if err != nil {
+			errs = append(errs, err)
+
+			continue
+		}
+
+		targets = append(targets, server.Target{
+			Address:   net.JoinHostPort(baseAddress, strconv.Itoa(group.Port)),
+			Handler:   handler,
+			EnableTLS: group.Scheme == "https",
+		})
+	}
+
+	return targets, errors.Join(errs...)
+}
+
+func (r *Runtime) router(mappings config.Mappings, proxyURL string) (contracts.Handler, error) {
+	muxRouter, err := router.NewRouter(
+		mappings,
+		router.WithDiContainer(r),
+		router.ForRouterWithDefaultHandler(r.container.ProxyHandler(mappings, proxyURL)),
+		router.ForRouterWithCacheMiddlewareFactory(r.CacheMiddleware),
+	)
+
+	return infra.CastToContractsHandler(muxRouter), err
+}
+
+// register binds a resource to the generation's lifetime.
+func register[T io.Closer](runtime *Runtime, resource T) T {
+	runtime.closers = append(runtime.closers, resource)
+
+	return resource
+}

--- a/internal/di/runtime_test.go
+++ b/internal/di/runtime_test.go
@@ -1,0 +1,113 @@
+package di_test
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/evg4b/uncors/internal/di"
+	"github.com/evg4b/uncors/testing/hosts"
+	"github.com/evg4b/uncors/testing/testutils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func harConfiguration() *config.UncorsConfig {
+	return &config.UncorsConfig{
+		CacheConfig: config.CacheConfig{MaxSize: 100, ExpirationTime: time.Minute},
+		Mappings: config.Mappings{
+			{
+				From:  hosts.Localhost.HTTP(),
+				To:    hosts.Localhost.HTTPS(),
+				Cache: config.CacheGlobs{"*.json"},
+				HAR:   config.HARConfig{File: "/test.har"},
+			},
+		},
+	}
+}
+
+func TestBuildRuntime(t *testing.T) {
+	t.Run("builds a target per port group", func(t *testing.T) {
+		container := di.NewContainer(di.WithFs(afero.NewMemMapFs()))
+		defer testutils.Close(t, container)
+
+		runtime, err := container.BuildRuntime(harConfiguration())
+		require.NoError(t, err)
+
+		defer testutils.Close(t, runtime)
+
+		require.Len(t, runtime.Targets(), 1)
+		assert.NotNil(t, runtime.Targets()[0].Handler)
+	})
+
+	t.Run("cache middleware uses the current cache config", func(t *testing.T) {
+		container := di.NewContainer(di.WithFs(afero.NewMemMapFs()))
+		defer testutils.Close(t, container)
+
+		runtime, err := container.BuildRuntime(harConfiguration())
+		require.NoError(t, err)
+
+		defer testutils.Close(t, runtime)
+
+		assert.Implements(t, (*contracts.Middleware)(nil), runtime.CacheMiddleware(config.CacheGlobs{"*.json"}))
+
+		store := runtime.Cache()
+
+		assert.Same(t, store, runtime.Cache())
+	})
+
+	t.Run("every generation gets its own resources", func(t *testing.T) {
+		container := di.NewContainer(di.WithFs(afero.NewMemMapFs()))
+		defer testutils.Close(t, container)
+
+		first, err := container.BuildRuntime(harConfiguration())
+		require.NoError(t, err)
+
+		second, err := container.BuildRuntime(harConfiguration())
+		require.NoError(t, err)
+
+		assert.NotSame(t, first.Cache(), second.Cache())
+
+		require.NoError(t, first.Close())
+		require.NoError(t, second.Close())
+	})
+
+	t.Run("close is idempotent", func(t *testing.T) {
+		container := di.NewContainer(di.WithFs(afero.NewMemMapFs()))
+		defer testutils.Close(t, container)
+
+		instance, err := container.BuildRuntime(harConfiguration())
+		require.NoError(t, err)
+
+		require.NoError(t, instance.Close())
+		require.NoError(t, instance.Close())
+	})
+
+	// Reloading the config used to leak a HAR writer, its goroutine and a
+	// ristretto instance per reload, with several writers racing over the same
+	// file. Generation scoped resources make the growth bounded.
+	t.Run("repeated reloads do not leak goroutines", func(t *testing.T) {
+		const reloads = 50
+
+		container := di.NewContainer(di.WithFs(afero.NewMemMapFs()))
+		defer testutils.Close(t, container)
+
+		warmUp, err := container.BuildRuntime(harConfiguration())
+		require.NoError(t, err)
+		require.NoError(t, warmUp.Close())
+
+		baseline := runtime.NumGoroutine()
+
+		for range reloads {
+			generation, buildErr := container.BuildRuntime(harConfiguration())
+			require.NoError(t, buildErr)
+			require.NoError(t, generation.Close())
+		}
+
+		assert.LessOrEqual(t, runtime.NumGoroutine(), baseline+reloads/2,
+			"config reloads must not accumulate goroutines")
+	})
+}

--- a/internal/handler/router/router_test.go
+++ b/internal/handler/router/router_test.go
@@ -49,6 +49,21 @@ var (
 	userIDHeader = "User-Id"
 )
 
+// newRuntime builds a configuration generation to act as the router's factory
+// source; closing it releases everything the router created.
+func newRuntime(t *testing.T, container *di.Container) *di.Runtime {
+	t.Helper()
+
+	runtime, err := container.BuildRuntime(&config.UncorsConfig{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, runtime.Close())
+	})
+
+	return runtime
+}
+
 func cacheFactory() router.CacheMiddlewareFactory {
 	return func(globs config.CacheGlobs) contracts.Middleware {
 		return cache.NewMiddleware(
@@ -172,7 +187,7 @@ func TestRouter(t *testing.T) {
 		mappings,
 		router.ForRouterWithDefaultHandler(proxyFactory(t, factory, httpMock)),
 		router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-		router.WithDiContainer(container),
+		router.WithDiContainer(newRuntime(t, container)),
 	)
 	require.NoError(t, err)
 
@@ -362,7 +377,7 @@ func TestRouterScriptsAndRewrites(t *testing.T) {
 			mappings,
 			router.ForRouterWithDefaultHandler(proxyFactory(t, nil, nil)),
 			router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-			router.WithDiContainer(container),
+			router.WithDiContainer(newRuntime(t, container)),
 		)
 		require.NoError(t, err)
 
@@ -405,7 +420,7 @@ func TestRouterScriptsAndRewrites(t *testing.T) {
 			mappings,
 			router.ForRouterWithDefaultHandler(proxyFactory(t, factory, httpMock)),
 			router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-			router.WithDiContainer(container),
+			router.WithDiContainer(newRuntime(t, container)),
 		)
 		require.NoError(t, err)
 
@@ -458,7 +473,7 @@ func TestRouterScriptsAndRewrites(t *testing.T) {
 
 				return cacheFactory()(globs)
 			}),
-			router.WithDiContainer(container),
+			router.WithDiContainer(newRuntime(t, container)),
 		)
 		require.NoError(t, err)
 
@@ -495,7 +510,7 @@ func TestRouterScriptsAndRewrites(t *testing.T) {
 			mappings,
 			router.ForRouterWithDefaultHandler(proxyFactory(t, nil, nil)),
 			router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-			router.WithDiContainer(container),
+			router.WithDiContainer(newRuntime(t, container)),
 		)
 		require.NoError(t, err)
 
@@ -535,7 +550,7 @@ func TestRouterMockMiddleware(t *testing.T) {
 				},
 				router.ForRouterWithDefaultHandler(proxyFactory(t, nil, nil)),
 				router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-				router.WithDiContainer(container),
+				router.WithDiContainer(newRuntime(t, container)),
 			)
 			require.NoError(t, err)
 
@@ -594,7 +609,7 @@ func TestRouterMockMiddleware(t *testing.T) {
 						}, nil
 					}))),
 				router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-				router.WithDiContainer(container),
+				router.WithDiContainer(newRuntime(t, container)),
 			)
 			require.NoError(t, err)
 
@@ -703,7 +718,7 @@ func TestRouterMockMiddleware(t *testing.T) {
 					}, nil
 				}))),
 			router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-			router.WithDiContainer(container),
+			router.WithDiContainer(newRuntime(t, container)),
 		)
 		require.NoError(t, err)
 
@@ -809,7 +824,7 @@ func TestRouterMockMiddleware(t *testing.T) {
 			},
 			router.ForRouterWithDefaultHandler(proxyFactory(t, nil, nil)),
 			router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-			router.WithDiContainer(container),
+			router.WithDiContainer(newRuntime(t, container)),
 		)
 		require.NoError(t, err)
 
@@ -915,7 +930,7 @@ func TestRouterMockMiddleware(t *testing.T) {
 			},
 			router.ForRouterWithDefaultHandler(proxyFactory(t, nil, nil)),
 			router.ForRouterWithCacheMiddlewareFactory(cacheFactory()),
-			router.WithDiContainer(container),
+			router.WithDiContainer(newRuntime(t, container)),
 		)
 		require.NoError(t, err)
 

--- a/internal/uncors/app.go
+++ b/internal/uncors/app.go
@@ -3,8 +3,7 @@ package uncors
 import (
 	"context"
 	"errors"
-	"net"
-	"strconv"
+	"sync"
 
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/di"
@@ -15,14 +14,17 @@ import (
 	"github.com/spf13/afero"
 )
 
-const baseAddress = "127.0.0.1"
-
 type Uncors struct {
 	fs afero.Fs
 
 	output    contracts.Output
 	server    *server.Server
 	container *di.Container
+
+	// runtimeMu guards the currently active configuration generation, which is
+	// replaced on every reload and released on shutdown.
+	runtimeMu sync.Mutex
+	runtime   *di.Runtime
 }
 
 func CreateUncors(container *di.Container) *Uncors {
@@ -42,37 +44,53 @@ func (app *Uncors) Start(ctx context.Context, uncorsConfig *config.UncorsConfig)
 	app.output.InfoBox(uncorsConfig.Mappings.String())
 	app.output.Print("")
 
-	targets, err := app.mappingsToTarget(uncorsConfig)
+	runtime, err := app.container.BuildRuntime(uncorsConfig)
 	if err != nil {
 		return err
 	}
 
-	return app.server.Start(ctx, targets)
+	err = app.server.Start(ctx, runtime.Targets())
+	if err != nil {
+		return errors.Join(err, runtime.Close())
+	}
+
+	app.swapRuntime(runtime)
+
+	return nil
 }
 
+// Restart builds the new configuration generation before touching the running
+// one, so a config that fails to build leaves the proxy serving the previous
+// generation untouched. The old generation is released only once the new one is
+// live, which is what flushes its HAR writers and frees its cache.
 func (app *Uncors) Restart(ctx context.Context, uncorsConfig *config.UncorsConfig) error {
 	app.output.Info("Restarting server....")
 
-	targets, err := app.mappingsToTarget(uncorsConfig)
+	runtime, err := app.container.BuildRuntime(uncorsConfig)
 	if err != nil {
 		return err
 	}
 
-	err = app.server.Restart(ctx, targets)
+	err = app.server.Restart(ctx, runtime.Targets())
 	if err != nil {
-		return err
+		return errors.Join(err, runtime.Close())
 	}
+
+	previous := app.swapRuntime(runtime)
 
 	app.output.InfoBox(
 		"Server restarted",
 		uncorsConfig.Mappings.String(),
 	)
 
-	return nil
+	return closeRuntime(previous)
 }
 
 func (app *Uncors) Close() error {
-	return app.server.Close()
+	return errors.Join(
+		app.server.Close(),
+		closeRuntime(app.swapRuntime(nil)),
+	)
 }
 
 func (app *Uncors) Wait() {
@@ -80,28 +98,28 @@ func (app *Uncors) Wait() {
 }
 
 func (app *Uncors) Shutdown(ctx context.Context) error {
-	return app.server.Shutdown(ctx)
+	return errors.Join(
+		app.server.Shutdown(ctx),
+		closeRuntime(app.swapRuntime(nil)),
+	)
 }
 
-func (app *Uncors) mappingsToTarget(uncorsConfig *config.UncorsConfig) ([]server.Target, error) {
-	groupedMappings := uncorsConfig.Mappings.GroupByPort()
-	targets := make([]server.Target, 0, len(groupedMappings))
-	errs := make([]error, 0, len(groupedMappings))
+// swapRuntime installs runtime as the active generation and returns the one it
+// replaced, which the caller is responsible for closing.
+func (app *Uncors) swapRuntime(runtime *di.Runtime) *di.Runtime {
+	app.runtimeMu.Lock()
+	defer app.runtimeMu.Unlock()
 
-	for _, group := range groupedMappings {
-		muxRouter, err := app.container.Router(group.Mappings, &uncorsConfig.CacheConfig, uncorsConfig.Proxy)
-		if err != nil {
-			errs = append(errs, err)
+	previous := app.runtime
+	app.runtime = runtime
 
-			continue
-		}
+	return previous
+}
 
-		targets = append(targets, server.Target{
-			Address:   net.JoinHostPort(baseAddress, strconv.Itoa(group.Port)),
-			Handler:   muxRouter,
-			EnableTLS: group.Scheme == "https",
-		})
+func closeRuntime(runtime *di.Runtime) error {
+	if runtime == nil {
+		return nil
 	}
 
-	return targets, errors.Join(errs...)
+	return runtime.Close()
 }


### PR DESCRIPTION
Fixes review finding **A02 — The DI container leaks a HAR writer per reload and permanently ignores cache-config changes**.

The container held one append-only closer slice that was drained only at
process exit, so every config reload leaked a HAR writer plus its goroutine and
left stale writers racing to rewrite the same archive. The cache went the other
way: `factory1` memoised the first instance and silently ignored the argument,
so `cache-config` changes never applied.

- New `di.Runtime` owns everything derived from one `UncorsConfig` (routers,
  targets, HAR writers, the response cache) and releases it on `Close`.
- `Uncors` builds the next generation before restarting, so a config that fails
  to build leaves the running proxy untouched, and closes the previous one only
  once the new one is live.
- `Shutdown`/`Close` release the active generation, which flushes HAR writers.
- `cache-config` is now genuinely hot-reloadable; the vestigial `factory1` is
  gone.

---

### Review

One commit, `e2083d9`. Step **2 of 33** in the review stack.

This PR targets **`fix/a01-request-tracker-non-blocking`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
