### PR TITLE
fix(reload): one reload engine, non-destructive and error-preserving (A03)

### DIFF
--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -30,17 +30,21 @@ func NewWatcher(filePath string) *Watcher {
 }
 
 func (w *Watcher) Watch(ctx context.Context, onChange func()) error {
-	if w.isWatching.Load() {
+	if !w.isWatching.CompareAndSwap(false, true) {
 		return errAlreadyWatching
 	}
 
 	_, err := os.Stat(w.filePath)
 	if err != nil {
+		w.isWatching.Store(false)
+
 		return fmt.Errorf("failed to watch config file '%s': %w", w.filePath, err)
 	}
 
 	fsWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
+		w.isWatching.Store(false)
+
 		return fmt.Errorf("failed to create file watcher: %w", err)
 	}
 
@@ -54,26 +58,38 @@ func (w *Watcher) Watch(ctx context.Context, onChange func()) error {
 	if err != nil {
 		_ = fsWatcher.Close()
 
+		w.isWatching.Store(false)
+
 		return fmt.Errorf("failed to watch config directory '%s': %w", dir, err)
 	}
 
 	w.fsWatcher = fsWatcher
-	w.isWatching.Store(true)
 
-	go w.run(ctx, onChange)
+	go w.run(ctx, fsWatcher, onChange)
 
 	return nil
 }
 
+// Close releases the file system watch. It is safe to call on a watcher that
+// was never started, and a closed watcher can be started again.
 func (w *Watcher) Close() error {
-	if w.fsWatcher != nil {
-		return w.fsWatcher.Close()
+	if !w.isWatching.CompareAndSwap(true, false) {
+		return nil
 	}
 
-	return nil
+	fsWatcher := w.fsWatcher
+	w.fsWatcher = nil
+
+	if fsWatcher == nil {
+		return nil
+	}
+
+	return fsWatcher.Close()
 }
 
-func (w *Watcher) run(ctx context.Context, onChange func()) {
+// run owns the fsnotify watcher it was handed: reading it from the struct would
+// race with Close clearing the field.
+func (w *Watcher) run(ctx context.Context, fsWatcher *fsnotify.Watcher, onChange func()) {
 	var debounce *time.Timer
 
 	defer func() {
@@ -87,14 +103,14 @@ func (w *Watcher) run(ctx context.Context, onChange func()) {
 		case <-ctx.Done():
 			return
 
-		case event, ok := <-w.fsWatcher.Events:
+		case event, ok := <-fsWatcher.Events:
 			if !ok {
 				return
 			}
 
 			w.handleEvent(event, &debounce, onChange)
 
-		case err, ok := <-w.fsWatcher.Errors:
+		case err, ok := <-fsWatcher.Errors:
 			if !ok {
 				return
 			}

--- a/internal/config/watcher_internal_test.go
+++ b/internal/config/watcher_internal_test.go
@@ -51,7 +51,7 @@ func runAndWait(ctx context.Context, watcher *Watcher, onChange func()) <-chan s
 	go func() {
 		defer close(exited)
 
-		watcher.run(ctx, onChange)
+		watcher.run(ctx, watcher.fsWatcher, onChange)
 	}()
 
 	return exited

--- a/internal/server/port_listener.go
+++ b/internal/server/port_listener.go
@@ -5,24 +5,40 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"sync/atomic"
+
+	"github.com/evg4b/uncors/internal/contracts"
 )
 
+// PortListener serves one address. Its handler is swappable so that a config
+// reload can replace the routing graph of an already listening port without
+// closing the socket and dropping live connections.
 type PortListener struct {
 	http.Server
 
-	target  *Target
-	manager *HostCertManager
+	address   string
+	enableTLS bool
+	manager   *HostCertManager
+	handler   atomic.Pointer[contracts.Handler]
+}
+
+func (ps *PortListener) SetHandler(handler contracts.Handler) {
+	ps.handler.Store(&handler)
+}
+
+func (ps *PortListener) Handler() contracts.Handler {
+	return *ps.handler.Load()
 }
 
 func (ps *PortListener) Listen(ctx context.Context, onReady func()) error {
 	var listenConfig net.ListenConfig
 
-	listener, err := listenConfig.Listen(ctx, "tcp", ps.target.Address)
+	listener, err := listenConfig.Listen(ctx, "tcp", ps.address)
 	if err != nil {
 		return err
 	}
 
-	if ps.target.EnableTLS {
+	if ps.enableTLS {
 		listener = tls.NewListener(listener, &tls.Config{
 			MinVersion:     tls.VersionTLS12,
 			GetCertificate: ps.manager.getCertificate,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,10 +29,12 @@ type Target struct {
 type Server struct {
 	sync.WaitGroup
 
-	listeners []*PortListener
-	manager   *HostCertManager
-	sink      RequestSink
-	nextID    atomic.Uint64
+	mu        sync.Mutex
+	listeners map[string]*PortListener
+
+	manager *HostCertManager
+	sink    RequestSink
+	nextID  atomic.Uint64
 }
 
 // New creates a server that reports request activity to sink. A nil sink is
@@ -43,45 +45,135 @@ func New(manager *HostCertManager, sink RequestSink) *Server {
 	}
 
 	return &Server{
-		listeners: []*PortListener{},
+		listeners: map[string]*PortListener{},
 		manager:   manager,
 		sink:      sink,
 	}
 }
 
+// Start brings the given targets online. It is idempotent with respect to
+// addresses that are already served: such a port keeps its listener and only
+// swaps its handler, so applying a new configuration never drops connections on
+// a port whose address did not change.
 func (s *Server) Start(ctx context.Context, targets []Target) error {
-	s.listeners = lo.Map(targets, func(target Target, _ int) *PortListener {
-		portCtx, portCtxCancel := context.WithCancel(ctx)
+	obsolete, pending := s.plan(targets)
 
-		portListener := &PortListener{
-			Server: http.Server{
-				BaseContext: func(_ net.Listener) context.Context {
-					return portCtx
-				},
-				ReadHeaderTimeout: readHeaderTimeout,
-				Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-					s.handleRequest(target.Handler, writer, request)
-				}),
-			},
-			target:  &target,
-			manager: s.manager,
+	return errors.Join(
+		shutdownListeners(ctx, obsolete),
+		s.launch(ctx, pending),
+	)
+}
+
+// Restart applies a new set of targets to a running server. Ports common to the
+// old and the new configuration stay up throughout.
+func (s *Server) Restart(ctx context.Context, targets []Target) error {
+	return s.Start(ctx, targets)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return shutdownListeners(ctx, s.takeListeners())
+}
+
+func (s *Server) Wait() {
+	s.WaitGroup.Wait()
+}
+
+func (s *Server) Close() error {
+	var errs []error
+
+	for _, portListener := range s.takeListeners() {
+		err := portListener.Close()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// plan reconciles the desired targets with the live listeners: listeners that
+// remain desired get the new handler, listeners that are no longer desired are
+// returned for shutdown, and listeners for new addresses are created (but not
+// yet started) and returned as pending.
+func (s *Server) plan(targets []Target) ([]*PortListener, []*PortListener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	desired := make(map[string]Target, len(targets))
+	for _, target := range targets {
+		desired[target.Address] = target
+	}
+
+	var obsolete []*PortListener
+
+	pending := make([]*PortListener, 0, len(desired))
+
+	for address, listener := range s.listeners {
+		target, keep := desired[address]
+		if keep && target.EnableTLS == listener.enableTLS {
+			listener.SetHandler(target.Handler)
+			delete(desired, address)
+
+			continue
 		}
 
-		portListener.RegisterOnShutdown(portCtxCancel)
+		obsolete = append(obsolete, listener)
 
-		return portListener
-	})
+		delete(s.listeners, address)
+	}
+
+	for address, target := range desired {
+		listener := s.newPortListener(target)
+		s.listeners[address] = listener
+		pending = append(pending, listener)
+	}
+
+	return obsolete, pending
+}
+
+func (s *Server) newPortListener(target Target) *PortListener {
+	portListener := &PortListener{
+		address:   target.Address,
+		enableTLS: target.EnableTLS,
+		manager:   s.manager,
+	}
+
+	portListener.SetHandler(target.Handler)
+
+	portListener.Server = http.Server{
+		ReadHeaderTimeout: readHeaderTimeout,
+		Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			s.handleRequest(portListener.Handler(), writer, request)
+		}),
+	}
+
+	return portListener
+}
+
+// launch starts the pending listeners and blocks until each of them is either
+// serving or has failed to bind.
+func (s *Server) launch(ctx context.Context, pending []*PortListener) error {
+	if len(pending) == 0 {
+		return nil
+	}
 
 	var launchWaitGroup sync.WaitGroup
-	launchWaitGroup.Add(len(s.listeners))
+
+	launchWaitGroup.Add(len(pending))
 
 	var (
 		launchErrorsMu sync.Mutex
 		launchErrs     []error
 	)
 
-	for _, server := range s.listeners {
+	for _, listener := range pending {
+		portCtx, portCtxCancel := context.WithCancel(ctx)
+
+		listener.BaseContext = func(net.Listener) context.Context { return portCtx }
+		listener.RegisterOnShutdown(portCtxCancel)
+
 		s.Add(1)
+
 		go func(srv *PortListener) {
 			defer s.Done()
 
@@ -92,6 +184,10 @@ func (s *Server) Start(ctx context.Context, targets []Target) error {
 			})
 
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				// A listener that never bound must not stay registered, or the
+				// next reload would believe its port is already served.
+				s.forget(srv)
+
 				launchErrorsMu.Lock()
 
 				launchErrs = append(launchErrs, err)
@@ -101,19 +197,42 @@ func (s *Server) Start(ctx context.Context, targets []Target) error {
 			// wait group here (after recording the error). On a clean shutdown
 			// onReady already fired, so this is a no-op.
 			once.Do(launchWaitGroup.Done)
-		}(server)
+		}(listener)
 	}
 
 	launchWaitGroup.Wait()
 
 	launchErrorsMu.Lock()
-	err := errors.Join(launchErrs...)
-	launchErrorsMu.Unlock()
+	defer launchErrorsMu.Unlock()
 
-	return err
+	return errors.Join(launchErrs...)
 }
 
-func (s *Server) Shutdown(ctx context.Context) error {
+// takeListeners detaches every live listener from the server and returns them.
+func (s *Server) takeListeners() []*PortListener {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	listeners := lo.Values(s.listeners)
+	s.listeners = map[string]*PortListener{}
+
+	return listeners
+}
+
+func (s *Server) forget(listener *PortListener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.listeners[listener.address] == listener {
+		delete(s.listeners, listener.address)
+	}
+}
+
+func shutdownListeners(ctx context.Context, listeners []*PortListener) error {
+	if len(listeners) == 0 {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 	defer cancel()
 
@@ -123,48 +242,19 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		errs      []error
 	)
 
-	for _, server := range s.listeners {
-		waitGroup.Add(1)
-		go func(srv *PortListener) {
-			defer waitGroup.Done()
-
-			err := srv.Shutdown(ctx)
+	for _, listener := range listeners {
+		waitGroup.Go(func() {
+			err := listener.Shutdown(ctx)
 			if err != nil {
 				errsMu.Lock()
 				defer errsMu.Unlock()
 
 				errs = append(errs, err)
 			}
-		}(server)
+		})
 	}
 
 	waitGroup.Wait()
-
-	return errors.Join(errs...)
-}
-
-func (s *Server) Restart(ctx context.Context, targets []Target) error {
-	err := s.Shutdown(ctx)
-	if err != nil {
-		return err
-	}
-
-	return s.Start(ctx, targets)
-}
-
-func (s *Server) Wait() {
-	s.WaitGroup.Wait()
-}
-
-func (s *Server) Close() error {
-	var errs []error
-
-	for _, portListener := range s.listeners {
-		err := portListener.Close()
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
 
 	return errors.Join(errs...)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -353,4 +354,104 @@ func TestServer(t *testing.T) {
 
 		require.Error(t, err)
 	})
+}
+
+func TestServerRestartReconcilesPorts(t *testing.T) {
+	manager := server.NewHostCertManager(afero.NewMemMapFs())
+
+	handlerFor := func(body string) contracts.Handler {
+		return infra.HandlerFunc(func(w contracts.ResponseWriter, _ *contracts.Request) error {
+			_, err := fmt.Fprint(w, body)
+
+			return err
+		})
+	}
+
+	t.Run("swaps the handler of a port that stays mapped", func(t *testing.T) {
+		instance := server.New(manager, server.NewRequestTracker())
+		port := testutils.GetFreePort(t)
+		address := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+
+		require.NoError(t, instance.Start(t.Context(), []server.Target{
+			{Address: address, Handler: handlerFor("first")},
+		}))
+
+		defer instance.Close()
+
+		assert.Equal(t, "first", getBody(t, "http://"+address))
+
+		require.NoError(t, instance.Restart(t.Context(), []server.Target{
+			{Address: address, Handler: handlerFor("second")},
+		}))
+
+		assert.Equal(t, "second", getBody(t, "http://"+address))
+	})
+
+	t.Run("stops listeners that are no longer mapped", func(t *testing.T) {
+		instance := server.New(manager, server.NewRequestTracker())
+		kept := net.JoinHostPort("127.0.0.1", strconv.Itoa(testutils.GetFreePort(t)))
+		dropped := net.JoinHostPort("127.0.0.1", strconv.Itoa(testutils.GetFreePort(t)))
+
+		require.NoError(t, instance.Start(t.Context(), []server.Target{
+			{Address: kept, Handler: handlerFor("kept")},
+			{Address: dropped, Handler: handlerFor("dropped")},
+		}))
+
+		defer instance.Close()
+
+		require.NoError(t, instance.Restart(t.Context(), []server.Target{
+			{Address: kept, Handler: handlerFor("kept")},
+		}))
+
+		assert.Equal(t, "kept", getBody(t, "http://"+kept))
+
+		request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+dropped, nil)
+		require.NoError(t, err)
+
+		_, err = http.DefaultClient.Do(request) //nolint:bodyclose // the request must not reach a listener
+		require.Error(t, err, "the unmapped port must no longer be served")
+	})
+
+	t.Run("a failing new port does not take down the ports that work", func(t *testing.T) {
+		instance := server.New(manager, server.NewRequestTracker())
+		kept := net.JoinHostPort("127.0.0.1", strconv.Itoa(testutils.GetFreePort(t)))
+
+		var listenConfig net.ListenConfig
+
+		occupied, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+
+		defer occupied.Close()
+
+		require.NoError(t, instance.Start(t.Context(), []server.Target{
+			{Address: kept, Handler: handlerFor("kept")},
+		}))
+
+		defer instance.Close()
+
+		err = instance.Restart(t.Context(), []server.Target{
+			{Address: kept, Handler: handlerFor("kept")},
+			{Address: occupied.Addr().String(), Handler: handlerFor("conflict")},
+		})
+
+		require.Error(t, err)
+		assert.Equal(t, "kept", getBody(t, "http://"+kept))
+	})
+}
+
+func getBody(t *testing.T, url string) string {
+	t.Helper()
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	return string(body)
 }

--- a/internal/uncors/reloader.go
+++ b/internal/uncors/reloader.go
@@ -1,0 +1,112 @@
+package uncors
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/contracts"
+)
+
+var errEmptyConfiguration = errors.New("configuration loader returned no configuration")
+
+// ConfigLoader loads and validates the current configuration. It must report a
+// malformed configuration as an error rather than as a nil result.
+type ConfigLoader = func() (*config.UncorsConfig, error)
+
+// Reloader owns configuration hot reload for every run mode. It watches the
+// config file, loads and validates the new configuration and applies it to the
+// running app.
+//
+// A configuration that fails to load is reported and discarded: the proxy keeps
+// serving the previous one. Keeping this in one place is what stops the two run
+// modes from growing two different reload contracts.
+type Reloader struct {
+	app        *Uncors
+	output     contracts.Output
+	load       ConfigLoader
+	configPath string
+
+	mu      sync.Mutex
+	watcher *config.Watcher
+}
+
+func NewReloader(app *Uncors, output contracts.Output, load ConfigLoader, configPath string) *Reloader {
+	return &Reloader{
+		app:        app,
+		output:     output,
+		load:       load,
+		configPath: configPath,
+	}
+}
+
+// Start begins watching the config file. It is a no-op when the process runs
+// without a config file.
+func (r *Reloader) Start(ctx context.Context) error {
+	if r.configPath == "" {
+		return nil
+	}
+
+	watcher := config.NewWatcher(r.configPath)
+
+	err := watcher.Watch(ctx, func() {
+		reloadErr := r.Reload(ctx)
+		if reloadErr != nil {
+			r.report(reloadErr)
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.watcher = watcher
+
+	return nil
+}
+
+// Reload loads the configuration and applies it to the running app. It is used
+// both by the file watcher and by the interactive restart command.
+func (r *Reloader) Reload(ctx context.Context) error {
+	uncorsConfig, err := r.load()
+	if err != nil {
+		return err
+	}
+
+	if uncorsConfig == nil {
+		return errEmptyConfiguration
+	}
+
+	return r.app.Restart(ctx, uncorsConfig)
+}
+
+// Watching reports whether the config file is currently being watched.
+func (r *Reloader) Watching() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.watcher != nil
+}
+
+func (r *Reloader) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.watcher == nil {
+		return nil
+	}
+
+	watcher := r.watcher
+	r.watcher = nil
+
+	return watcher.Close()
+}
+
+func (r *Reloader) report(err error) {
+	log.Printf("Config reloading error: %v", err)
+	r.output.Errorf("Config reloading error: %v", err)
+}

--- a/internal/uncors/reloader_test.go
+++ b/internal/uncors/reloader_test.go
@@ -1,0 +1,184 @@
+package uncors_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/di"
+	"github.com/evg4b/uncors/internal/uncors"
+	"github.com/evg4b/uncors/testing/hosts"
+	"github.com/evg4b/uncors/testing/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errBrokenConfig = errors.New("mappings[0].from is not a valid host")
+
+func TestReloaderReload(t *testing.T) {
+	t.Run("keeps serving the previous config when loading fails", func(t *testing.T) {
+		container := di.NewContainer(di.WithVersion(version))
+		defer testutils.Close(t, container)
+
+		app := uncors.CreateUncors(container)
+
+		targetServer := testutils.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "OK")
+		}))
+		defer targetServer.Close()
+
+		port := testutils.GetFreePort(t)
+
+		require.NoError(t, app.Start(t.Context(), &config.UncorsConfig{
+			Mappings: config.Mappings{
+				{From: hosts.Loopback.HTTPPort(port), To: hosts.Parse(targetServer.URL)},
+			},
+		}))
+
+		defer app.Close()
+
+		reloader := uncors.NewReloader(app, container.CliOutput(), func() (*config.UncorsConfig, error) {
+			return nil, errBrokenConfig
+		}, "")
+
+		err := reloader.Reload(t.Context())
+
+		require.ErrorIs(t, err, errBrokenConfig)
+		assert.Equal(t, "OK", get(t, hosts.Loopback.HTTPPort(port).String()))
+	})
+
+	t.Run("reports a nil configuration instead of panicking", func(t *testing.T) {
+		container := di.NewContainer(di.WithVersion(version))
+		defer testutils.Close(t, container)
+
+		app := uncors.CreateUncors(container)
+		reloader := uncors.NewReloader(app, container.CliOutput(), func() (*config.UncorsConfig, error) {
+			return nil, nil //nolint:nilnil // exactly the contract violation under test
+		}, "")
+
+		require.Error(t, reloader.Reload(t.Context()))
+	})
+
+	t.Run("applies the new configuration", func(t *testing.T) {
+		container := di.NewContainer(di.WithVersion(version))
+		defer testutils.Close(t, container)
+
+		app := uncors.CreateUncors(container)
+
+		first := testutils.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "first")
+		}))
+		defer first.Close()
+
+		second := testutils.NewServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "second")
+		}))
+		defer second.Close()
+
+		port := testutils.GetFreePort(t)
+
+		require.NoError(t, app.Start(t.Context(), &config.UncorsConfig{
+			Mappings: config.Mappings{
+				{From: hosts.Loopback.HTTPPort(port), To: hosts.Parse(first.URL)},
+			},
+		}))
+
+		defer app.Close()
+
+		reloader := uncors.NewReloader(app, container.CliOutput(), func() (*config.UncorsConfig, error) {
+			return &config.UncorsConfig{
+				Mappings: config.Mappings{
+					{From: hosts.Loopback.HTTPPort(port), To: hosts.Parse(second.URL)},
+				},
+			}, nil
+		}, "")
+
+		require.NoError(t, reloader.Reload(t.Context()))
+		assert.Equal(t, "second", get(t, hosts.Loopback.HTTPPort(port).String()))
+	})
+}
+
+func TestReloaderStart(t *testing.T) {
+	t.Run("does nothing without a config file", func(t *testing.T) {
+		reloader := uncors.NewReloader(nil, nil, nil, "")
+
+		require.NoError(t, reloader.Start(t.Context()))
+		assert.False(t, reloader.Watching())
+		require.NoError(t, reloader.Close())
+	})
+
+	t.Run("fails for a missing config file", func(t *testing.T) {
+		reloader := uncors.NewReloader(nil, nil, nil, "/no/such/config.yaml")
+
+		require.Error(t, reloader.Start(t.Context()))
+		assert.False(t, reloader.Watching())
+	})
+
+	t.Run("reloads on config file change", func(t *testing.T) {
+		container := di.NewContainer(di.WithVersion(version))
+		defer testutils.Close(t, container)
+
+		configPath := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte("proxy: \"\""), 0o600))
+
+		reloaded := make(chan struct{}, 1)
+
+		app := uncors.CreateUncors(container)
+		reloader := uncors.NewReloader(app, container.CliOutput(), func() (*config.UncorsConfig, error) {
+			select {
+			case reloaded <- struct{}{}:
+			default:
+			}
+
+			return &config.UncorsConfig{Mappings: config.Mappings{}}, nil
+		}, configPath)
+
+		require.NoError(t, reloader.Start(t.Context()))
+		assert.True(t, reloader.Watching())
+
+		defer testutils.Close(t, reloader)
+
+		require.NoError(t, os.WriteFile(configPath, []byte("proxy: \"\"\n"), 0o600))
+
+		select {
+		case <-reloaded:
+		case <-time.After(time.Second):
+			t.Fatal("config change did not trigger a reload")
+		}
+	})
+
+	t.Run("close is idempotent and stops watching", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte("proxy: \"\""), 0o600))
+
+		reloader := uncors.NewReloader(nil, nil, nil, configPath)
+
+		require.NoError(t, reloader.Start(t.Context()))
+		require.NoError(t, reloader.Close())
+		require.NoError(t, reloader.Close())
+		assert.False(t, reloader.Watching())
+	})
+}
+
+func get(t *testing.T, url string) string {
+	t.Helper()
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	return string(body)
+}

--- a/internal/uncors_app/app.go
+++ b/internal/uncors_app/app.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/di"
-	"github.com/evg4b/uncors/internal/helpers"
 	"github.com/evg4b/uncors/internal/server"
 	"github.com/evg4b/uncors/internal/uncors"
 )
@@ -39,10 +38,9 @@ type UncorsApp struct {
 	cancel     context.CancelFunc
 
 	cfg        *config.UncorsConfig
-	loadConfig func() *config.UncorsConfig
 	configPath string
 
-	watcher *config.Watcher
+	reloader *uncors.Reloader
 
 	termHeight int
 	termWidth  int
@@ -71,7 +69,7 @@ func NewUncorsApp(
 	container *di.Container,
 	configPath string,
 	cfg *config.UncorsConfig,
-	loadConfig func() *config.UncorsConfig,
+	loadConfig uncors.ConfigLoader,
 ) *UncorsApp {
 	outputCh := make(chan string, outputChannelSize)
 	output := newTuiOutput(outputCh)
@@ -86,9 +84,11 @@ func NewUncorsApp(
 
 	historyWidget := NewHistoryWidget(keys)
 
+	app := uncors.CreateUncors(container)
+
 	return &UncorsApp{
 		keys:          keys,
-		app:           uncors.CreateUncors(container),
+		app:           app,
 		output:        output,
 		tracker:       container.RequestTracker(),
 		container:     container,
@@ -97,8 +97,8 @@ func NewUncorsApp(
 		appDone:       appCtx.Done(),
 		cancel:        cancel,
 		cfg:           cfg,
-		loadConfig:    loadConfig,
 		configPath:    configPath,
+		reloader:      uncors.NewReloader(app, output, loadConfig, configPath),
 		historyWidget: historyWidget,
 		trackerWidget: NewTrackerWidget(),
 		helpWidget:    NewHelpWidget(keys),
@@ -268,26 +268,10 @@ func (msg shutdownMsg) update(app *UncorsApp) tea.Cmd {
 }
 
 func (m *UncorsApp) handleServerStarted() tea.Cmd {
-	if m.configPath != "" {
-		watcher := config.NewWatcher(m.configPath)
-
-		err := watcher.Watch(m.appContext(), func() {
-			defer helpers.PanicInterceptor(func(value any) {
-				m.output.Errorf("Config reloading error: %v", value)
-			})
-
-			newCfg := m.loadConfig()
-
-			err := m.app.Restart(m.appContext(), newCfg)
-			if err != nil {
-				m.output.Errorf("Failed to restart server: %v", err)
-			}
-		})
-		if err != nil {
-			m.output.Errorf("Failed to watch config file: %v", err)
-		} else {
-			m.watcher = watcher
-		}
+	err := m.reloader.Start(m.appContext())
+	if err != nil {
+		log.Printf("Failed to watch config file: %v", err)
+		m.output.Errorf("Failed to watch config file: %v", err)
 	}
 
 	return m.versionCheckCmd()
@@ -319,9 +303,7 @@ func (m *UncorsApp) handleRestart() {
 func (m *UncorsApp) handleShutdown() tea.Cmd {
 	log.Println("Handling shutdown")
 
-	if m.watcher != nil {
-		_ = m.watcher.Close()
-	}
+	_ = m.reloader.Close()
 
 	_ = m.historyWidget.Close()
 
@@ -384,14 +366,9 @@ func (m *UncorsApp) shutdownCmd() tea.Cmd {
 
 func (m *UncorsApp) restartCmd() tea.Cmd {
 	return func() tea.Msg {
-		defer helpers.PanicInterceptor(func(value any) {
-			m.output.Errorf("Restart error: %v", value)
-		})
-
-		newCfg := m.loadConfig()
-
-		err := m.app.Restart(m.appContext(), newCfg)
+		err := m.reloader.Reload(m.appContext())
 		if err != nil {
+			log.Printf("Failed to restart: %v", err)
 			m.output.Errorf("Failed to restart: %v", err)
 		}
 

--- a/internal/uncors_app/app_internal_test.go
+++ b/internal/uncors_app/app_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/di"
 	"github.com/evg4b/uncors/internal/server"
+	"github.com/evg4b/uncors/internal/uncors"
 	"github.com/evg4b/uncors/testing/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,10 +39,10 @@ func newTestApp(t *testing.T) (*UncorsApp, *int) {
 		container,
 		"", // no config file — watcher is not created
 		uncorsConfig,
-		func() *config.UncorsConfig {
+		func() (*config.UncorsConfig, error) {
 			loadCalls++
 
-			return uncorsConfig
+			return uncorsConfig, nil
 		},
 	)
 
@@ -320,7 +321,7 @@ func TestHandleServerStartedWithConfigPath(t *testing.T) {
 		container := di.NewContainer()
 		defer testutils.Close(t, container)
 
-		app := NewUncorsApp(container, tmpFile.Name(), cfg, func() *config.UncorsConfig { return cfg })
+		app := NewUncorsApp(container, tmpFile.Name(), cfg, func() (*config.UncorsConfig, error) { return cfg, nil })
 
 		defer func() {
 			app.cancel()
@@ -336,10 +337,9 @@ func TestHandleServerStartedWithConfigPath(t *testing.T) {
 		cmd := app.handleServerStarted()
 
 		require.NotNil(t, cmd)
-		require.NotNil(t, app.watcher)
+		require.True(t, app.reloader.Watching())
 
-		err = app.watcher.Close()
-		require.NoError(t, err)
+		require.NoError(t, app.reloader.Close())
 	})
 
 	t.Run("logs error when config file does not exist", func(t *testing.T) {
@@ -348,7 +348,8 @@ func TestHandleServerStartedWithConfigPath(t *testing.T) {
 		container := di.NewContainer()
 		defer testutils.Close(t, container)
 
-		app := NewUncorsApp(container, "/nonexistent/path/config.yaml", cfg, func() *config.UncorsConfig { return cfg })
+		loader := func() (*config.UncorsConfig, error) { return cfg, nil }
+		app := NewUncorsApp(container, "/nonexistent/path/config.yaml", cfg, loader)
 
 		defer func() {
 			app.cancel()
@@ -364,7 +365,7 @@ func TestHandleServerStartedWithConfigPath(t *testing.T) {
 		cmd := app.handleServerStarted()
 
 		require.NotNil(t, cmd)
-		assert.Nil(t, app.watcher)
+		assert.False(t, app.reloader.Watching())
 	})
 }
 
@@ -403,13 +404,13 @@ func TestHandleServerStartedCallbackOnFileChange(t *testing.T) {
 	container := di.NewContainer()
 	defer testutils.Close(t, container)
 
-	app := NewUncorsApp(container, tmpFile.Name(), cfg, func() *config.UncorsConfig {
+	app := NewUncorsApp(container, tmpFile.Name(), cfg, func() (*config.UncorsConfig, error) {
 		select {
 		case called <- struct{}{}:
 		default:
 		}
 
-		return cfg
+		return cfg, nil
 	})
 
 	defer func() {
@@ -419,10 +420,7 @@ func TestHandleServerStartedCallbackOnFileChange(t *testing.T) {
 		// app.closers, which would be a data race.
 		app.cancel()
 
-		if app.watcher != nil {
-			err := app.watcher.Close()
-			require.NoError(t, err)
-		}
+		require.NoError(t, app.reloader.Close())
 
 		if app.historyWidget != nil && app.historyWidget.hist != nil {
 			err := app.historyWidget.hist.Close()
@@ -433,7 +431,7 @@ func TestHandleServerStartedCallbackOnFileChange(t *testing.T) {
 	cmd := app.handleServerStarted()
 
 	require.NotNil(t, cmd)
-	require.NotNil(t, app.watcher)
+	require.True(t, app.reloader.Watching())
 
 	require.NoError(t, os.WriteFile(tmpFile.Name(), []byte("proxy: \"\""), 0o600))
 
@@ -451,14 +449,13 @@ func TestHandleShutdownWithWatcher(t *testing.T) {
 	err = tmpFile.Close()
 	require.NoError(t, err)
 
-	ctx := t.Context()
-
-	watcher := config.NewWatcher(tmpFile.Name())
-	err = watcher.Watch(ctx, func() {})
-	require.NoError(t, err)
-
 	app, _ := newTestApp(t)
-	app.watcher = watcher
+	app.reloader = uncors.NewReloader(app.app, app.output, func() (*config.UncorsConfig, error) {
+		return app.cfg, nil
+	}, tmpFile.Name())
+
+	require.NoError(t, app.reloader.Start(t.Context()))
+	require.True(t, app.reloader.Watching())
 
 	cmd := app.handleShutdown()
 	require.NotNil(t, cmd)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,10 @@ func run() int {
 		pflag.PrintDefaults()
 	}
 
-	uncorsConfig, configPath := loadConfiguration(fs)
+	uncorsConfig, configPath, err := loadConfiguration(fs)
+	if err != nil {
+		panic(err)
+	}
 
 	if uncorsConfig.Interactive {
 		return runInteractive(container, configPath, uncorsConfig)
@@ -112,11 +115,23 @@ func runNonInteractive(
 
 	go server.RequestPrinter(tracker, output)
 
-	startConfigWatcher(ctx, container, configPath, app)
+	reloader := uncors.NewReloader(app, output, configLoader(container.Fs()), configPath)
+	defer func() {
+		closeErr := reloader.Close()
+		if closeErr != nil {
+			log.Printf("Failed to close config watcher: %v", closeErr)
+		}
+	}()
 
 	err := app.Start(ctx, cfg)
 	if err != nil {
 		panic(err)
+	}
+
+	err = reloader.Start(ctx)
+	if err != nil {
+		log.Printf("Failed to start config watcher: %v", err)
+		output.Errorf("Failed to start config watcher: %v", err)
 	}
 
 	go startVersionChecker(ctx, container, cfg.Proxy)
@@ -138,44 +153,6 @@ func runNonInteractive(
 	return 0
 }
 
-// startConfigWatcher begins watching the config file and restarts the proxy on
-// every change. The watcher lives for the process lifetime (not closed explicitly).
-func startConfigWatcher(
-	ctx context.Context,
-	container *di.Container,
-	configPath string,
-	app *uncors.Uncors,
-) {
-	if configPath == "" {
-		return
-	}
-
-	output := container.CliOutput()
-	fs := container.Fs()
-	watcher := config.NewWatcher(configPath)
-
-	err := watcher.Watch(ctx, func() {
-		defer helpers.PanicInterceptor(func(value any) {
-			log.Printf("Config reloading error: %v", value)
-			output.Errorf("Config reloading error: %v", value)
-		})
-
-		reloaded, _ := loadConfiguration(fs)
-
-		restartErr := app.Restart(ctx, reloaded)
-		if restartErr != nil {
-			log.Printf("Failed to restart server: %v", restartErr)
-			output.Errorf("Failed to restart server: %v", restartErr)
-		}
-	})
-	if err != nil {
-		log.Printf("Failed to start config watcher: %v", err)
-		output.Errorf("Failed to start config watcher: %v", err)
-
-		return
-	}
-}
-
 // startVersionChecker waits for a short delay then checks for a newer release.
 func startVersionChecker(ctx context.Context, container *di.Container, proxy string) {
 	const checkDelay = 50 * time.Millisecond
@@ -192,11 +169,7 @@ func runInteractive(container *di.Container, configPath string, cfg *config.Unco
 		container,
 		configPath,
 		cfg,
-		func() *config.UncorsConfig {
-			reloaded, _ := loadConfiguration(container.Fs())
-
-			return reloaded
-		},
+		configLoader(container.Fs()),
 	)
 
 	_, err := tea.NewProgram(app).Run()
@@ -213,19 +186,29 @@ const (
 	logFilePerm  = 0o644
 )
 
+// configLoader returns the loader both run modes use to reload the
+// configuration. Errors are propagated so that a malformed config is reported
+// as such instead of silently becoming a nil configuration.
+func configLoader(fs afero.Fs) uncors.ConfigLoader {
+	return func() (*config.UncorsConfig, error) {
+		uncorsConfig, _, err := loadConfiguration(fs)
+
+		return uncorsConfig, err
+	}
+}
+
 // loadConfiguration loads and validates the configuration from CLI args and the
-// config file. It panics on any error so that the PanicInterceptor in run() can
-// display a human-readable message and exit cleanly.
-func loadConfiguration(fs afero.Fs) (*config.UncorsConfig, string) {
+// config file.
+func loadConfiguration(fs afero.Fs) (*config.UncorsConfig, string, error) {
 	uncorsConfig, configPath, err := config.LoadConfiguration(fs, os.Args)
 	if err != nil {
-		panic(err)
+		return nil, "", err
 	}
 
 	if uncorsConfig.Debug {
 		logFile, err := os.OpenFile(logFileName, logFileFlags, logFilePerm)
 		if err != nil {
-			panic(fmt.Sprintf("Failed to open log file: %v", err))
+			return nil, "", fmt.Errorf("failed to open log file: %w", err)
 		}
 
 		log.SetOutput(logFile)
@@ -234,5 +217,5 @@ func loadConfiguration(fs afero.Fs) (*config.UncorsConfig, string) {
 		log.SetOutput(io.Discard)
 	}
 
-	return uncorsConfig, configPath
+	return uncorsConfig, configPath, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/evg4b/uncors/internal/di"
@@ -25,27 +24,28 @@ func TestLoadConfiguration(t *testing.T) {
 	t.Run("returns config for valid flags", func(t *testing.T) {
 		defer setArgs([]string{"uncors", "-f", "http://localhost:3000", "-t", "https://api.example.com"})()
 
-		cfg, path := loadConfiguration(afero.NewMemMapFs())
+		cfg, path, err := loadConfiguration(afero.NewMemMapFs())
 
+		require.NoError(t, err)
 		require.NotNil(t, cfg)
 		assert.Empty(t, path)
 		assert.Len(t, cfg.Mappings, 1)
 	})
 
-	t.Run("panics when mappings are empty", func(t *testing.T) {
+	t.Run("fails when mappings are empty", func(t *testing.T) {
 		defer setArgs([]string{"uncors"})()
 
-		assert.Panics(t, func() {
-			loadConfiguration(afero.NewMemMapFs())
-		})
+		_, _, err := loadConfiguration(afero.NewMemMapFs())
+
+		require.Error(t, err)
 	})
 
-	t.Run("panics on invalid flags", func(t *testing.T) {
+	t.Run("fails on invalid flags", func(t *testing.T) {
 		defer setArgs([]string{"uncors", "--no-such-flag"})()
 
-		assert.Panics(t, func() {
-			loadConfiguration(afero.NewMemMapFs())
-		})
+		_, _, err := loadConfiguration(afero.NewMemMapFs())
+
+		require.Error(t, err)
 	})
 }
 
@@ -90,8 +90,9 @@ func TestLoadConfigurationWithDebug(t *testing.T) {
 
 	defer setArgs([]string{"uncors", "-f", "http://localhost:3000", "-t", "https://api.example.com", "--debug"})()
 
-	cfg, _ := loadConfiguration(afero.NewMemMapFs())
+	cfg, _, err := loadConfiguration(afero.NewMemMapFs())
 
+	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.True(t, cfg.Debug)
 }
@@ -108,8 +109,9 @@ mappings:
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/config.yaml", []byte(cfgContent), 0o600))
 
-	cfg, path := loadConfiguration(fs)
+	cfg, path, err := loadConfiguration(fs)
 
+	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "/config.yaml", path)
 	assert.Len(t, cfg.Mappings, 1)
@@ -126,26 +128,22 @@ func TestStartVersionChecker(t *testing.T) {
 	})
 }
 
-func TestStartConfigWatcher(t *testing.T) {
-	t.Run("logs error for non-existent config path", func(t *testing.T) {
-		container := di.NewContainer()
-		defer testutils.Close(t, container)
+func TestConfigLoader(t *testing.T) {
+	t.Run("propagates configuration errors instead of returning a nil config", func(t *testing.T) {
+		defer setArgs([]string{"uncors"})()
 
-		assert.NotPanics(t, func() {
-			startConfigWatcher(context.Background(), container, "/no/such/config.yaml", nil)
-		})
+		cfg, err := configLoader(afero.NewMemMapFs())()
+
+		require.Error(t, err)
+		assert.Nil(t, cfg)
 	})
 
-	t.Run("creates watcher for existing config file", func(t *testing.T) {
-		container := di.NewContainer()
-		defer testutils.Close(t, container)
+	t.Run("returns the loaded configuration", func(t *testing.T) {
+		defer setArgs([]string{"uncors", "-f", "http://localhost:3000", "-t", "https://api.example.com"})()
 
-		tmpDir := t.TempDir()
-		configFile := filepath.Join(tmpDir, "config.yaml")
-		require.NoError(t, os.WriteFile(configFile, []byte("proxy: \"\""), 0o600))
+		cfg, err := configLoader(afero.NewMemMapFs())()
 
-		assert.NotPanics(t, func() {
-			startConfigWatcher(context.Background(), container, configFile, nil)
-		})
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
 	})
 }


### PR DESCRIPTION
Fixes review finding **A03 — Hot reload is implemented twice, discards errors, and can restart the server with a `nil` config**.

Hot reload existed twice — once in main, once inside the BubbleTea model — with
different error handling. The interactive copy discarded config errors, so a
typo made the loader return a nil config and the restart panicked with a nil
dereference instead of showing the validation message. The headless copy never
closed its watcher.

- New `uncors.Reloader` owns loading, validating and applying a configuration,
  plus the watcher's lifetime. Both run modes now call it; the TUI restart key
  goes through the same path.
- `ConfigLoader` returns an error, so a malformed config is reported instead of
  becoming a nil config; `PanicInterceptor` is no longer the reload error
  handler.
- `Server` reconciles targets instead of shutting everything down: a port that
  stays mapped keeps its listener and only swaps its handler, unmapped ports are
  closed, and a new port that fails to bind no longer takes the working ports
  with it.
- `config.Watcher` keeps its `isWatching` flag consistent, can be restarted
  after Close, and no longer races its own goroutine.

---

### Review

One commit, `568d746`. Step **3 of 33** in the review stack.

This PR targets **`fix/a02-generation-scoped-resources`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
