### PR TITLE
perf(http): share one tuned transport per upstream proxy setting (A09)

### DIFF
--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evg4b/uncors/internal/commands"
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/helpers"
+	"github.com/evg4b/uncors/internal/infra"
 	"github.com/evg4b/uncors/internal/server"
 	"github.com/evg4b/uncors/internal/tui"
 	"github.com/spf13/afero"
@@ -24,6 +25,7 @@ type Container struct {
 	version string
 
 	cliOutput            func() contracts.Output
+	clients              func() *infra.ClientPool
 	requestTracker       func() *server.RequestTracker
 	generateCertsCommand func() *commands.GenerateCertsCommand
 	hostCertManager      func() *server.HostCertManager
@@ -72,7 +74,16 @@ func NewContainer(options ...ContainerOption) *Container {
 
 	container = helpers.ApplyOptions(container, options)
 
+	// The client pool is process scoped: a transport owns a connection pool and
+	// is meant to outlive any single configuration.
+	container.closers = append(container.closers, closerFn(func() error {
+		container.clients().CloseIdleConnections()
+
+		return nil
+	}))
+
 	container.cliOutput = sync.OnceValue(container.newCliOutput)
+	container.clients = sync.OnceValue(infra.NewClientPool)
 	container.requestTracker = sync.OnceValue(server.NewRequestTracker)
 	container.generateCertsCommand = sync.OnceValue(container.newGenerateCertsCommand)
 	container.hostCertManager = sync.OnceValue(container.newHostCertManager)
@@ -93,6 +104,11 @@ func (c *Container) Close() error {
 
 	return errors.Join(errs...)
 }
+
+// closerFn adapts a function to io.Closer.
+type closerFn func() error
+
+func (f closerFn) Close() error { return f() }
 
 func (c *Container) newCliOutput() contracts.Output {
 	if c.output != nil {

--- a/internal/di/public_api.go
+++ b/internal/di/public_api.go
@@ -75,12 +75,22 @@ func (c *Container) StaticMiddleware(path string, dir config.StaticDirectory) co
 	)
 }
 
-func (c *Container) VersionChecker(proxy string) *version.Checker {
+// HTTPClient returns the shared client for the given upstream proxy setting.
+func (c *Container) HTTPClient(proxy string) (*http.Client, error) {
+	return c.clients().For(proxy)
+}
+
+func (c *Container) VersionChecker(proxy string) (*version.Checker, error) {
+	client, err := c.HTTPClient(proxy)
+	if err != nil {
+		return nil, err
+	}
+
 	return version.NewVersionChecker(
 		version.WithOutput(c.CliOutput()),
-		version.WithHTTPClient(infra.MakeHTTPClient(proxy)),
+		version.WithHTTPClient(client),
 		version.WithCurrentVersion(c.version),
-	)
+	), nil
 }
 
 func (c *Container) MockHandler(response *config.Response) http.Handler {
@@ -111,13 +121,18 @@ func (c *Container) RewriteMiddleware(rewriting *config.RewritingOption) contrac
 	)
 }
 
-func (c *Container) ProxyHandler(mappings config.Mappings, proxyURL string) http.Handler {
+func (c *Container) ProxyHandler(mappings config.Mappings, proxyURL string) (http.Handler, error) {
+	client, err := c.HTTPClient(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
 	prefix := styles.ProxyStyle.Render("PROXY")
 	output := c.CliOutput()
 
 	return infra.WithPrefix(prefix, proxy.NewProxyHandler(
 		proxy.WithURLReplacerFactory(urlreplacer.NewURLReplacerFactory(mappings)),
-		proxy.WithHTTPClient(infra.MakeHTTPClient(proxyURL)),
+		proxy.WithHTTPClient(client),
 		proxy.WithOutput(output.NewPrefixOutput(prefix)),
-	))
+	)), nil
 }

--- a/internal/di/public_api_test.go
+++ b/internal/di/public_api_test.go
@@ -120,8 +120,9 @@ func TestContainer(t *testing.T) {
 	})
 
 	t.Run("version checker", func(t *testing.T) {
-		checker := container.VersionChecker("")
+		checker, err := container.VersionChecker("")
 
+		require.NoError(t, err)
 		assert.NotNil(t, checker)
 		assert.IsType(t, &version.Checker{}, checker)
 	})
@@ -156,8 +157,9 @@ func TestContainer(t *testing.T) {
 		mappings := config.Mappings{
 			{From: hosts.Localhost.HTTP(), To: hosts.Localhost.HTTPS()},
 		}
-		handler := container.ProxyHandler(mappings, "")
+		handler, err := container.ProxyHandler(mappings, "")
 
+		require.NoError(t, err)
 		assert.NotNil(t, handler)
 		assert.Implements(t, (*http.Handler)(nil), handler)
 	})

--- a/internal/di/runtime.go
+++ b/internal/di/runtime.go
@@ -133,8 +133,13 @@ func (r *Runtime) buildTargets(uncorsConfig *config.UncorsConfig) ([]server.Targ
 }
 
 func (r *Runtime) router(mappings config.Mappings, proxyURL string) (http.Handler, error) {
+	proxyHandler, err := r.container.ProxyHandler(mappings, proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
 	muxRouter, err := router.NewRouter(mappings, router.Deps{
-		Proxy:   r.container.ProxyHandler(mappings, proxyURL),
+		Proxy:   proxyHandler,
 		Static:  r.container.StaticMiddleware,
 		Rewrite: r.container.RewriteMiddleware,
 		Options: r.container.OptionsMiddleware,

--- a/internal/infra/httpclient.go
+++ b/internal/infra/httpclient.go
@@ -1,33 +1,110 @@
 package infra
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 )
 
-const defaultTimeout = 5 * time.Minute
+const (
+	// maxIdleConnsPerHost is well above the ~6 parallel connections a browser
+	// opens per host, so a browser driven workload reuses connections instead of
+	// paying for a TCP and TLS handshake per request. The standard library's
+	// default of 2 makes that impossible.
+	maxIdleConnsPerHost = 32
 
-func MakeHTTPClient(proxy string) *http.Client {
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+	// responseHeaderTimeout bounds an upstream that accepts the connection and
+	// then never replies. There is deliberately no whole-request timeout: that
+	// would cap long downloads and make streamed responses impossible. A client
+	// that gives up cancels the inbound request context instead.
+	responseHeaderTimeout = 60 * time.Second
+)
+
+// errUnexpectedDefaultTransport guards the assumption that the standard
+// library's default transport is an *http.Transport we can clone.
+var errUnexpectedDefaultTransport = errors.New("http.DefaultTransport is not an *http.Transport")
+
+// ClientPool hands out the HTTP clients used to talk to upstreams. A transport
+// owns a connection pool and is meant to be shared and long lived, so there is
+// one client per distinct upstream proxy setting rather than one per handler.
+type ClientPool struct {
+	mu      sync.Mutex
+	clients map[string]*http.Client
+}
+
+func NewClientPool() *ClientPool {
+	return &ClientPool{clients: map[string]*http.Client{}}
+}
+
+// For returns the client for the given upstream proxy ("" means "use the
+// environment"), creating it on first use.
+func (p *ClientPool) For(proxy string) (*http.Client, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if client, ok := p.clients[proxy]; ok {
+		return client, nil
 	}
+
+	client, err := newHTTPClient(proxy)
+	if err != nil {
+		return nil, err
+	}
+
+	p.clients[proxy] = client
+
+	return client, nil
+}
+
+// CloseIdleConnections releases the keep-alive connections held by every client
+// in the pool. Without it, each discarded generation of the configuration would
+// leave its idle connections open until the upstream or the OS closed them.
+func (p *ClientPool) CloseIdleConnections() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, client := range p.clients {
+		client.CloseIdleConnections()
+	}
+}
+
+// Close implements io.Closer so the pool can take part in generation teardown.
+func (p *ClientPool) Close() error {
+	p.CloseIdleConnections()
+
+	return nil
+}
+
+func newHTTPClient(proxy string) (*http.Client, error) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errUnexpectedDefaultTransport
+	}
+
+	// Cloning the default transport keeps the standard library's timeouts,
+	// connection limits and HTTP/2 support instead of silently opting out of all
+	// of them by building a transport from its zero value.
+	upstream := transport.Clone()
+	upstream.MaxIdleConnsPerHost = maxIdleConnsPerHost
+	upstream.ResponseHeaderTimeout = responseHeaderTimeout
+	upstream.ForceAttemptHTTP2 = true
 
 	if proxy != "" {
 		parsedURL, err := url.Parse(proxy)
 		if err != nil {
-			panic(fmt.Errorf("failed to create http client: %w", err))
+			return nil, fmt.Errorf("failed to create http client: %w", err)
 		}
 
-		transport.Proxy = http.ProxyURL(parsedURL)
+		upstream.Proxy = http.ProxyURL(parsedURL)
 	}
 
 	return &http.Client{
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
-		Transport: transport,
-		Timeout:   defaultTimeout,
-	}
+		Transport: upstream,
+	}, nil
 }

--- a/internal/infra/httpclient_internal_test.go
+++ b/internal/infra/httpclient_internal_test.go
@@ -8,43 +8,74 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMakeHTTPClient(t *testing.T) {
-	t.Run("return client with default transport where proxy is not set", func(t *testing.T) {
-		client := MakeHTTPClient("")
+func TestClientPool(t *testing.T) {
+	t.Run("returns a client with a tuned transport", func(t *testing.T) {
+		client, err := NewClientPool().For("")
 
-		assert.NotNil(t, client)
-		assert.NotNil(t, client.Transport)
-		assert.Equal(t, defaultTimeout, client.Timeout)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok)
+
+		assert.Equal(t, maxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+		assert.Equal(t, responseHeaderTimeout, transport.ResponseHeaderTimeout)
+		assert.True(t, transport.ForceAttemptHTTP2)
+
+		// A whole-request deadline would cap long downloads and make streamed
+		// responses impossible.
+		assert.Zero(t, client.Timeout)
 	})
 
-	t.Run("check redirect should return error", func(t *testing.T) {
-		t.Run("for default client", func(t *testing.T) {
-			client := MakeHTTPClient("")
+	t.Run("reuses one client per upstream proxy setting", func(t *testing.T) {
+		pool := NewClientPool()
 
-			err := client.CheckRedirect(nil, nil)
-			require.ErrorIs(t, http.ErrUseLastResponse, err)
-		})
+		first, err := pool.For("")
+		require.NoError(t, err)
 
-		t.Run("for client with proxy", func(t *testing.T) {
-			client := MakeHTTPClient("http://localhost:8000")
+		second, err := pool.For("")
+		require.NoError(t, err)
 
-			err := client.CheckRedirect(nil, nil)
-			require.ErrorIs(t, http.ErrUseLastResponse, err)
-		})
+		viaProxy, err := pool.For("http://localhost:8000")
+		require.NoError(t, err)
+
+		assert.Same(t, first, second, "a transport owns a connection pool and must be shared")
+		assert.NotSame(t, first, viaProxy)
 	})
 
-	t.Run("return configured client where proxy is set", func(t *testing.T) {
-		client := MakeHTTPClient("http://localhost:8000")
+	t.Run("does not follow redirects", func(t *testing.T) {
+		client, err := NewClientPool().For("")
+		require.NoError(t, err)
 
-		assert.NotNil(t, client)
-		assert.NotNil(t, client.Transport)
-		assert.Equal(t, defaultTimeout, client.Timeout)
+		require.ErrorIs(t, client.CheckRedirect(nil, nil), http.ErrUseLastResponse)
 	})
 
-	t.Run("return error where url is incorrect", func(t *testing.T) {
-		expectedError := "failed to create http client: parse \"http://loca^host:8000\": invalid character \"^\" in host name"
-		assert.PanicsWithError(t, expectedError, func() {
-			MakeHTTPClient("http://loca^host:8000")
-		})
+	t.Run("routes through the configured proxy", func(t *testing.T) {
+		client, err := NewClientPool().For("http://localhost:8000")
+		require.NoError(t, err)
+
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.NotNil(t, transport.Proxy)
+
+		proxyURL, err := transport.Proxy(&http.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8000", proxyURL.String())
+	})
+
+	t.Run("reports an invalid proxy url instead of panicking", func(t *testing.T) {
+		client, err := NewClientPool().For("http://loca^host:8000")
+
+		require.Error(t, err)
+		assert.Nil(t, client)
+	})
+
+	t.Run("closing releases idle connections", func(t *testing.T) {
+		pool := NewClientPool()
+
+		_, err := pool.For("")
+		require.NoError(t, err)
+
+		require.NoError(t, pool.Close())
 	})
 }

--- a/internal/uncors_app/app.go
+++ b/internal/uncors_app/app.go
@@ -373,8 +373,14 @@ func (m *UncorsApp) versionCheckCmd() tea.Cmd {
 	return func() tea.Msg {
 		time.Sleep(versionCheckDelay)
 
-		m.container.VersionChecker(m.cfg.Proxy).
-			CheckNewVersion(m.appContext())
+		checker, err := m.container.VersionChecker(m.cfg.Proxy)
+		if err != nil {
+			log.Printf("Version check failed: %v", err)
+
+			return nil
+		}
+
+		checker.CheckNewVersion(m.appContext())
 
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -167,8 +167,14 @@ func startVersionChecker(ctx context.Context, container *di.Container, proxy str
 
 	time.Sleep(checkDelay)
 
-	container.VersionChecker(proxy).
-		CheckNewVersion(ctx)
+	checker, err := container.VersionChecker(proxy)
+	if err != nil {
+		log.Printf("Version check failed: %v", err)
+
+		return
+	}
+
+	checker.CheckNewVersion(ctx)
 }
 
 // runInteractive starts the proxy in interactive TUI mode.


### PR DESCRIPTION
Fixes review finding **A09 — A fresh `http.Transport` is created per port group and per reload, and none are ever closed**.

`MakeHTTPClient` built a transport from its zero value and was called once per
port group and again for every port group on every config reload. Each call
created an independent connection pool that nothing ever closed, and every
tunable was left at zero — `MaxIdleConnsPerHost` at 2, no HTTP/2, none of the
standard library's timeouts — while a 5 minute whole-request deadline capped
long downloads.

- `infra.ClientPool` memoises one client per upstream proxy setting and releases
  idle connections on teardown.
- The transport is cloned from `http.DefaultTransport`, so it keeps the standard
  timeouts and HTTP/2, with `MaxIdleConnsPerHost` raised to 32 — a browser opens
  ~6 connections per host, which the default of 2 turned into a handshake per
  request.
- The whole-request timeout is gone; a hung upstream is bounded by
  `ResponseHeaderTimeout` and a client that gives up by its request context.
- An invalid proxy URL is an error instead of a panic inside a factory.

---

### Review

One commit, `65edd3e`. Step **9 of 33** in the review stack.

This PR targets **`refactor/a08-reverse-proxy`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
