### PR TITLE
refactor(proxy): forward with httputil.ReverseProxy (A08)

### DIFF
--- a/internal/handler/proxy/handler.go
+++ b/internal/handler/proxy/handler.go
@@ -1,176 +1,159 @@
 package proxy
 
 import (
-	"fmt"
-	"io"
+	"context"
+	"log"
 	"net/http"
+	"net/http/httputil"
+	"sync"
+	"time"
 
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/handler/rewrite"
 	"github.com/evg4b/uncors/internal/helpers"
 	"github.com/evg4b/uncors/internal/infra"
 	"github.com/evg4b/uncors/internal/urlreplacer"
-	"github.com/evg4b/uncors/pkg/urlt"
 	"github.com/go-http-utils/headers"
 )
+
+// flushInterval bounds how long a proxied byte may sit in the transport buffer.
+// httputil.ReverseProxy flushes immediately regardless for responses that stream
+// (text/event-stream, or an unknown content length).
+const flushInterval = 100 * time.Millisecond
+
+type replacersKey struct{}
+
+// exchange carries what the ReverseProxy hooks need about the inbound request:
+// they run after routing, and neither of them can report an error.
+type exchange struct {
+	target *urlreplacer.Replacer
+	source *urlreplacer.Replacer
+	origin string
+}
 
 type Handler struct {
 	replacers urlreplacer.ReplacerFactory
 	http      contracts.HTTPClient
 	output    contracts.Output
+
+	proxy *httputil.ReverseProxy
+
+	// rewriteReplacers memoises the replacers built for rewrite hosts. Building
+	// them compiles two regexps, and the set of hosts comes from the config, so
+	// it is small and bounded.
+	rewriteReplacers sync.Map
 }
 
 func NewProxyHandler(options ...HandlerOption) *Handler {
-	middleware := helpers.ApplyOptions(&Handler{}, options)
+	handler := helpers.ApplyOptions(&Handler{}, options)
 
-	helpers.AssertIsDefined(middleware.replacers, "ProxyHandler: ReplacerFactory is not configured")
-	helpers.AssertIsDefined(middleware.output, "ProxyHandler: Output is not configured")
-	helpers.AssertIsDefined(middleware.http, "ProxyHandler: Http client is not configured")
+	helpers.AssertIsDefined(handler.replacers, "ProxyHandler: ReplacerFactory is not configured")
+	helpers.AssertIsDefined(handler.output, "ProxyHandler: Output is not configured")
+	helpers.AssertIsDefined(handler.http, "ProxyHandler: Http client is not configured")
 
-	return middleware
+	handler.proxy = &httputil.ReverseProxy{
+		Rewrite:        rewriteRequest,
+		ModifyResponse: modifyResponse,
+		ErrorHandler:   handler.handleError,
+		Transport:      roundTripper{client: handler.http},
+		FlushInterval:  flushInterval,
+		ErrorLog:       log.Default(),
+	}
+
+	return handler
 }
 
 func (h *Handler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 	infra.HandlerFunc(h.Serve).ServeHTTP(response, request)
 }
 
-// Serve is the error returning form of ServeHTTP. ServeHTTP renders a returned
-// error as an HTTP error response; callers that want to handle it themselves
-// call Serve directly.
+// Serve is the error returning form of ServeHTTP. Only failures to resolve the
+// mapping are reported this way; upstream transport failures are rendered by the
+// proxy's error handler.
 func (h *Handler) Serve(response http.ResponseWriter, request *http.Request) error {
-	err := h.handle(response, request)
+	target, source, err := h.createReplacers(request)
 	if err != nil {
-		if request.Context().Err() != nil {
-			return err
-		}
-
 		h.output.Errorf("Proxy handler error: %v", err)
 
 		return err
 	}
 
-	return nil
-}
-
-func (h *Handler) handle(resp http.ResponseWriter, req *http.Request) error {
-	targetReplacer, sourceReplacer, err := h.createReplacers(req)
-	if err != nil {
-		return err
-	}
-
-	originalRequest, err := h.makeOriginalRequest(req, targetReplacer)
-	if err != nil {
-		return fmt.Errorf("failed to create request to original source: %w", err)
-	}
-
-	originalResponse, err := h.executeQuery(originalRequest)
-	if err != nil {
-		return err
-	}
-
-	defer helpers.CloseSafe(originalResponse.Body)
-
-	err = h.makeUncorsResponse(originalResponse, resp, sourceReplacer, req)
-	if err != nil {
-		return fmt.Errorf("failed to make uncors response: %w", err)
-	}
-
-	return nil
-}
-
-func (h *Handler) makeOriginalRequest(
-	req *http.Request,
-	replacer *urlreplacer.Replacer,
-) (*http.Request, error) {
-	url, err := replacer.Replace(urlt.URL_String(req.URL))
-	if err != nil {
-		return nil, fmt.Errorf("failed to replace URL: %w", err)
-	}
-
-	//nolint:gosec // G704: forwarding to user-configured target is intentional
-	originalRequest, err := http.NewRequestWithContext(req.Context(), req.Method, url, req.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make request to original server: %w", err)
-	}
-
-	err = copyHeaders(req.Header, originalRequest.Header, modificationsMap{
-		headers.Origin:  replacer.Replace,
-		headers.Referer: replacer.Replace,
+	ctx := context.WithValue(request.Context(), replacersKey{}, &exchange{
+		target: target,
+		source: source,
+		origin: request.Header.Get(headers.Origin),
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	copyCookiesToTarget(req, replacer, originalRequest)
-
-	return originalRequest, nil
-}
-
-func (h *Handler) makeUncorsResponse(
-	original *http.Response,
-	target http.ResponseWriter,
-	replacer *urlreplacer.Replacer,
-	req *http.Request,
-) error {
-	copyCookiesToSource(original, replacer, target)
-
-	err := copyHeaders(original.Header, target.Header(), modificationsMap{
-		headers.Location: func(s string) (string, error) { //nolint:unparam
-			return replacer.ReplaceSoft(s), nil
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	origin := req.Header.Get(headers.Origin)
-	infra.WriteCorsHeaders(target.Header(), origin)
-
-	target.WriteHeader(original.StatusCode)
-
-	_, err = io.Copy(target, original.Body)
-	if err != nil {
-		return fmt.Errorf("failed to copy body to response: %w", err)
-	}
+	h.proxy.ServeHTTP(response, request.WithContext(ctx))
 
 	return nil
+}
+
+func (h *Handler) handleError(writer http.ResponseWriter, request *http.Request, err error) {
+	if request.Context().Err() != nil {
+		// The client went away; there is nobody left to report to.
+		return
+	}
+
+	h.output.Errorf("Proxy handler error: %v", err)
+	http.Error(writer, "uncors: the request to the original source failed", http.StatusBadGateway)
 }
 
 func (h *Handler) createReplacers(req *http.Request) (*urlreplacer.Replacer, *urlreplacer.Replacer, error) {
 	rewriteHost, err := rewrite.GetRewriteHost(req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get rewrite host: %w", err)
+		return nil, nil, err
 	}
 
 	if rewriteHost == "" {
-		targetReplacer, sourceReplacer, err := h.replacers.Make(req.URL)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to transform general url: %w", err)
-		}
-
-		return targetReplacer, sourceReplacer, nil
+		return h.replacers.Make(req.URL)
 	}
 
-	target, err := urlreplacer.NewReplacer(req.URL.Host, rewriteHost)
+	return h.rewriteReplacersFor(req.URL.Host, rewriteHost)
+}
+
+func (h *Handler) rewriteReplacersFor(host, rewriteHost string) (*urlreplacer.Replacer, *urlreplacer.Replacer, error) {
+	key := host + "->" + rewriteHost
+
+	if cached, ok := h.rewriteReplacers.Load(key); ok {
+		pair, _ := cached.(*replacerPair)
+
+		return pair.target, pair.source, nil
+	}
+
+	target, err := urlreplacer.NewReplacer(host, rewriteHost)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	source, err := urlreplacer.NewReplacer(rewriteHost, req.URL.Host)
+	source, err := urlreplacer.NewReplacer(rewriteHost, host)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	h.rewriteReplacers.Store(key, &replacerPair{target: target, source: source})
 
 	return target, source, nil
 }
 
-func (h *Handler) executeQuery(request *http.Request) (*http.Response, error) {
-	originalResponse, err := h.http.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute request: %w", err)
-	}
+type replacerPair struct {
+	target *urlreplacer.Replacer
+	source *urlreplacer.Replacer
+}
 
-	return originalResponse, nil
+// roundTripper adapts the configured HTTP client to the transport the
+// ReverseProxy drives.
+type roundTripper struct {
+	client contracts.HTTPClient
+}
+
+func (t roundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	// The proxy hands over a clone of the inbound request, which still carries
+	// the server side RequestURI that http.Client refuses to send. The clone
+	// belongs to this call, so clearing it in place is safe.
+	request.RequestURI = ""
+
+	return t.client.Do(request) //nolint:wrapcheck // the proxy's ErrorHandler reports it
 }
 
 type HandlerOption = func(*Handler)

--- a/internal/handler/proxy/handler_test.go
+++ b/internal/handler/proxy/handler_test.go
@@ -327,7 +327,7 @@ func TestProxyHandler(t *testing.T) {
 		handler.ServeHTTP(infra.NewResponseRecorder(recorder), req)
 	})
 
-	t.Run("should return error when http client fails", func(t *testing.T) {
+	t.Run("should answer 502 when the upstream request fails", func(t *testing.T) {
 		httpMock := mocks.NewHTTPClientMock(t).DoMock.Set(func(_ *http.Request) (*http.Response, error) {
 			return nil, errNetworkError
 		})
@@ -348,9 +348,9 @@ func TestProxyHandler(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		responseWriter := infra.NewResponseRecorder(recorder)
 
-		handlerErr := handler.Serve(responseWriter, req)
+		require.NoError(t, handler.Serve(responseWriter, req))
 
-		assert.ErrorIs(t, handlerErr, errNetworkError)
+		assert.Equal(t, http.StatusBadGateway, recorder.Code)
 	})
 
 	t.Run("OPTIONS request handling", func(t *testing.T) {
@@ -423,6 +423,84 @@ func TestProxyHandler(t *testing.T) {
 					assert.Equal(t, testCase.expected, recorder.Header())
 				})
 			}
+		})
+	})
+}
+
+func TestProxyHandlerForwarding(t *testing.T) {
+	replacerFactory := urlreplacer.NewURLReplacerFactory(config.Mappings{
+		{From: hosts.Parse("http://premium.local.com"), To: hosts.Parse("https://premium.api.com")},
+	})
+
+	newRequest := func(t *testing.T) *http.Request {
+		t.Helper()
+
+		request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://premium.local.com/app", nil)
+		require.NoError(t, err)
+
+		request.Host = "premium.local.com"
+		request.RemoteAddr = "10.1.2.3:4567"
+		helpers.NormaliseRequest(request)
+
+		return request
+	}
+
+	serve := func(t *testing.T, request *http.Request, inspect func(*http.Request)) *httptest.ResponseRecorder {
+		t.Helper()
+
+		handler := proxy.NewProxyHandler(
+			proxy.WithHTTPClient(testutils.NewTestClient(func(outbound *http.Request) *http.Response {
+				inspect(outbound)
+
+				return &http.Response{
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+					Header:     http.Header{},
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    outbound,
+				}
+			})),
+			proxy.WithURLReplacerFactory(replacerFactory),
+			proxy.WithOutput(mocks.NoopOutput()),
+		)
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(infra.NewResponseRecorder(recorder), request)
+
+		return recorder
+	}
+
+	t.Run("does not forward hop-by-hop headers", func(t *testing.T) {
+		request := newRequest(t)
+		request.Header.Set("Connection", "keep-alive, X-Custom-Hop")
+		request.Header.Set("X-Custom-Hop", "dropped")
+		request.Header.Set(headers.ProxyAuthorization, "Basic dGVzdA==")
+
+		serve(t, request, func(outbound *http.Request) {
+			assert.Empty(t, outbound.Header.Get("Connection"))
+			assert.Empty(t, outbound.Header.Get("X-Custom-Hop"))
+			assert.Empty(t, outbound.Header.Get(headers.ProxyAuthorization))
+		})
+	})
+
+	t.Run("announces the original client", func(t *testing.T) {
+		serve(t, newRequest(t), func(outbound *http.Request) {
+			assert.Equal(t, "10.1.2.3", outbound.Header.Get(headers.XForwardedFor))
+			assert.Equal(t, "premium.local.com", outbound.Header.Get("X-Forwarded-Host"))
+			assert.Equal(t, "http", outbound.Header.Get(headers.XForwardedProto))
+		})
+	})
+
+	t.Run("keeps path and query while replacing the host", func(t *testing.T) {
+		request := newRequest(t)
+		request.URL.RawQuery = "q=a%20b&x=1"
+
+		serve(t, request, func(outbound *http.Request) {
+			assert.Equal(t, "premium.api.com", outbound.URL.Host)
+			assert.Equal(t, "https", outbound.URL.Scheme)
+			assert.Equal(t, "/app", outbound.URL.Path)
+			assert.Equal(t, "q=a%20b&x=1", outbound.URL.RawQuery)
+			assert.Equal(t, "premium.api.com", outbound.Host)
 		})
 	})
 }

--- a/internal/handler/proxy/helpers.go
+++ b/internal/handler/proxy/helpers.go
@@ -2,51 +2,101 @@ package proxy
 
 import (
 	"net/http"
+	"net/http/httputil"
 
+	"github.com/evg4b/uncors/internal/infra"
 	"github.com/evg4b/uncors/internal/urlreplacer"
 	"github.com/go-http-utils/headers"
 )
 
-type modificationsMap = map[string]func(string) (string, error)
-
-func noop(s string) (string, error) { return s, nil }
-
-func copyHeaders(source, dest http.Header, modifications modificationsMap) error {
-	for key, values := range source {
-		if key == headers.Cookie || key == headers.SetCookie || key == headers.ContentLength {
-			continue
-		}
-
-		modificationFunc, ok := modifications[headers.Normalize(key)]
-		if !ok {
-			modificationFunc = noop
-		}
-
-		for _, value := range values {
-			modifiedValue, err := modificationFunc(value)
-			if err != nil {
-				return err
-			}
-
-			dest.Add(key, modifiedValue)
-		}
+// rewriteRequest points the outbound request at the mapped origin. Hop-by-hop
+// headers, X-Forwarded-* and the request body are handled by ReverseProxy.
+func rewriteRequest(request *httputil.ProxyRequest) {
+	current := exchangeOf(request.In)
+	if current == nil {
+		return
 	}
+
+	targetURL, err := current.target.ReplaceURL(request.In.URL)
+	if err != nil {
+		// Serve resolved the replacers against this very URL, so a failure here
+		// is not reachable; leaving the URL alone makes the transport report it.
+		return
+	}
+
+	request.Out.URL = targetURL
+	request.Out.Host = targetURL.Host
+
+	request.SetXForwarded()
+
+	rewriteHeaders(request.Out.Header, current.target, headers.Origin, headers.Referer)
+}
+
+// modifyResponse maps the upstream response back onto the source origin.
+func modifyResponse(response *http.Response) error {
+	current := exchangeOf(response.Request)
+	if current == nil {
+		return nil
+	}
+
+	if response.Header == nil {
+		response.Header = http.Header{}
+	}
+
+	rewriteHeaders(response.Header, current.source, headers.Location)
+	rewriteResponseCookies(response, current.source)
+	infra.WriteCorsHeaders(response.Header, current.origin)
 
 	return nil
 }
 
-func copyCookiesToSource(target *http.Response, replacer *urlreplacer.Replacer, source http.ResponseWriter) {
-	for _, cookie := range target.Cookies() {
-		cookie.Secure = replacer.IsTargetSecure()
-		cookie.Domain = replacer.ReplaceSoft(cookie.Domain)
-		http.SetCookie(source, cookie)
+func exchangeOf(request *http.Request) *exchange {
+	if request == nil {
+		return nil
+	}
+
+	current, _ := request.Context().Value(replacersKey{}).(*exchange)
+
+	return current
+}
+
+// rewriteHeaders maps the URLs carried by the named headers onto the other side
+// of the mapping. Values that are not URLs of the mapped host are left as they
+// are.
+func rewriteHeaders(header http.Header, replacer *urlreplacer.Replacer, names ...string) {
+	for _, name := range names {
+		values := header.Values(name)
+		if len(values) == 0 {
+			continue
+		}
+
+		rewritten := make([]string, 0, len(values))
+		for _, value := range values {
+			rewritten = append(rewritten, replacer.ReplaceSoft(value))
+		}
+
+		header.Del(name)
+
+		for _, value := range rewritten {
+			header.Add(name, value)
+		}
 	}
 }
 
-func copyCookiesToTarget(source *http.Request, replacer *urlreplacer.Replacer, target *http.Request) {
-	for _, cookie := range source.Cookies() {
+// rewriteResponseCookies re-issues the upstream cookies for the source host, so
+// that the browser stores them against the address it actually talked to.
+func rewriteResponseCookies(response *http.Response, replacer *urlreplacer.Replacer) {
+	cookies := response.Cookies()
+	if len(cookies) == 0 {
+		return
+	}
+
+	response.Header.Del(headers.SetCookie)
+
+	for _, cookie := range cookies {
 		cookie.Secure = replacer.IsTargetSecure()
 		cookie.Domain = replacer.ReplaceSoft(cookie.Domain)
-		target.AddCookie(cookie)
+
+		response.Header.Add(headers.SetCookie, cookie.String())
 	}
 }

--- a/internal/urlreplacer/replacer.go
+++ b/internal/urlreplacer/replacer.go
@@ -3,6 +3,7 @@ package urlreplacer
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -100,6 +101,31 @@ func (r *Replacer) Replace(source string) (string, error) {
 	}
 
 	return replaced, nil
+}
+
+// ReplaceURL rewrites the scheme and host of a URL, carrying the path, query and
+// fragment across untouched. Placeholders are host-only, so there is nothing in
+// the rest of the URL to substitute, and the request path never has to survive a
+// render-match-reparse round trip.
+func (r *Replacer) ReplaceURL(source *url.URL) (*url.URL, error) {
+	replaced, err := r.Replace(source.Scheme + "://" + source.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, err := url.Parse(replaced)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse replaced url '%s': %w", replaced, err)
+	}
+
+	result := *source
+	result.Host = parsed.Host
+
+	if parsed.Scheme != "" {
+		result.Scheme = parsed.Scheme
+	}
+
+	return &result, nil
 }
 
 func (r *Replacer) ReplaceSoft(source string) string {

--- a/tests/integration/domains/__snapshots__/domains_test.snap
+++ b/tests/integration/domains/__snapshots__/domains_test.snap
@@ -4,6 +4,9 @@ GET /users HTTP/1.1
 Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: api.example.local:<port>
+X-Forwarded-Proto: https
 
 
 ---
@@ -28,6 +31,9 @@ GET /catalog HTTP/1.1
 Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: shop.local:<port>
+X-Forwarded-Proto: https
 
 
 ---

--- a/tests/integration/mock/__snapshots__/mock_test.snap
+++ b/tests/integration/mock/__snapshots__/mock_test.snap
@@ -38,6 +38,9 @@ Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 Content-Length: 0
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: mock.local:<port>
+X-Forwarded-Proto: https
 
 
 ---

--- a/tests/integration/options/__snapshots__/options_test.snap
+++ b/tests/integration/options/__snapshots__/options_test.snap
@@ -18,6 +18,9 @@ OPTIONS /any/path HTTP/1.1
 Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: options.local:<port>
+X-Forwarded-Proto: https
 
 
 ---

--- a/tests/integration/proxy/__snapshots__/proxy_test.snap
+++ b/tests/integration/proxy/__snapshots__/proxy_test.snap
@@ -4,6 +4,9 @@ GET /echo HTTP/1.1
 Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: app.example.local:<port>
+X-Forwarded-Proto: https
 
 
 ---
@@ -28,6 +31,9 @@ GET /echo HTTP/1.1
 Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: plain.local:<port>
+X-Forwarded-Proto: http
 
 
 ---

--- a/tests/integration/rewrite/__snapshots__/rewrite_test.snap
+++ b/tests/integration/rewrite/__snapshots__/rewrite_test.snap
@@ -4,6 +4,9 @@ GET /new HTTP/1.1
 Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: rewrite.local:<port>
+X-Forwarded-Proto: https
 
 
 ---
@@ -28,6 +31,9 @@ GET /accounts/42 HTTP/1.1
 Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: rewrite.local:<port>
+X-Forwarded-Proto: https
 
 
 ---

--- a/tests/integration/routing/__snapshots__/routing_test.snap
+++ b/tests/integration/routing/__snapshots__/routing_test.snap
@@ -4,6 +4,9 @@ GET /api/users HTTP/1.1
 Host: 127.0.0.1:<port>
 Accept-Encoding: gzip
 User-Agent: <scrubbed>
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Host: routing.local:<port>
+X-Forwarded-Proto: https
 
 
 ---


### PR DESCRIPTION
Fixes review finding **A08 — The proxy handler hand-rolls a reverse proxy instead of using `httputil.ReverseProxy`**.

The proxy hand-rolled request forwarding on top of http.Client. It forwarded
hop-by-hop headers verbatim (a spec violation that produces double
Transfer-Encoding and upstreams seeing upgrades they cannot honour), sent no
X-Forwarded-*, dropped trailers and 1xx responses, could not stream, could not
upgrade a connection, and answered upstream failures with a 500 stack-trace page.

- Forwarding is now `httputil.ReverseProxy`; uncors policy lives in its two
  hooks. `makeUncorsResponse`, `executeQuery`, `copyHeaders` and the
  cookie-copying helpers are gone.
- Upstream failures answer 502, not 500, and a client that went away is no
  longer reported as an error.
- `FlushInterval` bounds proxy latency; SSE and unknown-length responses flush
  immediately (ReverseProxy's own rule).
- `Replacer.ReplaceURL` rewrites scheme and host structurally and carries path,
  query and fragment across untouched, removing the render-match-reparse round
  trip from the hot path.
- Rewrite-host replacers are memoised instead of compiling two regexps per
  request.

Behaviour change: X-Forwarded-For/Host/Proto are now sent upstream, and
hop-by-hop headers are no longer forwarded. Integration snapshots updated.

---

### Review

One commit, `1c0d857`. Step **8 of 33** in the review stack.

This PR targets **`fix/a07-streaming-and-capture-limit`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
