### PR TITLE
fix(logging): report diagnostics instead of discarding them (A13)

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,5 +1,22 @@
 This guide helps you diagnose and resolve common issues when using UNCORS.
 
+## Diagnostics and Logging
+
+UNCORS writes its diagnostics to **stderr** by default, at `info` level. Failures
+that used to be silent — a HAR archive that could not be written, a config
+watcher that died, a rejected TLS handshake — are reported there.
+
+```bash
+uncors --config .uncors.yaml --log-level debug   # everything, including per-handler detail
+uncors --config .uncors.yaml --debug             # shorthand for --log-level debug
+uncors --config .uncors.yaml --quiet             # errors only
+uncors --config .uncors.yaml --log-file uncors.log
+```
+
+In interactive mode the diagnostics appear in the history view rather than on
+stderr, because writing to the terminal would corrupt the UI. Passing
+`--log-file` sends them to the file instead.
+
 ## Quick Diagnostics Checklist
 
 Before diving into specific issues, verify these basics:
@@ -156,7 +173,7 @@ curl -k https://api.local:8443/
 Enable debug logging and verify requests appear in the output:
 
 ```bash
-uncors --config .uncors.yaml --debug
+uncors --config .uncors.yaml --log-level debug
 ```
 
 **2. OPTIONS request being forwarded instead of handled**

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"text/tabwriter"
 
@@ -137,7 +138,7 @@ func printCommands(out io.Writer, commands []Command) {
 }
 
 func report(env Env, err error) int {
-	log.Printf("Error: %v", err)
+	slog.Error("command failed", "err", err)
 	env.Console.Error(err)
 
 	return exitError

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -4,23 +4,18 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/di"
+	"github.com/evg4b/uncors/internal/infra"
 	"github.com/evg4b/uncors/internal/server"
 	tuiapp "github.com/evg4b/uncors/internal/tui/app"
 	"github.com/evg4b/uncors/internal/uncors"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
-)
-
-const (
-	logFileName  = "uncors.log"
-	logFileFlags = os.O_CREATE | os.O_WRONLY | os.O_APPEND
-	logFilePerm  = 0o644
 )
 
 // proxyCommand is the root command: it runs the proxy itself.
@@ -40,7 +35,18 @@ func proxyCommand() Command {
 
 			// The output implementation is chosen before the container is built,
 			// so that nothing can capture the wrong one.
-			if uncorsConfig.Interactive && isTerminal(env.Stdout) {
+			interactive := uncorsConfig.Interactive && isTerminal(env.Stdout)
+
+			closer, err := setupLogging(flags, interactive)
+			if err != nil {
+				return err
+			}
+
+			if closer != nil {
+				defer closer.Close()
+			}
+
+			if interactive {
 				return runInteractive(env, flags, uncorsConfig)
 			}
 
@@ -59,6 +65,25 @@ func isTerminal(file *os.File) bool {
 	}
 
 	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// setupLogging installs the process logger. In interactive mode the diagnostics
+// must not be written to the terminal, where they would corrupt the alt-screen,
+// so they are routed into the history view instead — unless the user asked for a
+// log file, which is a request to keep them out of the view.
+func setupLogging(flags *config.Flags, interactive bool) (io.Closer, error) {
+	options := infra.LogOptions{Level: flags.LogLevel(), File: flags.LogFile()}
+
+	if interactive && options.File == "" {
+		level, err := infra.ParseLogLevel(options.Level)
+		if err != nil {
+			return nil, err
+		}
+
+		options.Handler = tuiapp.NewLogHandler(level)
+	}
+
+	return infra.SetupLogging(options)
 }
 
 // runHeadless starts the proxy without a terminal UI and blocks until the server
@@ -137,7 +162,7 @@ func versionCheck(container *di.Container, proxy string) uncors.VersionCheck {
 	return func(ctx context.Context) {
 		checker, err := container.VersionChecker(proxy)
 		if err != nil {
-			log.Printf("Version check failed: %v", err)
+			slog.Error("version check failed", "err", err)
 
 			return
 		}
@@ -156,33 +181,5 @@ func configLoader(fs afero.Fs, flags *config.Flags) uncors.ConfigLoader {
 }
 
 func loadConfiguration(fs afero.Fs, flags *config.Flags) (*config.UncorsConfig, error) {
-	uncorsConfig, err := config.LoadConfiguration(fs, flags)
-	if err != nil {
-		return nil, err
-	}
-
-	err = configureLogging(uncorsConfig.Debug)
-	if err != nil {
-		return nil, err
-	}
-
-	return uncorsConfig, nil
-}
-
-func configureLogging(debug bool) error {
-	if !debug {
-		log.SetOutput(io.Discard)
-
-		return nil
-	}
-
-	logFile, err := os.OpenFile(logFileName, logFileFlags, logFilePerm)
-	if err != nil {
-		return fmt.Errorf("failed to open log file: %w", err)
-	}
-
-	log.SetOutput(logFile)
-	log.Print("Enabled debug messages")
-
-	return nil
+	return config.LoadConfiguration(fs, flags)
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -20,7 +20,10 @@ func DefineFlags(set *pflag.FlagSet) *Flags {
 	set.StringSliceP("from", "f", []string{},
 		"Local host with protocol for the resource from which proxying will take place")
 	set.String("proxy", "", "HTTP/HTTPS proxy for requests to the real server (uses system proxy by default)")
-	set.Bool("debug", false, "Write debug output to uncors.log")
+	set.Bool("debug", false, "Shorthand for --log-level=debug")
+	set.String("log-level", "info", "Diagnostic verbosity: debug, info, warn or error")
+	set.String("log-file", "", "Write diagnostics to this file instead of stderr")
+	set.Bool("quiet", false, "Report errors only (shorthand for --log-level=error)")
 	set.StringP("config", "c", "", "Path to the configuration file")
 	set.Bool("interactive", true, "Render the terminal UI (falls back to plain output when stdout is not a terminal)")
 
@@ -43,6 +46,29 @@ func ParseFlags(args []string) (*Flags, error) {
 // ConfigPath is the config file the flags point at, empty when none was given.
 func (f *Flags) ConfigPath() string {
 	value, _ := f.set.GetString("config")
+
+	return value
+}
+
+// LogLevel is the requested diagnostic verbosity. --debug and --quiet are
+// shorthands, so they win over an explicit --log-level only when they were set.
+func (f *Flags) LogLevel() string {
+	if debug, _ := f.set.GetBool("debug"); debug {
+		return "debug"
+	}
+
+	if quiet, _ := f.set.GetBool("quiet"); quiet {
+		return "error"
+	}
+
+	level, _ := f.set.GetString("log-level")
+
+	return level
+}
+
+// LogFile is the file diagnostics are written to, empty for stderr.
+func (f *Flags) LogFile() string {
+	value, _ := f.set.GetString("log-file")
 
 	return value
 }

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -115,7 +115,7 @@ func (w *Watcher) run(ctx context.Context, fsWatcher *fsnotify.Watcher, onChange
 				return
 			}
 
-			log.Printf("config watcher error: %v", err)
+			slog.Error("config watcher failed", "err", err)
 		}
 	}
 }

--- a/internal/handler/har/writer.go
+++ b/internal/handler/har/writer.go
@@ -2,7 +2,7 @@ package har
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -127,7 +127,7 @@ func (w *Writer) flush() {
 
 	err = os.MkdirAll(filepath.Dir(w.path), harDirMode)
 	if err != nil {
-		log.Printf("har: cannot create directory for %q: %v", w.path, err)
+		slog.Error("har: cannot create directory", "path", w.path, "err", err)
 
 		return
 	}
@@ -136,14 +136,14 @@ func (w *Writer) flush() {
 
 	err = os.WriteFile(tmp, data, harFileMode)
 	if err != nil {
-		log.Printf("har: cannot write temp file %q: %v", tmp, err)
+		slog.Error("har: cannot write temp file", "path", tmp, "err", err)
 
 		return
 	}
 
 	err = os.Rename(tmp, w.path)
 	if err != nil {
-		log.Printf("har: cannot rename %q to %q: %v", tmp, w.path, err)
+		slog.Error("har: cannot publish archive", "from", tmp, "to", w.path, "err", err)
 		_ = os.Remove(tmp)
 	}
 }

--- a/internal/handler/mock/handler.go
+++ b/internal/handler/mock/handler.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"time"
@@ -44,10 +44,7 @@ func (h *Handler) Serve(writer http.ResponseWriter, request *http.Request) error
 
 	err := h.writeResponse(writer, request)
 	if err != nil {
-		//nolint:gosec // G706: both values are passed through SanitizeLogValue
-		log.Printf("ERROR: Mock handler error: %s (URL: %s)",
-			infra.SanitizeLogValue(err.Error()),
-			infra.SanitizeLogValue(urlt.URL_String(request.URL)))
+		slog.Error("mock handler failed", "err", err, "url", urlt.URL_String(request.URL))
 
 		return err
 	}

--- a/internal/handler/proxy/handler.go
+++ b/internal/handler/proxy/handler.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"sync"
@@ -65,7 +64,7 @@ func NewProxyHandler(options ...HandlerOption) *Handler {
 		ErrorHandler:   handler.handleError,
 		Transport:      roundTripper{client: handler.http},
 		FlushInterval:  flushInterval,
-		ErrorLog:       log.Default(),
+		ErrorLog:       infra.StdLogger(),
 	}
 
 	return handler

--- a/internal/handler/router/router.go
+++ b/internal/handler/router/router.go
@@ -3,7 +3,7 @@ package router
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/evg4b/uncors/internal/config"
@@ -40,8 +40,7 @@ func NewRouter(mappings config.Mappings, deps Deps) (*Router, error) {
 	}
 
 	setDefaultHandler(instance.Router, infra.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) error {
-		//nolint:gosec // G706: the host is passed through SanitizeLogValue
-		log.Printf("Host %s is not mapped", infra.SanitizeLogValue(request.Host))
+		slog.Warn("host is not mapped", "host", request.Host)
 
 		return errHostNotMapped
 	}))

--- a/internal/handler/static/middleware.go
+++ b/internal/handler/static/middleware.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path"
@@ -42,10 +42,7 @@ func (h *Middleware) Wrap(next http.Handler) http.Handler {
 				return nil
 			}
 
-			//nolint:gosec // G706: both values are passed through SanitizeLogValue
-			log.Printf("ERROR: Static handler error: %s, url: %s",
-				infra.SanitizeLogValue(err.Error()),
-				infra.SanitizeLogValue(request.URL.String()))
+			slog.Error("static handler failed", "err", err, "url", request.URL.String())
 
 			return err
 		}
@@ -64,8 +61,7 @@ func closeFile(file afero.File) {
 
 	err := file.Close()
 	if err != nil {
-		//nolint:gosec // G706: the value is passed through SanitizeLogValue
-		log.Printf("ERROR: Static handler failed to close file: %s", infra.SanitizeLogValue(err.Error()))
+		slog.Warn("static handler failed to close file", "err", err)
 	}
 }
 

--- a/internal/infra/errors.go
+++ b/internal/infra/errors.go
@@ -1,0 +1,5 @@
+package infra
+
+import "errors"
+
+var ErrUnknownLogLevel = errors.New("unknown log level")

--- a/internal/infra/logging.go
+++ b/internal/infra/logging.go
@@ -1,0 +1,93 @@
+package infra
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	logFileFlags = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	logFilePerm  = 0o600
+)
+
+// LogOptions describe where diagnostics go and how much of them is kept.
+type LogOptions struct {
+	// Level is one of debug, info, warn or error.
+	Level string
+	// File, when set, receives the diagnostics instead of stderr.
+	File string
+	// Handler overrides both of the above; the terminal UI uses it to route
+	// records into its own view instead of writing over the alt-screen.
+	Handler slog.Handler
+}
+
+// SetupLogging installs the process wide logger and returns the log file, if one
+// was opened, for the caller to close.
+//
+// Diagnostics go to stderr by default. Discarding them by default is what made a
+// dead config watcher, a HAR archive that never got written and a rejected TLS
+// handshake all look exactly like success.
+func SetupLogging(options LogOptions) (io.Closer, error) {
+	level, err := ParseLogLevel(options.Level)
+	if err != nil {
+		return nil, err
+	}
+
+	if options.Handler != nil {
+		installLogger(slog.New(options.Handler))
+
+		return nil, nil //nolint:nilnil // the caller owns no file in this case
+	}
+
+	var (
+		writer io.Writer = os.Stderr
+		closer io.Closer
+	)
+
+	if options.File != "" {
+		file, openErr := os.OpenFile(filepath.Clean(options.File), logFileFlags, logFilePerm)
+		if openErr != nil {
+			return nil, fmt.Errorf("failed to open log file '%s': %w", options.File, openErr)
+		}
+
+		writer, closer = file, file
+	}
+
+	installLogger(slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{Level: level})))
+
+	return closer, nil
+}
+
+// ParseLogLevel maps a level name to its slog level.
+func ParseLogLevel(name string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return 0, fmt.Errorf("%w: %q (want debug, info, warn or error)", ErrUnknownLogLevel, name)
+	}
+}
+
+// StdLogger adapts the process logger to the *log.Logger that net/http wants for
+// http.Server.ErrorLog, so that TLS handshake failures and recovered handler
+// panics stop being invisible.
+func StdLogger() *log.Logger {
+	return slog.NewLogLogger(slog.Default().Handler(), slog.LevelWarn)
+}
+
+func installLogger(logger *slog.Logger) {
+	// SetDefault also routes the standard log package through this handler, so
+	// any log.Printf left in the tree still reaches the same place.
+	slog.SetDefault(logger)
+}

--- a/internal/infra/logging_test.go
+++ b/internal/infra/logging_test.go
@@ -1,0 +1,106 @@
+package infra_test
+
+import (
+	"log"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/infra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	levels := map[string]slog.Level{
+		"":        slog.LevelInfo,
+		"info":    slog.LevelInfo,
+		"DEBUG":   slog.LevelDebug,
+		"warn":    slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"error":   slog.LevelError,
+	}
+
+	for name, expected := range levels {
+		t.Run(name, func(t *testing.T) {
+			level, err := infra.ParseLogLevel(name)
+
+			require.NoError(t, err)
+			assert.Equal(t, expected, level)
+		})
+	}
+
+	t.Run("reports an unknown level", func(t *testing.T) {
+		_, err := infra.ParseLogLevel("chatty")
+
+		require.ErrorIs(t, err, infra.ErrUnknownLogLevel)
+	})
+}
+
+func TestSetupLogging(t *testing.T) {
+	restore := slog.Default()
+
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
+	t.Run("writes diagnostics to the requested file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "uncors.log")
+
+		closer, err := infra.SetupLogging(infra.LogOptions{Level: "debug", File: path})
+		require.NoError(t, err)
+		require.NotNil(t, closer)
+
+		slog.Debug("hello from slog")
+		// The standard log package is routed through the same handler, so
+		// nothing that still uses it is lost.
+		log.Print("hello from log")
+
+		require.NoError(t, closer.Close())
+
+		content, err := os.ReadFile(path) //nolint:gosec // a path this test created
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), "hello from slog")
+		assert.Contains(t, string(content), "hello from log")
+	})
+
+	t.Run("keeps records below the level out", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "uncors.log")
+
+		closer, err := infra.SetupLogging(infra.LogOptions{Level: "error", File: path})
+		require.NoError(t, err)
+
+		slog.Info("not important enough")
+		slog.Error("important")
+
+		require.NoError(t, closer.Close())
+
+		content, err := os.ReadFile(path) //nolint:gosec // a path this test created
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(content), "not important enough")
+		assert.Contains(t, string(content), "important")
+	})
+
+	t.Run("reports an unusable log file", func(t *testing.T) {
+		_, err := infra.SetupLogging(infra.LogOptions{File: filepath.Join(t.TempDir(), "no", "such", "dir", "x.log")})
+
+		require.Error(t, err)
+	})
+
+	t.Run("provides a std logger for net/http", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "uncors.log")
+
+		closer, err := infra.SetupLogging(infra.LogOptions{Level: "warn", File: path})
+		require.NoError(t, err)
+
+		infra.StdLogger().Print("http server error")
+
+		require.NoError(t, closer.Close())
+
+		content, err := os.ReadFile(path) //nolint:gosec // a path this test created
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), "http server error")
+	})
+}

--- a/internal/server/host_cert_manager.go
+++ b/internal/server/host_cert_manager.go
@@ -3,7 +3,7 @@ package server
 import (
 	"crypto/tls"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"sync"
 
@@ -105,7 +105,7 @@ func (m *HostCertManager) certificateForHost(host string) (*tls.Certificate, err
 	}
 
 	m.cache[host] = cert
-	log.Printf("Generated TLS certificate for host: %s", host)
+	slog.Debug("generated TLS certificate", "host", host)
 
 	return cert, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,6 +141,10 @@ func (s *Server) newPortListener(target Target) *PortListener {
 
 	portListener.Server = http.Server{
 		ReadHeaderTimeout: readHeaderTimeout,
+		// Without this, net/http writes TLS handshake failures and recovered
+		// handler panics to the standard logger, where they used to be
+		// discarded.
+		ErrorLog: infra.StdLogger(),
 		Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			s.handleRequest(portListener.Handler(), writer, request)
 		}),

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -2,7 +2,7 @@ package app
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -30,6 +30,7 @@ type UncorsApp struct {
 	container *di.Container
 
 	outputCh   <-chan string
+	logCh      <-chan string
 	appContext func() context.Context
 	appDone    <-chan struct{}
 	cancel     context.CancelFunc
@@ -87,6 +88,7 @@ func NewUncorsApp(
 		tracker:       container.RequestTracker(),
 		container:     container,
 		outputCh:      output.Lines(),
+		logCh:         logRecords(),
 		appContext:    func() context.Context { return appCtx },
 		appDone:       appCtx.Done(),
 		cancel:        cancel,
@@ -102,11 +104,12 @@ func NewUncorsApp(
 }
 
 func (m *UncorsApp) Init() tea.Cmd {
-	log.Println("Initializing UncorsApp")
+	slog.Debug("Initializing UncorsApp")
 
 	return tea.Batch(
 		m.startServerCmd(),
 		m.waitOutputCmd(),
+		m.waitLogCmd(),
 		m.watchEventsCmd(),
 		m.memWidget.Init(),
 		m.trackerWidget.Init(),
@@ -120,17 +123,22 @@ func (m *UncorsApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch typedMsg := msg.(type) {
 	case tea.WindowSizeMsg:
-		log.Printf("Window resized to %dx%d", typedMsg.Width, typedMsg.Height)
+		slogDebugf("Window resized to %dx%d", typedMsg.Width, typedMsg.Height)
 		m.termHeight = typedMsg.Height
 		m.termWidth = typedMsg.Width
 		m.updateHistoryHeight()
 
 	case restartMsg:
-		log.Println("Restart message received")
+		slog.Debug("Restart message received")
 		m.handleRestart()
 
 	case outputLineMsg:
 		cmds = append(cmds, m.waitOutputCmd())
+
+	case logLineMsg:
+		m.historyWidget.Update(outputLineMsg(typedMsg))
+
+		cmds = append(cmds, m.waitLogCmd())
 
 	case requestEventMsg:
 		m.handleRequestEvent(typedMsg)
@@ -138,7 +146,7 @@ func (m *UncorsApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.watchEventsCmd())
 
 	case tea.KeyPressMsg:
-		log.Printf("Key pressed: %s", typedMsg.String())
+		slogDebugf("Key pressed: %s", typedMsg.String())
 
 		if cmd := m.handleKeyPress(typedMsg); cmd != nil {
 			return m, cmd
@@ -231,7 +239,7 @@ func (m *UncorsApp) updateHistoryHeight() {
 	footerHeight := m.footerHeight()
 	viewportHeight := max(m.termHeight-footerHeight, 1)
 
-	log.Printf(
+	slogDebugf(
 		"Updating layout: termHeight=%d, footerHeight=%d => viewportHeight=%d",
 		m.termHeight,
 		footerHeight,
@@ -283,12 +291,12 @@ func (m *UncorsApp) handleRequestEvent(event requestEventMsg) {
 }
 
 func (m *UncorsApp) handleRestart() {
-	log.Println("Handling restart")
+	slog.Debug("Handling restart")
 	m.updateHistoryHeight()
 }
 
 func (m *UncorsApp) handleShutdown() tea.Cmd {
-	log.Println("Handling shutdown")
+	slog.Debug("Handling shutdown")
 
 	_ = m.reloader.Close()
 
@@ -323,6 +331,28 @@ func (m *UncorsApp) waitOutputCmd() tea.Cmd {
 	}
 }
 
+// waitLogCmd renders the process diagnostics in the history view, which is
+// where they have to go in interactive mode: writing them to the terminal would
+// corrupt the alt-screen.
+func (m *UncorsApp) waitLogCmd() tea.Cmd {
+	if m.logCh == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		select {
+		case line, ok := <-m.logCh:
+			if !ok {
+				return nil
+			}
+
+			return logLineMsg(line)
+		case <-m.appDone:
+			return nil
+		}
+	}
+}
+
 func (m *UncorsApp) watchEventsCmd() tea.Cmd {
 	return func() tea.Msg {
 		select {
@@ -345,7 +375,7 @@ func (m *UncorsApp) shutdownCmd() tea.Cmd {
 
 		err := m.runner.Shutdown(ctx)
 		if err != nil {
-			log.Printf("Shutdown error: %v", err)
+			slog.Error("shutdown failed", "err", err)
 		}
 
 		return shutdownMsg{}
@@ -356,7 +386,7 @@ func (m *UncorsApp) restartCmd() tea.Cmd {
 	return func() tea.Msg {
 		err := m.runner.Reload(m.appContext())
 		if err != nil {
-			log.Printf("Failed to restart: %v", err)
+			slog.Error("restart failed", "err", err)
 			m.output.Errorf("Failed to restart: %v", err)
 		}
 

--- a/internal/tui/app/history.go
+++ b/internal/tui/app/history.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 )
@@ -17,7 +17,7 @@ type history struct {
 }
 
 func newHistory() *history {
-	log.Println("Initializing new history")
+	slog.Debug("Initializing new history")
 
 	return &history{
 		lines: make([]string, 0, historyInitialCapacity),
@@ -34,7 +34,7 @@ func (h *history) AppendLine(line string) {
 	newLines := strings.Split(line, "\n")
 	h.lines = append(h.lines, newLines...)
 
-	log.Printf("Appended %d lines to history (total lines: %d)", len(newLines), len(h.lines))
+	slogDebugf("Appended %d lines to history (total lines: %d)", len(newLines), len(h.lines))
 }
 
 // Lines returns a copy of the slice of all stored lines.
@@ -61,7 +61,7 @@ func (h *history) Close() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	log.Printf("Closing history with %d lines", len(h.lines))
+	slogDebugf("Closing history with %d lines", len(h.lines))
 	h.lines = nil
 
 	return nil

--- a/internal/tui/app/history_widget.go
+++ b/internal/tui/app/history_widget.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	"log"
+	"log/slog"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/viewport"
@@ -19,7 +19,7 @@ type HistoryWidget struct {
 }
 
 func NewHistoryWidget(keys keyMap) *HistoryWidget {
-	log.Println("Creating HistoryWidget")
+	slog.Debug("Creating HistoryWidget")
 
 	hist := newHistory()
 
@@ -55,7 +55,7 @@ func (m *HistoryWidget) Update(msg tea.Msg) (*HistoryWidget, tea.Cmd) {
 		}
 
 	case restartMsg:
-		log.Println("HistoryWidget: handling restartMsg")
+		slog.Debug("HistoryWidget: handling restartMsg")
 
 		return m, nil
 
@@ -67,7 +67,7 @@ func (m *HistoryWidget) Update(msg tea.Msg) (*HistoryWidget, tea.Cmd) {
 }
 
 func (m *HistoryWidget) SetHeight(height int) {
-	log.Printf("HistoryWidget: setting height to %d", height)
+	slogDebugf("HistoryWidget: setting height to %d", height)
 	m.vp.SetHeight(height)
 }
 
@@ -76,7 +76,7 @@ func (m *HistoryWidget) HasLines() bool {
 }
 
 func (m *HistoryWidget) Close() error {
-	log.Println("HistoryWidget: closing")
+	slog.Debug("HistoryWidget: closing")
 
 	return m.hist.Close()
 }

--- a/internal/tui/app/log_handler.go
+++ b/internal/tui/app/log_handler.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// logHandlerBuffer bounds how many records are kept before the model starts
+// draining them.
+const logHandlerBuffer = 256
+
+// LogHandler collects diagnostics for the terminal UI. Writing them to stderr
+// would corrupt the alt-screen, so records are queued and rendered in the
+// history view like any other line.
+type LogHandler struct {
+	level slog.Level
+
+	mu      sync.Mutex
+	records chan string
+	attrs   []slog.Attr
+	group   string
+}
+
+func NewLogHandler(level slog.Level) *LogHandler {
+	return &LogHandler{
+		level:   level,
+		records: make(chan string, logHandlerBuffer),
+	}
+}
+
+// Records is the stream of formatted diagnostics for the model to render.
+func (h *LogHandler) Records() <-chan string {
+	return h.records
+}
+
+func (h *LogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *LogHandler) Handle(_ context.Context, record slog.Record) error {
+	var builder strings.Builder
+
+	builder.WriteString(record.Level.String())
+	builder.WriteString(": ")
+	builder.WriteString(record.Message)
+
+	h.mu.Lock()
+	attrs := h.attrs
+	group := h.group
+	h.mu.Unlock()
+
+	for _, attr := range attrs {
+		writeAttr(&builder, group, attr)
+	}
+
+	record.Attrs(func(attr slog.Attr) bool {
+		writeAttr(&builder, group, attr)
+
+		return true
+	})
+
+	select {
+	case h.records <- builder.String():
+	default:
+		// The view is a convenience, never a reason to slow the proxy down.
+	}
+
+	return nil
+}
+
+func (h *LogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return &LogHandler{
+		level:   h.level,
+		records: h.records,
+		attrs:   append(append([]slog.Attr{}, h.attrs...), attrs...),
+		group:   h.group,
+	}
+}
+
+func (h *LogHandler) WithGroup(name string) slog.Handler {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return &LogHandler{
+		level:   h.level,
+		records: h.records,
+		attrs:   append([]slog.Attr{}, h.attrs...),
+		group:   name,
+	}
+}
+
+func writeAttr(builder *strings.Builder, group string, attr slog.Attr) {
+	builder.WriteByte(' ')
+
+	if group != "" {
+		builder.WriteString(group)
+		builder.WriteByte('.')
+	}
+
+	builder.WriteString(attr.Key)
+	builder.WriteByte('=')
+	builder.WriteString(attr.Value.String())
+}

--- a/internal/tui/app/logging.go
+++ b/internal/tui/app/logging.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+// logLineMsg is a diagnostic record on its way to the history view.
+type logLineMsg string
+
+// logRecords returns the stream of diagnostics when the process logger is the
+// TUI's own handler, and nil when diagnostics go somewhere else (a log file, or
+// a test).
+func logRecords() <-chan string {
+	handler, ok := slog.Default().Handler().(*LogHandler)
+	if !ok {
+		return nil
+	}
+
+	return handler.Records()
+}
+
+// slogDebugf traces the model's own behaviour. These lines describe the widget
+// plumbing rather than anything the user did, so they are debug level.
+func slogDebugf(format string, args ...any) {
+	if !slog.Default().Enabled(nil, slog.LevelDebug) { //nolint:staticcheck // no request context here
+		return
+	}
+
+	slog.Debug(fmt.Sprintf(format, args...))
+}

--- a/internal/tui/app/tracker_widget.go
+++ b/internal/tui/app/tracker_widget.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	"log"
+	"log/slog"
 	"strings"
 
 	"charm.land/bubbles/v2/spinner"
@@ -32,7 +32,7 @@ type TrackerWidget struct {
 }
 
 func NewTrackerWidget() *TrackerWidget {
-	log.Println("Creating TrackerWidget")
+	slog.Debug("Creating TrackerWidget")
 
 	loader := spinner.New()
 	loader.Spinner = spinner.Meter
@@ -66,7 +66,7 @@ func (m *TrackerWidget) Update(msg tea.Msg) (*TrackerWidget, tea.Cmd) {
 		return m, nil
 
 	case restartMsg:
-		log.Println("TrackerWidget: handling restartMsg")
+		slog.Debug("TrackerWidget: handling restartMsg")
 
 		m.pending = make(map[uint64]server.RequestEvent)
 		m.ticking = false
@@ -128,17 +128,17 @@ func (m *TrackerWidget) View() tea.View {
 func (m *TrackerWidget) requestEventMsg(msg requestEventMsg) (*TrackerWidget, tea.Cmd) {
 	switch {
 	case msg.Done:
-		log.Printf("TrackerWidget: request done: %d", msg.ID)
+		slogDebugf("TrackerWidget: request done: %d", msg.ID)
 		delete(m.pending, msg.ID)
 	case msg.URL != nil:
-		log.Printf("TrackerWidget: request started: %d %s %s", msg.ID, msg.Method, urlt.URL_String(msg.URL))
+		slogDebugf("TrackerWidget: request started: %d %s %s", msg.ID, msg.Method, urlt.URL_String(msg.URL))
 		m.pending[msg.ID] = server.RequestEvent(msg)
 	}
 
 	var cmd tea.Cmd
 
 	if len(m.pending) > 0 && !m.ticking {
-		log.Println("TrackerWidget: starting tick")
+		slog.Debug("TrackerWidget: starting tick")
 
 		m.ticking = true
 		cmd = m.spinner.Tick

--- a/internal/tui/output.go
+++ b/internal/tui/output.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -149,7 +150,9 @@ func (output *CliOutput) print(msg string, level outputType) {
 	output.buffer.Reset()
 
 	if err != nil {
-		panic(err)
+		// A failing console write (a closed pipe from `uncors | head`, a
+		// detached terminal) is normal and must not take the proxy down.
+		slog.Debug("failed to write console output", "err", err)
 	}
 }
 

--- a/internal/tui/output_test.go
+++ b/internal/tui/output_test.go
@@ -175,11 +175,13 @@ func TestCliOutput_NewPrefixOutput(t *testing.T) {
 	})
 }
 
-func TestCliOutput_PanicsOnWriteError(t *testing.T) {
+// A failing console write is normal — `uncors | head` closes the pipe — and must
+// not take the proxy down with it.
+func TestCliOutput_SurvivesWriteError(t *testing.T) {
 	out := tui.NewCliOutput(&errorWriter{})
 
-	assert.Panics(t, func() {
-		out.Info("this will panic")
+	assert.NotPanics(t, func() {
+		out.Info("this must not panic")
 	})
 }
 

--- a/internal/uncors/reloader.go
+++ b/internal/uncors/reloader.go
@@ -3,7 +3,7 @@ package uncors
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"sync"
 
 	"github.com/evg4b/uncors/internal/config"
@@ -107,6 +107,6 @@ func (r *Reloader) Close() error {
 }
 
 func (r *Reloader) report(err error) {
-	log.Printf("Config reloading error: %v", err)
+	slog.Error("config reloading failed", "err", err)
 	r.output.Errorf("Config reloading error: %v", err)
 }

--- a/internal/uncors/runner.go
+++ b/internal/uncors/runner.go
@@ -3,7 +3,7 @@ package uncors
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/evg4b/uncors/internal/config"
@@ -50,7 +50,7 @@ func (r *Runner) Start(ctx context.Context, uncorsConfig *config.UncorsConfig) e
 
 	watchErr := r.reloader.Start(ctx)
 	if watchErr != nil {
-		log.Printf("Failed to watch config file: %v", watchErr)
+		slog.Error("failed to watch the config file", "err", watchErr)
 		r.output.Errorf("Failed to watch config file: %v", watchErr)
 	}
 
@@ -88,7 +88,7 @@ func (r *Runner) Shutdown(ctx context.Context) error {
 
 func (r *Runner) awaitShutdownSignal(ctx context.Context) {
 	GracefulShutdown(ctx, func(shutdownCtx context.Context) error {
-		log.Println("shutdown signal received")
+		slog.Info("shutdown signal received")
 
 		return r.Shutdown(shutdownCtx)
 	})

--- a/internal/version/check_new_version.go
+++ b/internal/version/check_new_version.go
@@ -3,7 +3,7 @@ package version
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/evg4b/uncors/internal/tui"
@@ -17,10 +17,10 @@ type versionInfo struct {
 }
 
 func (checker *Checker) CheckNewVersion(ctx context.Context) {
-	log.Print("Checking new version")
+	slog.Debug("checking for a new version")
 
 	if checker.skip {
-		log.Print("Skipping version check in debug mode")
+		slog.Debug("skipping the version check in debug mode")
 		checker.output.Info("Skipping version check in debug mode")
 
 		return
@@ -28,14 +28,14 @@ func (checker *Checker) CheckNewVersion(ctx context.Context) {
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, lastVersionURL, nil)
 	if err != nil {
-		log.Printf("failed to generate new version check request: %v", err)
+		slog.Debug("failed to build the version check request", "err", err)
 
 		return
 	}
 
 	response, err := checker.http.Do(request)
 	if err != nil {
-		log.Printf("http error occurred: %v", err)
+		slog.Debug("version check request failed", "err", err)
 
 		return
 	}
@@ -48,14 +48,14 @@ func (checker *Checker) CheckNewVersion(ctx context.Context) {
 
 	err = decoder.Decode(&lastVersionInfo)
 	if err != nil {
-		log.Printf("failed to parse last version response: %v", err)
+		slog.Debug("failed to parse the version check response", "err", err)
 
 		return
 	}
 
 	lastVersion, err := version.NewVersion(lastVersionInfo.Version)
 	if err != nil {
-		log.Printf("failed to parse last version: %v", err)
+		slog.Debug("failed to parse the latest version", "err", err)
 
 		return
 	}
@@ -64,6 +64,6 @@ func (checker *Checker) CheckNewVersion(ctx context.Context) {
 		checker.output.Infof(tui.NewVersionIsAvailable, checker.currentVersion.String(), lastVersion.String())
 		checker.output.Info("")
 	} else {
-		log.Print("Version is up to date")
+		slog.Debug("version is up to date")
 	}
 }


### PR DESCRIPTION
Fixes review finding **A13 — Three parallel output systems, and by default all diagnostics are discarded**.

Every internal diagnostic was written to the standard logger, which was pointed
at io.Discard unless the user passed --debug. A HAR archive that was never
written, a config watcher that died mid-session and a rejected TLS handshake all
looked exactly like success — which is how a total service stall (A01) shipped
undetected.

- Diagnostics go through `log/slog` to stderr at info level by default;
  `--log-level`, `--log-file` and `--quiet` control them, and `--debug` is the
  documented shorthand. `slog.SetDefault` also routes the standard log package,
  so nothing is lost in transit.
- Every `log.Printf` call site was reclassified deliberately: handler failures
  and HAR write failures are errors, per-request and widget tracing is debug.
- `http.Server.ErrorLog` is wired on the listeners and on the reverse proxy, so
  TLS handshake failures and recovered handler panics finally surface.
- In interactive mode the records are routed into the history view by a slog
  handler rather than written over the alt-screen.
- `CliOutput` no longer panics when a console write fails: `uncors | head`
  closing the pipe must not take the proxy down.

---

### Review

One commit, `055c1cc`. Step **13 of 33** in the review stack.

This PR targets **`refactor/a12-layering-and-helpers`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
