### PR TITLE
refactor(app): one lifecycle for both run modes (A10)

### DIFF
--- a/internal/uncors/runner.go
+++ b/internal/uncors/runner.go
@@ -1,0 +1,96 @@
+package uncors
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/evg4b/uncors/internal/helpers"
+)
+
+// shutdownTimeout bounds how long in-flight requests are given to finish. It is
+// a property of the proxy, not of the run mode that started it.
+const shutdownTimeout = 15 * time.Second
+
+// VersionCheck looks for a newer release and reports it to the user.
+type VersionCheck = func(ctx context.Context)
+
+// Runner owns the process wide lifecycle of the proxy: startup, config watching,
+// the version check, signal handling and shutdown.
+//
+// Both run modes drive the same Runner, so none of that can differ between an
+// interactive and a headless process — which is how interactive mode came to
+// ignore SIGTERM, headless came to leak its config watcher, and the two came to
+// use different shutdown timeouts.
+type Runner struct {
+	app          *Uncors
+	reloader     *Reloader
+	output       contracts.Output
+	checkVersion VersionCheck
+}
+
+func NewRunner(app *Uncors, reloader *Reloader, output contracts.Output, checkVersion VersionCheck) *Runner {
+	return &Runner{
+		app:          app,
+		reloader:     reloader,
+		output:       output,
+		checkVersion: checkVersion,
+	}
+}
+
+// Start brings the proxy up and begins watching the config file and the shutdown
+// signals. It returns once the listeners are live.
+func (r *Runner) Start(ctx context.Context, uncorsConfig *config.UncorsConfig) error {
+	err := r.app.Start(ctx, uncorsConfig)
+	if err != nil {
+		return err
+	}
+
+	watchErr := r.reloader.Start(ctx)
+	if watchErr != nil {
+		log.Printf("Failed to watch config file: %v", watchErr)
+		r.output.Errorf("Failed to watch config file: %v", watchErr)
+	}
+
+	go r.awaitShutdownSignal(ctx)
+
+	if r.checkVersion != nil {
+		go r.checkVersion(ctx)
+	}
+
+	return nil
+}
+
+// Wait blocks until every listener has stopped.
+func (r *Runner) Wait() {
+	r.app.Wait()
+}
+
+// Reload applies the configuration currently on disk.
+func (r *Runner) Reload(ctx context.Context) error {
+	return r.reloader.Reload(ctx)
+}
+
+// Shutdown stops watching the config and drains the listeners.
+func (r *Runner) Shutdown(ctx context.Context) error {
+	// The shutdown deadline must survive the cancellation that usually triggers
+	// it, or in-flight requests would be cut off instead of drained.
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownTimeout)
+	defer cancel()
+
+	return errors.Join(
+		r.reloader.Close(),
+		r.app.Shutdown(shutdownCtx),
+	)
+}
+
+func (r *Runner) awaitShutdownSignal(ctx context.Context) {
+	helpers.GracefulShutdown(ctx, func(shutdownCtx context.Context) error {
+		log.Println("shutdown signal received")
+
+		return r.Shutdown(shutdownCtx)
+	})
+}

--- a/internal/uncors_app/app.go
+++ b/internal/uncors_app/app.go
@@ -17,8 +17,6 @@ import (
 
 const (
 	outputChannelSize = 1000
-	shutdownTimeout   = 5 * time.Second
-	versionCheckDelay = 50 * time.Millisecond
 	memTickInterval   = 2 * time.Second
 	bytesPerMegabyte  = 1024 * 1024
 )
@@ -40,6 +38,7 @@ type UncorsApp struct {
 	configPath string
 
 	reloader *uncors.Reloader
+	runner   *uncors.Runner
 
 	termHeight int
 	termWidth  int
@@ -70,6 +69,7 @@ func NewUncorsApp(
 	configPath string,
 	cfg *config.UncorsConfig,
 	loadConfig uncors.ConfigLoader,
+	checkVersion uncors.VersionCheck,
 ) *UncorsApp {
 	appCtx, cancel := context.WithCancel(context.Background())
 
@@ -78,6 +78,7 @@ func NewUncorsApp(
 	historyWidget := NewHistoryWidget(keys)
 
 	app := uncors.CreateUncors(container)
+	reloader := uncors.NewReloader(app, output, loadConfig, configPath)
 
 	return &UncorsApp{
 		keys:          keys,
@@ -91,7 +92,8 @@ func NewUncorsApp(
 		cancel:        cancel,
 		cfg:           cfg,
 		configPath:    configPath,
-		reloader:      uncors.NewReloader(app, output, loadConfig, configPath),
+		reloader:      reloader,
+		runner:        uncors.NewRunner(app, reloader, output, checkVersion),
 		historyWidget: historyWidget,
 		trackerWidget: NewTrackerWidget(),
 		helpWidget:    NewHelpWidget(keys),
@@ -248,8 +250,10 @@ func (m *UncorsApp) footerHeight() int {
 	return footerHeight
 }
 
-func (msg serverStartedMsg) update(app *UncorsApp) tea.Cmd {
-	return app.handleServerStarted()
+// The runner starts config watching, signal handling and the version check as
+// part of startup, so there is nothing left for the model to kick off here.
+func (msg serverStartedMsg) update(*UncorsApp) tea.Cmd {
+	return nil
 }
 
 func (msg serverErrMsg) update(app *UncorsApp) tea.Cmd {
@@ -258,16 +262,6 @@ func (msg serverErrMsg) update(app *UncorsApp) tea.Cmd {
 
 func (msg shutdownMsg) update(app *UncorsApp) tea.Cmd {
 	return app.handleShutdown()
-}
-
-func (m *UncorsApp) handleServerStarted() tea.Cmd {
-	err := m.reloader.Start(m.appContext())
-	if err != nil {
-		log.Printf("Failed to watch config file: %v", err)
-		m.output.Errorf("Failed to watch config file: %v", err)
-	}
-
-	return m.versionCheckCmd()
 }
 
 func (m *UncorsApp) handleServerError(msg serverErrMsg) tea.Cmd {
@@ -305,7 +299,7 @@ func (m *UncorsApp) handleShutdown() tea.Cmd {
 
 func (m *UncorsApp) startServerCmd() tea.Cmd {
 	return func() tea.Msg {
-		err := m.app.Start(m.appContext(), m.cfg)
+		err := m.runner.Start(m.appContext(), m.cfg)
 		if err != nil {
 			return serverErrMsg{err: err}
 		}
@@ -346,12 +340,13 @@ func (m *UncorsApp) watchEventsCmd() tea.Cmd {
 
 func (m *UncorsApp) shutdownCmd() tea.Cmd {
 	return func() tea.Msg {
+		ctx := m.appContext()
 		m.cancel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-
-		_ = m.app.Shutdown(ctx)
+		err := m.runner.Shutdown(ctx)
+		if err != nil {
+			log.Printf("Shutdown error: %v", err)
+		}
 
 		return shutdownMsg{}
 	}
@@ -359,29 +354,12 @@ func (m *UncorsApp) shutdownCmd() tea.Cmd {
 
 func (m *UncorsApp) restartCmd() tea.Cmd {
 	return func() tea.Msg {
-		err := m.reloader.Reload(m.appContext())
+		err := m.runner.Reload(m.appContext())
 		if err != nil {
 			log.Printf("Failed to restart: %v", err)
 			m.output.Errorf("Failed to restart: %v", err)
 		}
 
 		return restartMsg{}
-	}
-}
-
-func (m *UncorsApp) versionCheckCmd() tea.Cmd {
-	return func() tea.Msg {
-		time.Sleep(versionCheckDelay)
-
-		checker, err := m.container.VersionChecker(m.cfg.Proxy)
-		if err != nil {
-			log.Printf("Version check failed: %v", err)
-
-			return nil
-		}
-
-		checker.CheckNewVersion(m.appContext())
-
-		return nil
 	}
 }

--- a/internal/uncors_app/app_internal_test.go
+++ b/internal/uncors_app/app_internal_test.go
@@ -1,6 +1,7 @@
 package uncorsapp
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"os"
@@ -46,6 +47,7 @@ func newTestApp(t *testing.T) (*UncorsApp, *int) {
 
 			return uncorsConfig, nil
 		},
+		func(context.Context) {},
 	)
 
 	return app, &loadCalls
@@ -165,9 +167,6 @@ func TestUncorsAppCommandFactoriesAndChannels(t *testing.T) {
 
 		msg := app.startServerCmd()()
 		assert.IsType(t, serverStartedMsg{}, msg)
-
-		cmd := app.handleServerStarted()
-		require.NotNil(t, cmd)
 
 		msg = app.restartCmd()()
 		assert.Equal(t, restartMsg{}, msg)
@@ -304,14 +303,15 @@ func TestServerStartedMsgUpdate(t *testing.T) {
 	app, _ := newTestApp(t)
 	defer cleanupTestApp(t, app)
 
-	model, cmd := app.Update(serverStartedMsg{})
+	model, _ := app.Update(serverStartedMsg{})
 
 	require.Same(t, app, model)
-	require.NotNil(t, cmd)
 }
 
-func TestHandleServerStartedWithConfigPath(t *testing.T) {
-	t.Run("creates watcher when config file exists", func(t *testing.T) {
+// The config watcher, the signal handler and the version check are started by
+// the shared runner, so that they behave identically in both run modes.
+func TestStartServerWatchesTheConfigFile(t *testing.T) {
+	t.Run("watches an existing config file", func(t *testing.T) {
 		tmpFile, err := os.CreateTemp(t.TempDir(), "uncors-*.yaml")
 		require.NoError(t, err)
 
@@ -324,7 +324,7 @@ func TestHandleServerStartedWithConfigPath(t *testing.T) {
 		defer testutils.Close(t, container)
 
 		loader := func() (*config.UncorsConfig, error) { return cfg, nil }
-		app := NewUncorsApp(container, NewOutput(), tmpFile.Name(), cfg, loader)
+		app := NewUncorsApp(container, NewOutput(), tmpFile.Name(), cfg, loader, func(context.Context) {})
 
 		defer func() {
 			app.cancel()
@@ -337,22 +337,20 @@ func TestHandleServerStartedWithConfigPath(t *testing.T) {
 			}
 		}()
 
-		cmd := app.handleServerStarted()
-
-		require.NotNil(t, cmd)
+		require.IsType(t, serverStartedMsg{}, app.startServerCmd()())
 		require.True(t, app.reloader.Watching())
 
 		require.NoError(t, app.reloader.Close())
 	})
 
-	t.Run("logs error when config file does not exist", func(t *testing.T) {
+	t.Run("reports a missing config file and keeps running", func(t *testing.T) {
 		cfg := &config.UncorsConfig{Mappings: config.Mappings{}}
 
 		container := di.NewContainer()
 		defer testutils.Close(t, container)
 
 		loader := func() (*config.UncorsConfig, error) { return cfg, nil }
-		app := NewUncorsApp(container, NewOutput(), "/nonexistent/path/config.yaml", cfg, loader)
+		app := NewUncorsApp(container, NewOutput(), "/nonexistent/path/config.yaml", cfg, loader, func(context.Context) {})
 
 		defer func() {
 			app.cancel()
@@ -365,9 +363,7 @@ func TestHandleServerStartedWithConfigPath(t *testing.T) {
 			}
 		}()
 
-		cmd := app.handleServerStarted()
-
-		require.NotNil(t, cmd)
+		require.IsType(t, serverStartedMsg{}, app.startServerCmd()())
 		assert.False(t, app.reloader.Watching())
 	})
 }
@@ -414,7 +410,7 @@ func TestHandleServerStartedCallbackOnFileChange(t *testing.T) {
 		}
 
 		return cfg, nil
-	})
+	}, func(context.Context) {})
 
 	defer func() {
 		// Cancel context first so any in-flight Restart fails fast.
@@ -431,9 +427,7 @@ func TestHandleServerStartedCallbackOnFileChange(t *testing.T) {
 		}
 	}()
 
-	cmd := app.handleServerStarted()
-
-	require.NotNil(t, cmd)
+	require.IsType(t, serverStartedMsg{}, app.startServerCmd()())
 	require.True(t, app.reloader.Watching())
 
 	require.NoError(t, os.WriteFile(tmpFile.Name(), []byte("proxy: \"\""), 0o600))

--- a/internal/uncors_app/output.go
+++ b/internal/uncors_app/output.go
@@ -3,22 +3,40 @@ package uncorsapp
 import (
 	"bytes"
 	"strings"
+	"sync"
 
 	"github.com/evg4b/uncors/internal/contracts"
 	"github.com/evg4b/uncors/internal/tui"
 )
 
 // Output is the TUI's contracts.Output implementation: every line it is given
-// is queued on a channel that the model drains and renders. It is created before
-// the container so that the container can be built with it, instead of having it
-// swapped in after other components may already have captured the default one.
+// is rendered and queued on a channel that the model drains. It is created
+// before the container so that the container can be built with it, instead of
+// having it swapped in after other components may already have captured the
+// default one.
+//
+// The renderers and their buffer are built once per Output and reused, rather
+// than allocated per line.
 type Output struct {
 	ch     chan string
 	prefix string
+
+	mu          sync.Mutex
+	buf         bytes.Buffer
+	renderer    *tui.CliOutput
+	boxRenderer *tui.CliOutput
 }
 
 func NewOutput() *Output {
-	return &Output{ch: make(chan string, outputChannelSize)}
+	return newOutput(make(chan string, outputChannelSize), "")
+}
+
+func newOutput(ch chan string, prefix string) *Output {
+	output := &Output{ch: ch, prefix: prefix}
+	output.renderer = tui.NewCliOutput(&output.buf, tui.WithPrefix(prefix))
+	output.boxRenderer = tui.NewCliOutput(&output.buf)
+
+	return output
 }
 
 // Lines returns the channel of rendered output lines for the model to drain.
@@ -81,10 +99,7 @@ func (o *Output) Request(data *contracts.RequestData) {
 }
 
 func (o *Output) NewPrefixOutput(prefix string) contracts.Output {
-	return &Output{
-		ch:     o.ch,
-		prefix: prefix,
-	}
+	return newOutput(o.ch, prefix)
 }
 
 func (o *Output) send(msg string) {
@@ -98,15 +113,19 @@ func (o *Output) send(msg string) {
 }
 
 func (o *Output) capture(fn func(out *tui.CliOutput)) {
-	var buf bytes.Buffer
-
-	tmp := tui.NewCliOutput(&buf, tui.WithPrefix(o.prefix))
-	fn(tmp)
-	o.send(buf.String())
+	o.send(o.render(o.renderer, fn))
 }
 
 func (o *Output) captureBox(fn func(out *tui.CliOutput)) {
-	var buf bytes.Buffer
-	fn(tui.NewCliOutput(&buf))
-	o.send(buf.String())
+	o.send(o.render(o.boxRenderer, fn))
+}
+
+func (o *Output) render(renderer *tui.CliOutput, fn func(out *tui.CliOutput)) string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.buf.Reset()
+	fn(renderer)
+
+	return o.buf.String()
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/evg4b/uncors/internal/config"
@@ -59,11 +58,23 @@ func run() int {
 
 	// The output implementation is chosen before the container is built, so
 	// nothing can capture the wrong one.
-	if uncorsConfig.Interactive {
+	if uncorsConfig.Interactive && isTerminal(os.Stdout) {
 		return runInteractive(console, fs, configPath, uncorsConfig)
 	}
 
 	return runNonInteractive(context.Background(), fs, configPath, uncorsConfig)
+}
+
+// isTerminal reports whether the writer is an interactive terminal. Interactive
+// mode is the default, so without this check `uncors | tee log.txt`, a CI script
+// and the Docker image would all start a full-screen TUI against a pipe.
+func isTerminal(file *os.File) bool {
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+
+	return info.Mode()&os.ModeCharDevice != 0
 }
 
 func newContainer(fs afero.Fs, options ...di.ContainerOption) *di.Container {
@@ -123,34 +134,19 @@ func runNonInteractive(
 
 	go server.RequestPrinter(tracker, output)
 
-	reloader := uncors.NewReloader(app, output, configLoader(fs), configPath)
-	defer func() {
-		closeErr := reloader.Close()
-		if closeErr != nil {
-			log.Printf("Failed to close config watcher: %v", closeErr)
-		}
-	}()
+	runner := uncors.NewRunner(
+		app,
+		uncors.NewReloader(app, output, configLoader(fs), configPath),
+		output,
+		versionCheck(container, cfg.Proxy),
+	)
 
-	err := app.Start(ctx, cfg)
+	err := runner.Start(ctx, cfg)
 	if err != nil {
 		panic(err)
 	}
 
-	err = reloader.Start(ctx)
-	if err != nil {
-		log.Printf("Failed to start config watcher: %v", err)
-		output.Errorf("Failed to start config watcher: %v", err)
-	}
-
-	go startVersionChecker(ctx, container, cfg.Proxy)
-
-	go helpers.GracefulShutdown(ctx, func(shutdownCtx context.Context) error {
-		log.Println("shutdown signal received")
-
-		return app.Shutdown(shutdownCtx)
-	})
-
-	app.Wait()
+	runner.Wait()
 
 	if dropped := tracker.Dropped(); dropped > 0 {
 		output.Warnf("%d activity lines were dropped to keep the proxy responsive", dropped)
@@ -161,20 +157,18 @@ func runNonInteractive(
 	return 0
 }
 
-// startVersionChecker waits for a short delay then checks for a newer release.
-func startVersionChecker(ctx context.Context, container *di.Container, proxy string) {
-	const checkDelay = 50 * time.Millisecond
+// versionCheck builds the release check both run modes perform after startup.
+func versionCheck(container *di.Container, proxy string) uncors.VersionCheck {
+	return func(ctx context.Context) {
+		checker, err := container.VersionChecker(proxy)
+		if err != nil {
+			log.Printf("Version check failed: %v", err)
 
-	time.Sleep(checkDelay)
+			return
+		}
 
-	checker, err := container.VersionChecker(proxy)
-	if err != nil {
-		log.Printf("Version check failed: %v", err)
-
-		return
+		checker.CheckNewVersion(ctx)
 	}
-
-	checker.CheckNewVersion(ctx)
 }
 
 // runInteractive starts the proxy in interactive TUI mode.
@@ -190,6 +184,7 @@ func runInteractive(console contracts.Output, fs afero.Fs, configPath string, cf
 		configPath,
 		cfg,
 		configLoader(fs),
+		versionCheck(container, cfg.Proxy),
 	)
 
 	_, err := tea.NewProgram(app).Run()

--- a/main_test.go
+++ b/main_test.go
@@ -117,14 +117,26 @@ mappings:
 	assert.Len(t, cfg.Mappings, 1)
 }
 
-func TestStartVersionChecker(t *testing.T) {
+func TestVersionCheck(t *testing.T) {
 	t.Run("runs without panic", func(t *testing.T) {
 		container := di.NewContainer()
 		defer testutils.Close(t, container)
 
 		assert.NotPanics(t, func() {
-			startVersionChecker(context.Background(), container, "")
+			versionCheck(container, "")(context.Background())
 		})
+	})
+}
+
+func TestIsTerminal(t *testing.T) {
+	t.Run("a pipe is not a terminal", func(t *testing.T) {
+		reader, writer, err := os.Pipe()
+		require.NoError(t, err)
+
+		defer reader.Close()
+		defer writer.Close()
+
+		assert.False(t, isTerminal(writer))
 	})
 }
 


### PR DESCRIPTION
Fixes review finding **A10 — Interactive and headless modes are two parallel implementations of the same application**.

Interactive and headless mode were two independent implementations of the same
startup sequence, and they had already diverged: interactive mode never handled
SIGTERM/SIGHUP (so `docker stop` and systemd could not stop it gracefully), the
two used different shutdown timeouts for no stated reason, and the 50 ms sleep
before the version check was copy-pasted into both as an output-ordering
workaround.

- `uncors.Runner` owns startup, config watching, the version check, signal
  handling and shutdown. Both modes drive it, so none of that can differ between
  them any more; the TUI now handles termination signals and both modes share
  one shutdown timeout.
- The version-check sleep is gone: the check simply runs after startup.
- `--interactive` falls back to the plain presenter when stdout is not a
  terminal, so `uncors | tee`, CI scripts and the Docker image stop opening a
  full-screen TUI against a pipe.
- The TUI output builds its renderers once instead of allocating a buffer, a
  CliOutput and a mutex per log line.

---

### Review

One commit, `0330c61`. Step **10 of 33** in the review stack.

This PR targets **`perf/a09-shared-transport`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
