### PR TITLE
fix(http): keep streaming capabilities and bound body capture (A07)

### DIFF
--- a/internal/contracts/response_writer.go
+++ b/internal/contracts/response_writer.go
@@ -9,16 +9,15 @@ type ResponseCapture struct {
 	StatusCode int
 	Header     http.Header
 	Body       []byte
-	Duration   time.Duration
+	// Truncated reports that the response was larger than the capture limit, so
+	// Body holds only its beginning.
+	Truncated bool
+	Duration  time.Duration
 }
 
 type BodyCapturer interface {
-	EnableBodyCapture()
+	// EnableBodyCapture starts recording the response body, keeping at most
+	// maxBytes of it. Capture is skipped for responses that are meant to stream.
+	EnableBodyCapture(maxBytes int64)
 	Captured() ResponseCapture
-}
-
-type ResponseWriter interface {
-	http.ResponseWriter
-	StatusCode() int
-	BodyCapturer
 }

--- a/internal/handler/cache/middleware.go
+++ b/internal/handler/cache/middleware.go
@@ -67,7 +67,7 @@ func (m *Middleware) cacheRequest(writer http.ResponseWriter, request *http.Requ
 		capturer, writer = recorder, recorder
 	}
 
-	capturer.EnableBodyCapture()
+	capturer.EnableBodyCapture(infra.DefaultCaptureLimit)
 
 	next.ServeHTTP(writer, request)
 
@@ -76,6 +76,12 @@ func (m *Middleware) cacheRequest(writer http.ResponseWriter, request *http.Requ
 
 func (m *Middleware) storeResponse(key string, capture contracts.ResponseCapture) {
 	if !helpers.Is2xxCode(capture.StatusCode) {
+		return
+	}
+
+	// Storing a body we only saw the beginning of would serve a corrupted
+	// response on the next hit, so oversized responses are simply not cached.
+	if capture.Truncated {
 		return
 	}
 

--- a/internal/handler/har/middleware.go
+++ b/internal/handler/har/middleware.go
@@ -2,10 +2,8 @@ package har
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/evg4b/uncors/internal/contracts"
@@ -14,7 +12,12 @@ import (
 	"github.com/evg4b/uncors/pkg/urlt"
 )
 
-const nanosecondsPerMillisecond = 1e6
+const (
+	nanosecondsPerMillisecond = 1e6
+
+	// truncatedBodyComment marks entries whose body exceeded the capture limit.
+	truncatedBodyComment = "body truncated by uncors: response larger than the capture limit"
+)
 
 var secureHeaderNames = map[string]bool{
 	"Cookie":              true,
@@ -43,17 +46,10 @@ func (m *Middleware) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 
-		var reqBodySize int64
-
-		if req.Body != nil && req.Body != http.NoBody {
-			var buf strings.Builder
-
-			n, _ := io.Copy(&buf, req.Body)
-			reqBodySize = n
-			_ = req.Body.Close()
-
-			req.Body = io.NopCloser(strings.NewReader(buf.String()))
-		}
+		// The request body is reported, not buffered: HAR entries never carried
+		// postData, so reading the whole body into memory bought nothing and
+		// broke streamed uploads.
+		reqBodySize := max(req.ContentLength, 0)
 
 		// The pipeline normally installs a recorder; when it did not, record
 		// into one of our own rather than giving up on the archive.
@@ -63,7 +59,7 @@ func (m *Middleware) Wrap(next http.Handler) http.Handler {
 			capturer, writer = recorder, recorder
 		}
 
-		capturer.EnableBodyCapture()
+		capturer.EnableBodyCapture(infra.DefaultCaptureLimit)
 
 		next.ServeHTTP(writer, req)
 
@@ -135,6 +131,10 @@ func (m *Middleware) buildResponse(capture contracts.ResponseCapture) Response {
 
 	rawBody := capture.Body
 	content := buildContent(rawBody, capture.Header.Get("Content-Encoding"), mimeType)
+
+	if capture.Truncated {
+		content.Comment = truncatedBodyComment
+	}
 
 	return Response{
 		Status:      capture.StatusCode,

--- a/internal/handler/har/types.go
+++ b/internal/handler/har/types.go
@@ -63,6 +63,9 @@ type Content struct {
 	MimeType string `json:"mimeType"`
 	Text     string `json:"text,omitempty"`
 	Encoding string `json:"encoding,omitempty"`
+	// Comment records that the body was too large to keep in full, so that a
+	// partial body is never mistaken for a complete one.
+	Comment string `json:"comment,omitempty"`
 }
 
 // Timings breaks down request time into phases (all in ms).

--- a/internal/infra/recorder.go
+++ b/internal/infra/recorder.go
@@ -1,20 +1,37 @@
 package infra
 
 import (
+	"bufio"
 	"bytes"
 	"io"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/go-http-utils/headers"
 )
 
+// DefaultCaptureLimit bounds how much of a response body is kept in memory for
+// recording or caching. Without a bound, proxying a large download through a
+// mapping with HAR or cache enabled would buffer the whole thing.
+const DefaultCaptureLimit = 5 << 20 // 5 MiB
+
+// ResponseRecorder wraps the response writer of a request to observe its status
+// code and, on request, its body.
+//
+// It forwards the optional interfaces net/http's own writer implements. A
+// wrapper that swallows them silently breaks streaming: server sent events would
+// sit in the transport buffer, and connection upgrades would be impossible.
 type ResponseRecorder struct {
 	http.ResponseWriter
 
 	statusCode int
 	buf        *bytes.Buffer
-	output     io.Writer
+	limit      int64
+	truncated  bool
+	hijacked   bool
 	startedAt  time.Time
 }
 
@@ -38,41 +55,95 @@ func CaptureFrom(writer http.ResponseWriter) (contracts.BodyCapturer, bool) {
 }
 
 func NewResponseRecorder(w http.ResponseWriter) *ResponseRecorder {
-	rec := &ResponseRecorder{
+	return &ResponseRecorder{
 		ResponseWriter: w,
 		startedAt:      time.Now(),
 	}
-	rec.output = w
-
-	return rec
 }
 
 // Unwrap exposes the underlying writer, which is the convention net/http uses to
-// look through response writer wrappers.
+// look through response writer wrappers (http.NewResponseController).
 func (r *ResponseRecorder) Unwrap() http.ResponseWriter {
 	return r.ResponseWriter
 }
 
 func (r *ResponseRecorder) WriteHeader(statusCode int) {
 	r.statusCode = statusCode
+
+	if r.buf != nil && r.isStreaming() {
+		// A streamed response has no meaningful "body" to hold in memory, and
+		// buffering one would delay every event.
+		r.buf = nil
+	}
+
 	r.ResponseWriter.WriteHeader(statusCode)
 }
 
-func (r *ResponseRecorder) Write(b []byte) (int, error) {
-	return r.output.Write(b)
+func (r *ResponseRecorder) Write(chunk []byte) (int, error) {
+	r.capture(chunk)
+
+	return r.ResponseWriter.Write(chunk)
+}
+
+// ReadFrom lets io.Copy use the underlying writer's fast path when nothing needs
+// the body captured.
+func (r *ResponseRecorder) ReadFrom(src io.Reader) (int64, error) {
+	readerFrom, ok := r.ResponseWriter.(io.ReaderFrom)
+	if !ok || r.buf != nil {
+		return io.Copy(writerOnly{r}, src)
+	}
+
+	return readerFrom.ReadFrom(src)
+}
+
+// Flush forwards to the underlying writer so that streamed responses reach the
+// client as they are produced.
+func (r *ResponseRecorder) Flush() {
+	flusher, ok := r.ResponseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}
+
+// Hijack forwards connection upgrades (WebSocket and friends). A hijacked
+// connection is no longer an HTTP response, so nothing is recorded for it.
+func (r *ResponseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := r.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
+
+	conn, readWriter, err := hijacker.Hijack()
+	if err == nil {
+		r.hijacked = true
+		r.buf = nil
+	}
+
+	return conn, readWriter, err //nolint:wrapcheck // forwarding the writer's own error
 }
 
 func (r *ResponseRecorder) StatusCode() int {
 	return r.statusCode
 }
 
-func (r *ResponseRecorder) EnableBodyCapture() {
-	if r.buf != nil {
+// EnableBodyCapture starts capturing, keeping at most maxBytes. When capture is
+// already on, the larger of the two limits wins: consumers apply their own
+// policy to the result, and one of them asking for less must not shorten what
+// another one sees.
+func (r *ResponseRecorder) EnableBodyCapture(maxBytes int64) {
+	if r.hijacked {
 		return
 	}
 
-	r.buf = &bytes.Buffer{}
-	r.output = io.MultiWriter(r.buf, r.ResponseWriter)
+	if maxBytes <= 0 {
+		maxBytes = DefaultCaptureLimit
+	}
+
+	r.limit = max(r.limit, maxBytes)
+
+	if r.buf == nil {
+		r.buf = &bytes.Buffer{}
+	}
 }
 
 func (r *ResponseRecorder) Captured() contracts.ResponseCapture {
@@ -85,8 +156,43 @@ func (r *ResponseRecorder) Captured() contracts.ResponseCapture {
 		StatusCode: normaliseStatusCode(r.statusCode),
 		Header:     r.Header(),
 		Body:       body,
+		Truncated:  r.truncated,
 		Duration:   time.Since(r.startedAt),
 	}
+}
+
+func (r *ResponseRecorder) capture(chunk []byte) {
+	if r.buf == nil {
+		return
+	}
+
+	remaining := r.limit - int64(r.buf.Len())
+	if remaining <= 0 {
+		r.truncated = true
+
+		return
+	}
+
+	if int64(len(chunk)) > remaining {
+		r.buf.Write(chunk[:remaining])
+		r.truncated = true
+
+		return
+	}
+
+	r.buf.Write(chunk)
+}
+
+// isStreaming reports whether the response announces itself as a stream, in
+// which case capturing it would buffer an endless body.
+func (r *ResponseRecorder) isStreaming() bool {
+	header := r.Header()
+
+	if strings.HasPrefix(header.Get(headers.ContentType), "text/event-stream") {
+		return true
+	}
+
+	return header.Get(headers.ContentLength) == "" && r.statusCode == http.StatusSwitchingProtocols
 }
 
 func normaliseStatusCode(code int) int {
@@ -95,4 +201,10 @@ func normaliseStatusCode(code int) int {
 	}
 
 	return code
+}
+
+// writerOnly hides ReadFrom so that io.Copy falls back to Write, which is what
+// keeps body capture working on the copy path.
+type writerOnly struct {
+	io.Writer
 }

--- a/internal/infra/recorder_test.go
+++ b/internal/infra/recorder_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/infra"
+	"github.com/go-http-utils/headers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func TestResponseRecorder_Write(t *testing.T) {
 	t.Run("buffers body and still writes through when capture is enabled", func(t *testing.T) {
 		underlying := httptest.NewRecorder()
 		rec := infra.NewResponseRecorder(underlying)
-		rec.EnableBodyCapture()
+		rec.EnableBodyCapture(infra.DefaultCaptureLimit)
 
 		_, err := rec.Write([]byte("buffered"))
 		require.NoError(t, err)
@@ -74,7 +75,7 @@ func TestResponseRecorder_Captured(t *testing.T) {
 
 	t.Run("body is captured when EnableBodyCapture is called", func(t *testing.T) {
 		rec := infra.NewResponseRecorder(httptest.NewRecorder())
-		rec.EnableBodyCapture()
+		rec.EnableBodyCapture(infra.DefaultCaptureLimit)
 		_, err := rec.Write([]byte("captured"))
 		require.NoError(t, err)
 
@@ -83,8 +84,8 @@ func TestResponseRecorder_Captured(t *testing.T) {
 
 	t.Run("second EnableBodyCapture call is a no-op", func(t *testing.T) {
 		rec := infra.NewResponseRecorder(httptest.NewRecorder())
-		rec.EnableBodyCapture()
-		rec.EnableBodyCapture()
+		rec.EnableBodyCapture(infra.DefaultCaptureLimit)
+		rec.EnableBodyCapture(infra.DefaultCaptureLimit)
 		_, err := rec.Write([]byte("once"))
 		require.NoError(t, err)
 
@@ -110,4 +111,95 @@ func TestResponseRecorder_ImplementsInterfaces(t *testing.T) {
 	t.Run("implements BodyCapturer", func(_ *testing.T) {
 		var _ contracts.BodyCapturer = rec
 	})
+}
+
+func TestResponseRecorderCapabilities(t *testing.T) {
+	t.Run("forwards Flush to the underlying writer", func(t *testing.T) {
+		underlying := &flushableWriter{ResponseRecorder: httptest.NewRecorder()}
+		recorder := infra.NewResponseRecorder(underlying)
+
+		flusher, ok := any(recorder).(http.Flusher)
+		require.True(t, ok, "the recorder must be an http.Flusher, or nothing can stream")
+
+		flusher.Flush()
+
+		assert.True(t, underlying.flushed)
+	})
+
+	t.Run("is reachable through http.NewResponseController", func(t *testing.T) {
+		underlying := &flushableWriter{ResponseRecorder: httptest.NewRecorder()}
+		recorder := infra.NewResponseRecorder(underlying)
+
+		require.NoError(t, http.NewResponseController(recorder).Flush())
+		assert.True(t, underlying.flushed)
+	})
+
+	t.Run("reports that a plain writer cannot be hijacked", func(t *testing.T) {
+		recorder := infra.NewResponseRecorder(httptest.NewRecorder())
+
+		hijacker, ok := any(recorder).(http.Hijacker)
+		require.True(t, ok)
+
+		_, _, err := hijacker.Hijack()
+
+		require.ErrorIs(t, err, http.ErrNotSupported)
+	})
+}
+
+func TestResponseRecorderCaptureLimit(t *testing.T) {
+	t.Run("keeps at most the requested number of bytes", func(t *testing.T) {
+		const limit = 8
+
+		underlying := httptest.NewRecorder()
+		recorder := infra.NewResponseRecorder(underlying)
+		recorder.EnableBodyCapture(limit)
+
+		_, err := recorder.Write([]byte("0123456789abcdef"))
+		require.NoError(t, err)
+
+		capture := recorder.Captured()
+
+		assert.Equal(t, "01234567", string(capture.Body))
+		assert.True(t, capture.Truncated)
+		assert.Equal(t, "0123456789abcdef", underlying.Body.String(), "the client still gets the whole body")
+	})
+
+	t.Run("keeps the larger limit when two consumers enable capture", func(t *testing.T) {
+		recorder := infra.NewResponseRecorder(httptest.NewRecorder())
+		recorder.EnableBodyCapture(4)
+		recorder.EnableBodyCapture(16)
+
+		_, err := recorder.Write([]byte("0123456789"))
+		require.NoError(t, err)
+
+		capture := recorder.Captured()
+
+		assert.Equal(t, "0123456789", string(capture.Body))
+		assert.False(t, capture.Truncated)
+	})
+
+	t.Run("does not buffer a streamed response", func(t *testing.T) {
+		underlying := httptest.NewRecorder()
+		recorder := infra.NewResponseRecorder(underlying)
+		recorder.EnableBodyCapture(infra.DefaultCaptureLimit)
+
+		recorder.Header().Set(headers.ContentType, "text/event-stream")
+		recorder.WriteHeader(http.StatusOK)
+
+		_, err := recorder.Write([]byte("data: tick\n\n"))
+		require.NoError(t, err)
+
+		assert.Empty(t, recorder.Captured().Body)
+		assert.Equal(t, "data: tick\n\n", underlying.Body.String())
+	})
+}
+
+type flushableWriter struct {
+	*httptest.ResponseRecorder
+
+	flushed bool
+}
+
+func (w *flushableWriter) Flush() {
+	w.flushed = true
 }


### PR DESCRIPTION
Fixes review finding **A07 — `ResponseRecorder` drops `Flusher`/`Hijacker`, and body capture is unbounded**.

`ResponseRecorder` embedded the `http.ResponseWriter` interface, so it promoted
only three methods and silently dropped `Flusher`, `Hijacker` and `ReaderFrom`.
Nothing in the process could stream: server-sent events sat in the transport
buffer, and connection upgrades were impossible. Body capture had no limit, so
proxying a large download through a mapping with HAR or cache enabled buffered
the whole thing in memory.

- The recorder forwards `Flush`, `Hijack` and `ReadFrom`, and `Unwrap` makes it
  work with `http.NewResponseController`. A hijacked connection stops recording.
- Capture takes a limit (5 MiB by default), marks the capture truncated, and is
  skipped entirely for responses that announce themselves as streams.
- The cache declines to store a truncated body — serving half a response from
  cache would be a correctness bug; HAR marks it with a comment instead.
- HAR stops reading whole request bodies into memory: it never stored `postData`,
  so the buffering only broke streamed uploads.

---

### Review

One commit, `b44d569`. Step **7 of 33** in the review stack.

This PR targets **`fix/a06-mapping-wide-middleware`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
