### PR TITLE
fix(router): apply mapping-wide middleware to the whole mapping (A06)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -19,6 +19,7 @@ Settings are organized into two levels:
  - [Global Configuration Properties](#global-configuration-properties)
  - [Mapping Configuration](#mapping-configuration)
    
+    - [Route Precedence](#route-precedence)
     - [OPTIONS Request Handling](#options-request-handling)
     - [Protocol Scheme Mapping](#protocol-scheme-mapping)
     - [Named Placeholder Mapping](#named-placeholder-mapping)
@@ -166,6 +167,34 @@ for HTTP and 443 for HTTPS if omitted. Additional features like mocking, static
 file serving, and scripting can be configured per mapping. See [Response
 Mocking](Response-Mocking), [Static File Serving](Static-File-Serving), and
 [Script Handler](Script-Handler) for details.
+
+### Route Precedence
+
+Within one mapping, a request is offered to the configured handlers in a fixed
+order, from the most specific to the most general:
+
+1. **Mocks** — those with a method, header or query matcher first, then the ones
+   matched by path alone.
+2. **Scripts** — same two-step order as mocks.
+3. **Rewrites** — a rewritten request re-enters this list from the top, so it can
+   be answered by a mock, a script or a static file. Rewrites that keep
+   redirecting a request into each other are stopped after 8 rounds.
+4. **Statics** — path-prefix mounts are tried after everything above, so a static
+   directory mounted at `/` (the usual SPA setup) no longer shadows the mocks and
+   scripts of the same mapping.
+5. **The proxy** — anything nothing above claimed is forwarded to `to:`. A static
+   mount whose file (and index file) is missing also falls through to here.
+
+Two features apply to the whole mapping rather than to a single route:
+
+- **`options-handling`** answers CORS preflights before any of the above is
+  consulted, so a preflight to a mocked path is handled like any other.
+- **`har`** records every response the mapping produces, including mocked,
+  scripted and statically served ones.
+
+**`cache` applies only to proxied responses.** Locally produced responses
+(mocks, scripts, statics) are cheap to produce and change whenever the config
+changes, so caching them would only serve stale copies.
 
 ### OPTIONS Request Handling
 

--- a/internal/handler/router/composition_test.go
+++ b/internal/handler/router/composition_test.go
@@ -1,0 +1,204 @@
+package router_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/di"
+	"github.com/evg4b/uncors/internal/handler/router"
+	"github.com/evg4b/uncors/internal/helpers"
+	"github.com/evg4b/uncors/internal/infra"
+	"github.com/evg4b/uncors/testing/hosts"
+	"github.com/evg4b/uncors/testing/testutils"
+	"github.com/go-http-utils/headers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	spaIndexBody  = "SPA-INDEX"
+	mockHealth    = "MOCK-HEALTH"
+	upstreamBody  = "FROM-UPSTREAM"
+	healthPath    = "/api/health"
+	rewrittenPath = "/v2/api/health"
+)
+
+// harArchive is the slice of the HAR schema this test asserts on.
+type harArchive struct {
+	Log struct {
+		Entries []struct {
+			Request struct {
+				URL string `json:"url"`
+			} `json:"request"`
+		} `json:"entries"`
+	} `json:"log"`
+}
+
+func upstreamHandler() http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(upstreamBody))
+	})
+}
+
+func newMappingRouter(t *testing.T, mapping config.Mapping, upstream http.Handler) *router.Router {
+	t.Helper()
+
+	container := di.NewContainer(di.WithFs(testutils.FsFromMap(t, map[string]string{
+		"/dist/index.html": spaIndexBody,
+	})))
+
+	t.Cleanup(func() {
+		require.NoError(t, container.Close())
+	})
+
+	instance, err := router.NewRouter(config.Mappings{mapping}, newDeps(t, container, upstream))
+	require.NoError(t, err)
+
+	return instance
+}
+
+func serve(t *testing.T, handler http.Handler, method, url string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), method, url, nil)
+	helpers.NormaliseRequest(request)
+
+	handler.ServeHTTP(infra.NewResponseRecorder(recorder), request)
+
+	return recorder
+}
+
+// The flagship "SPA with API proxying" configuration: a static mount at "/" used
+// to shadow every mock in the same mapping.
+func TestStaticMountDoesNotShadowMocks(t *testing.T) {
+	instance := newMappingRouter(t, config.Mapping{
+		From:    hosts.Localhost.HTTP(),
+		To:      hosts.Localhost.HTTPS(),
+		Statics: config.StaticDirectories{{Dir: "/dist", Path: "/", Index: "index.html"}},
+		Mocks: config.Mocks{
+			{
+				Matcher:  config.RequestMatcher{Path: healthPath},
+				Response: config.Response{Code: http.StatusOK, Raw: mockHealth},
+			},
+		},
+	}, upstreamHandler())
+
+	t.Run("the mock answers its own path", func(t *testing.T) {
+		recorder := serve(t, instance, http.MethodGet, "http://localhost"+healthPath)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, mockHealth, recorder.Body.String())
+	})
+
+	t.Run("the static mount still answers everything else", func(t *testing.T) {
+		recorder := serve(t, instance, http.MethodGet, "http://localhost/some/spa/route")
+
+		assert.Equal(t, spaIndexBody, recorder.Body.String())
+	})
+}
+
+// HAR is a property of the mapping, so locally produced responses belong in the
+// archive too.
+func TestHARRecordsLocallyServedResponses(t *testing.T) {
+	harFile := filepath.Join(t.TempDir(), "test.har")
+
+	instance := newMappingRouter(t, config.Mapping{
+		From: hosts.Localhost.HTTP(),
+		To:   hosts.Localhost.HTTPS(),
+		HAR:  config.HARConfig{File: harFile},
+		Mocks: config.Mocks{
+			{
+				Matcher:  config.RequestMatcher{Path: healthPath},
+				Response: config.Response{Code: http.StatusOK, Raw: mockHealth},
+			},
+		},
+	}, upstreamHandler())
+
+	recorder := serve(t, instance, http.MethodGet, "http://localhost"+healthPath)
+	require.Equal(t, mockHealth, recorder.Body.String())
+
+	assert.Eventually(t, func() bool {
+		content, err := os.ReadFile(harFile) //nolint:gosec // a path this test created
+		if err != nil {
+			return false
+		}
+
+		var archive harArchive
+
+		if json.Unmarshal(content, &archive) != nil {
+			return false
+		}
+
+		for _, entry := range archive.Log.Entries {
+			if strings.HasSuffix(entry.Request.URL, healthPath) {
+				return true
+			}
+		}
+
+		return false
+	}, 2*time.Second, 20*time.Millisecond, "the mocked request was not recorded")
+}
+
+// A preflight is answered before the router decides what serves the path, so a
+// mocked path gets CORS handling like any other.
+func TestOptionsIsAnsweredForMockedPaths(t *testing.T) {
+	instance := newMappingRouter(t, config.Mapping{
+		From: hosts.Localhost.HTTP(),
+		To:   hosts.Localhost.HTTPS(),
+		Mocks: config.Mocks{
+			{
+				Matcher:  config.RequestMatcher{Path: healthPath},
+				Response: config.Response{Code: http.StatusOK, Raw: mockHealth},
+			},
+		},
+	}, upstreamHandler())
+
+	recorder := serve(t, instance, http.MethodOptions, "http://localhost"+healthPath)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.NotEmpty(t, recorder.Header().Get(headers.AccessControlAllowMethods))
+	assert.NotEqual(t, mockHealth, recorder.Body.String())
+}
+
+// A rewritten request re-enters routing, so it can be answered by a mock.
+func TestRewriteRedispatchesIntoTheMapping(t *testing.T) {
+	instance := newMappingRouter(t, config.Mapping{
+		From:     hosts.Localhost.HTTP(),
+		To:       hosts.Localhost.HTTPS(),
+		Rewrites: config.RewriteOptions{{From: "/old-api/{path}", To: "/v2/api/{path}"}},
+		Mocks: config.Mocks{
+			{
+				Matcher:  config.RequestMatcher{Path: rewrittenPath},
+				Response: config.Response{Code: http.StatusOK, Raw: mockHealth},
+			},
+		},
+	}, upstreamHandler())
+
+	recorder := serve(t, instance, http.MethodGet, "http://localhost/old-api/health")
+
+	assert.Equal(t, mockHealth, recorder.Body.String())
+}
+
+func TestRewriteLoopIsBounded(t *testing.T) {
+	instance := newMappingRouter(t, config.Mapping{
+		From: hosts.Localhost.HTTP(),
+		To:   hosts.Localhost.HTTPS(),
+		Rewrites: config.RewriteOptions{
+			{From: "/ping", To: "/pong"},
+			{From: "/pong", To: "/ping"},
+		},
+	}, upstreamHandler())
+
+	recorder := serve(t, instance, http.MethodGet, "http://localhost/ping")
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code, "a rewrite loop must terminate")
+}

--- a/internal/handler/router/router.go
+++ b/internal/handler/router/router.go
@@ -1,21 +1,28 @@
 package router
 
 import (
+	"context"
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/helpers"
 	"github.com/evg4b/uncors/internal/infra"
 
 	"github.com/gorilla/mux"
 )
 
-var errHostNotMapped = errors.New("host not mapped")
+// maxRewriteRedispatch bounds how many times a request may be rewritten before
+// it is refused, so that mutually recursive rewrite rules terminate.
+const maxRewriteRedispatch = 8
 
-func setDefaultHandler(router *mux.Router, handler http.Handler) {
-	router.NotFoundHandler = handler
-	router.MethodNotAllowedHandler = handler
-}
+var (
+	errHostNotMapped = errors.New("host not mapped")
+	errRewriteLoop   = errors.New("rewrite rules redirect the request in a loop")
+)
+
+type rewriteDepthKey struct{}
 
 type Router struct {
 	*mux.Router
@@ -33,60 +40,101 @@ func NewRouter(mappings config.Mappings, deps Deps) (*Router, error) {
 		instance.registerMapping(mapping)
 	}
 
-	setDefaultHandler(instance.Router, infra.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) error {
-		// instance.output.Errorf("Host %s://%s is not mapped", r.URL.Scheme, r.URL.Host)
-		// log.Printf("Host %s://%s is not mapped", r.URL.Scheme, r.URL.Host) // nolint: gosec
+	setDefaultHandler(instance.Router, infra.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) error {
+		//nolint:gosec // G706: the host is passed through SanitizeLogValue
+		log.Printf("Host %s is not mapped", helpers.SanitizeLogValue(request.Host))
+
 		return errHostNotMapped
 	}))
 
 	return &instance, nil
 }
 
+// registerMapping builds the request graph of a single mapping. The mapping gets
+// a router of its own so that its cross-cutting middleware wraps every route it
+// contains — mocks, scripts, statics and the proxy fallback alike — rather than
+// decorating one branch and silently skipping the others.
 func (r *Router) registerMapping(mapping config.Mapping) {
-	router := r.Router.Host(mapping.From.Hostname).
-		Subrouter()
+	mappingRouter := mux.NewRouter()
+	routes := mappingRouter.Host(mapping.From.Hostname).Subrouter()
 
-	defaultHandler := r.prepareDefaultHandler(mapping)
-
-	for _, staticDir := range mapping.Statics {
-		middleware := r.deps.Static(staticDir.Path, staticDir)
-		registerPrefixHandler(router, staticDir.Path, middleware(defaultHandler))
+	// The cache stays on the upstream branch on purpose: caching a mock, a
+	// script or a static file would only serve a stale copy of a response that
+	// is already produced locally.
+	upstream := r.deps.Proxy
+	if len(mapping.Cache) > 0 {
+		upstream = r.deps.Cache(mapping.Cache)(upstream)
 	}
 
+	// Registration order is the precedence policy: specific matchers first,
+	// path prefix catch-alls (statics, commonly mounted at "/") last, and the
+	// proxy fallback after everything else.
 	registerMatchedRoutes(mapping.Mocks,
 		func(m *config.Mock) *config.RequestMatcher { return &m.Matcher },
 		func(def *config.Mock) {
-			registerRoute(createRoute(router, def.Matcher), r.deps.Mock(&def.Response))
+			registerRoute(createRoute(routes, def.Matcher), r.deps.Mock(&def.Response))
 		})
 
 	registerMatchedRoutes(mapping.Scripts,
 		func(s *config.Script) *config.RequestMatcher { return &s.Matcher },
 		func(def *config.Script) {
-			registerRoute(createRoute(router, def.Matcher), r.deps.Script(def))
+			registerRoute(createRoute(routes, def.Matcher), r.deps.Script(def))
 		})
 
-	for _, rewrite := range mapping.Rewrites {
-		wrappedHandler := r.deps.Rewrite(&rewrite)(defaultHandler)
+	// A rewritten request re-enters the mapping's routes, so that it can be
+	// answered by a mock, a script or a static file instead of always going
+	// upstream.
+	redispatch := redispatchHandler(mappingRouter)
 
-		registerPathHandler(router, rewrite.From, wrappedHandler)
+	for _, rewriting := range mapping.Rewrites {
+		registerPathHandler(routes, rewriting.From, r.deps.Rewrite(&rewriting)(redispatch))
 	}
 
-	setDefaultHandler(router, defaultHandler)
+	for _, staticDir := range mapping.Statics {
+		registerPrefixHandler(routes, staticDir.Path, r.deps.Static(staticDir.Path, staticDir)(upstream))
+	}
+
+	// The fallback is a route rather than a NotFoundHandler because gorilla/mux
+	// does not run route middleware for the latter.
+	registerRoute(routes.NewRoute(), upstream)
+
+	r.Router.Host(mapping.From.Hostname).
+		Handler(r.wrapMapping(mapping, mappingRouter))
 }
 
-func (r *Router) prepareDefaultHandler(mapping config.Mapping) http.Handler {
-	defaultHandler := r.deps.Proxy
+// wrapMapping applies the middleware that belongs to the whole mapping rather
+// than to one of its routes.
+func (r *Router) wrapMapping(mapping config.Mapping, handler http.Handler) http.Handler {
+	// A CORS preflight is a transport concern: it is answered before the router
+	// decides whether the path is a mock, a static file or a proxy target.
 	if !mapping.OptionsHandling.Disabled {
-		defaultHandler = r.deps.Options(mapping.OptionsHandling)(defaultHandler)
+		handler = r.deps.Options(mapping.OptionsHandling)(handler)
 	}
 
-	if len(mapping.Cache) > 0 {
-		defaultHandler = r.deps.Cache(mapping.Cache)(defaultHandler)
-	}
-
+	// HAR records everything the mapping serves, locally produced responses
+	// included, which is what "records the traffic of a mapping" means.
 	if mapping.HAR.Enabled() {
-		defaultHandler = r.deps.HAR(&mapping.HAR)(defaultHandler)
+		handler = r.deps.HAR(&mapping.HAR)(handler)
 	}
 
-	return defaultHandler
+	return handler
+}
+
+func redispatchHandler(routes http.Handler) http.Handler {
+	return infra.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) error {
+		depth, _ := request.Context().Value(rewriteDepthKey{}).(int)
+		if depth >= maxRewriteRedispatch {
+			return errRewriteLoop
+		}
+
+		ctx := context.WithValue(request.Context(), rewriteDepthKey{}, depth+1)
+		routes.ServeHTTP(writer, request.WithContext(ctx))
+
+		return nil
+	})
+}
+
+func setDefaultHandler(router *mux.Router, handler http.Handler) {
+	router.NotFoundHandler = handler
+	router.MethodNotAllowedHandler = handler
 }


### PR DESCRIPTION
Fixes review finding **A06 — Cross-cutting middleware wraps only the proxy branch, so mocks, scripts and statics silently bypass HAR, cache and OPTIONS**.

HAR, cache and OPTIONS decorated only the proxy branch, so mocks, scripts and
statics bypassed them; statics were registered first and silently shadowed every
mock behind them (the documented "SPA with API proxying" setup); and a rewrite
short-circuited straight to the proxy, so rewrite-then-mock could not work.

- Each mapping is now its own router, wrapped once: OPTIONS answers preflights
  before routing, and HAR records every response the mapping produces.
- The cache deliberately stays on the upstream branch — caching a mock, a script
  or a static file would only serve a stale copy of a local response.
- Route precedence is now a policy rather than an accident: specific matchers,
  then path-only ones, then rewrites, then path-prefix statics, then the proxy.
  It is documented in docs/Configuration.md.
- A rewritten request re-enters the mapping's routes (bounded at 8 rounds), so it
  can be answered by a mock, a script or a static file.
- The unmapped-host fallback logs instead of carrying commented-out logging.

---

### Review

One commit, `d02ed27`. Step **6 of 33** in the review stack.

This PR targets **`refactor/a05-standard-http-handlers`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
