### PR TITLE
fix(errors): give failures a status and stop leaking internals (A14)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	charm.land/lipgloss/v2 v2.0.4
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/dgraph-io/ristretto/v2 v2.4.0
-	github.com/dustin/go-humanize v1.0.1
 	github.com/gkampitakis/go-snaps v0.5.22
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/gojuno/minimock/v3 v3.4.7
@@ -33,6 +32,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gkampitakis/ciinfo v0.3.4 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/kr/pretty v0.3.1 // indirect

--- a/internal/handler/proxy/handler.go
+++ b/internal/handler/proxy/handler.go
@@ -103,7 +103,12 @@ func (h *Handler) handleError(writer http.ResponseWriter, request *http.Request,
 	}
 
 	h.output.Errorf("Proxy handler error: %v", err)
-	http.Error(writer, "uncors: the request to the original source failed", http.StatusBadGateway)
+
+	infra.HTTPError(writer, request, infra.NewHTTPStatusError(
+		http.StatusBadGateway,
+		"the request to the original source failed",
+		err,
+	))
 }
 
 func (h *Handler) createReplacers(req *http.Request) (*urlreplacer.Replacer, *urlreplacer.Replacer, error) {

--- a/internal/handler/router/composition_test.go
+++ b/internal/handler/router/composition_test.go
@@ -199,5 +199,5 @@ func TestRewriteLoopIsBounded(t *testing.T) {
 
 	recorder := serve(t, instance, http.MethodGet, "http://localhost/ping")
 
-	assert.Equal(t, http.StatusInternalServerError, recorder.Code, "a rewrite loop must terminate")
+	assert.Equal(t, http.StatusLoopDetected, recorder.Code, "a rewrite loop must terminate")
 }

--- a/internal/handler/router/router.go
+++ b/internal/handler/router/router.go
@@ -17,7 +17,7 @@ import (
 const maxRewriteRedispatch = 8
 
 var (
-	errHostNotMapped = errors.New("host not mapped")
+	errHostNotMapped = errors.New("host is not mapped in the uncors config")
 	errRewriteLoop   = errors.New("rewrite rules redirect the request in a loop")
 )
 
@@ -42,7 +42,11 @@ func NewRouter(mappings config.Mappings, deps Deps) (*Router, error) {
 	setDefaultHandler(instance.Router, infra.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) error {
 		slog.Warn("host is not mapped", "host", request.Host)
 
-		return errHostNotMapped
+		return infra.NewHTTPStatusError(
+			http.StatusNotFound,
+			"this host is not mapped in the uncors configuration",
+			errHostNotMapped,
+		)
 	}))
 
 	return &instance, nil
@@ -122,7 +126,11 @@ func redispatchHandler(routes http.Handler) http.Handler {
 	return infra.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) error {
 		depth, _ := request.Context().Value(rewriteDepthKey{}).(int)
 		if depth >= maxRewriteRedispatch {
-			return errRewriteLoop
+			return infra.NewHTTPStatusError(
+				http.StatusLoopDetected,
+				"the configured rewrites redirect this request in a loop",
+				errRewriteLoop,
+			)
 		}
 
 		ctx := context.WithValue(request.Context(), rewriteDepthKey{}, depth+1)

--- a/internal/infra/handlers.go
+++ b/internal/infra/handlers.go
@@ -12,6 +12,6 @@ type HandlerFunc func(http.ResponseWriter, *http.Request) error
 func (f HandlerFunc) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	err := f(writer, request)
 	if err != nil {
-		HTTPError(writer, err)
+		HTTPError(writer, request, err)
 	}
 }

--- a/internal/infra/http_error.go
+++ b/internal/infra/http_error.go
@@ -1,14 +1,21 @@
 package infra
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"net"
 	"net/http"
-	"runtime"
-	"runtime/debug"
+	"syscall"
 
-	"github.com/dustin/go-humanize"
 	"github.com/go-http-utils/headers"
 )
+
+// statusClientClosedRequest is the conventional (non-standard) code for "the
+// client went away before we answered". Nothing is written for it; there is
+// nobody left to read it.
+const statusClientClosedRequest = 499
 
 const errorHeader = `
 ███████  ██████   ██████      ███████ ██████  ██████   ██████  ██████  
@@ -17,7 +24,69 @@ const errorHeader = `
      ██ ████  ██ ████  ██     ██      ██   ██ ██   ██ ██    ██ ██   ██ 
 ███████  ██████   ██████      ███████ ██   ██ ██   ██  ██████  ██   ██ `
 
-func HTTPError(writer http.ResponseWriter, err error) {
+// HTTPStatusError carries the status and the user-facing message a failure
+// should be reported with. Handlers that know what went wrong say so, instead of
+// leaving every failure to be reported as an indistinguishable 500.
+type HTTPStatusError struct {
+	Code int
+	Msg  string
+	Err  error
+}
+
+func NewHTTPStatusError(code int, msg string, err error) *HTTPStatusError {
+	return &HTTPStatusError{Code: code, Msg: msg, Err: err}
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Err == nil {
+		return e.Msg
+	}
+
+	return e.Msg + ": " + e.Err.Error()
+}
+
+func (e *HTTPStatusError) Unwrap() error {
+	return e.Err
+}
+
+// StatusFor maps an error onto the status and message the client should see.
+func StatusFor(err error) (int, string) {
+	var statusErr *HTTPStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.Code, statusErr.Msg
+	}
+
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, http.ErrAbortHandler):
+		return statusClientClosedRequest, ""
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, "the request to the original source timed out"
+	case isUpstreamUnreachable(err):
+		return http.StatusBadGateway, "the original source is unreachable"
+	default:
+		return http.StatusInternalServerError, "uncors could not handle this request"
+	}
+}
+
+// HTTPError reports a failed request: the detail goes to the log, where a
+// developer looks, and the client gets the status and a one-line summary.
+func HTTPError(writer http.ResponseWriter, request *http.Request, err error) {
+	code, message := StatusFor(err)
+
+	slog.Error("request failed",
+		"method", requestMethod(request),
+		"url", requestURL(request),
+		"status", code,
+		"err", err)
+
+	if code == statusClientClosedRequest {
+		return
+	}
+
+	writeErrorPage(writer, request, code, message, err)
+}
+
+func writeErrorPage(writer http.ResponseWriter, request *http.Request, code int, message string, err error) {
 	header := writer.Header()
 	header.Set(headers.ContentType, "text/plain; charset=utf-8")
 	header.Set(headers.ContentEncoding, "identity")
@@ -27,23 +96,51 @@ func HTTPError(writer http.ResponseWriter, err error) {
 
 	header.Del(headers.SetCookie)
 
-	writer.WriteHeader(http.StatusInternalServerError)
+	writer.WriteHeader(code)
 
 	fmt.Fprintln(writer)
 	fmt.Fprintln(writer, errorHeader)
 	fmt.Fprintln(writer)
 	fmt.Fprintln(writer)
-	fmt.Fprintf(writer, "An error occurred: %s\n", err)
+	fmt.Fprintf(writer, "Error %d: %s\n", code, message)
 	fmt.Fprintln(writer)
+	// Echoing the request back is the point of the page. It is served as
+	// text/plain with nosniff, so a browser will not render it as markup.
+	//nolint:gosec // G705
+	fmt.Fprintf(writer, "Request: %s %s\n", requestMethod(request), requestURL(request))
+	fmt.Fprintln(writer)
+	fmt.Fprintf(writer, "Details: %s\n", err)
+}
 
-	fmt.Fprint(writer, "Stack trace: ")
-	fmt.Fprintln(writer, string(debug.Stack()))
+// isUpstreamUnreachable reports the network failures that mean "the other side
+// is not there", as opposed to a failure of our own.
+func isUpstreamUnreachable(err error) bool {
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EHOSTUNREACH) {
+		return true
+	}
 
-	var memStats runtime.MemStats
-	runtime.ReadMemStats(&memStats)
-	fmt.Fprintln(writer, "Memory usage:")
-	fmt.Fprintf(writer, "Alloc = %v\n", humanize.Bytes(memStats.Alloc))
-	fmt.Fprintf(writer, "TotalAlloc = %v\n", humanize.Bytes(memStats.TotalAlloc))
-	fmt.Fprintf(writer, "Sys = %v\n", humanize.Bytes(memStats.Sys))
-	fmt.Fprintf(writer, "NumGC = %v\n", memStats.NumGC)
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	var opErr *net.OpError
+
+	return errors.As(err, &opErr)
+}
+
+func requestMethod(request *http.Request) string {
+	if request == nil {
+		return ""
+	}
+
+	return request.Method
+}
+
+func requestURL(request *http.Request) string {
+	if request == nil || request.URL == nil {
+		return ""
+	}
+
+	return request.URL.String()
 }

--- a/internal/infra/http_error_test.go
+++ b/internal/infra/http_error_test.go
@@ -1,56 +1,103 @@
 package infra_test
 
 import (
+	"context"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"syscall"
 	"testing"
 
 	"github.com/evg4b/uncors/internal/infra"
 	"github.com/evg4b/uncors/testing/testutils"
 	"github.com/go-http-utils/headers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-const expectedPage = `
-███████  ██████   ██████      ███████ ██████  ██████   ██████  ██████  
-██      ██  ████ ██  ████     ██      ██   ██ ██   ██ ██    ██ ██   ██ 
-███████ ██ ██ ██ ██ ██ ██     █████   ██████  ██████  ██    ██ ██████  
-     ██ ████  ██ ████  ██     ██      ██   ██ ██   ██ ██    ██ ██   ██ 
-███████  ██████   ██████      ███████ ██   ██ ██   ██  ██████  ██   ██ 
+var errUpstream = errors.New("dial failed")
 
+func request(t *testing.T) *http.Request {
+	t.Helper()
 
-An error occurred: net/http: abort Handler
-`
+	return httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://api.local/users", nil)
+}
 
-func TestHttpError(t *testing.T) {
-	recorder := httptest.NewRecorder()
-	infra.HTTPError(recorder, http.ErrAbortHandler)
-	body := testutils.ReadBody(t, recorder)
+func TestStatusFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected int
+	}{
+		{name: "explicit status", err: infra.NewHTTPStatusError(http.StatusNotFound, "nope", nil), expected: 404},
+		{name: "client went away", err: context.Canceled, expected: 499},
+		{name: "aborted handler", err: http.ErrAbortHandler, expected: 499},
+		{name: "timed out", err: context.DeadlineExceeded, expected: 504},
+		{name: "connection refused", err: syscall.ECONNREFUSED, expected: 502},
+		{name: "dns failure", err: &net.DNSError{Err: "no such host"}, expected: 502},
+		{name: "anything else", err: errUpstream, expected: 500},
+	}
 
-	t.Run("write correct page", func(t *testing.T) {
-		assert.Contains(t, body, expectedPage)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			code, _ := infra.StatusFor(testCase.err)
+
+			assert.Equal(t, testCase.expected, code)
+		})
+	}
+}
+
+func TestHTTPError(t *testing.T) {
+	t.Run("reports the status the error asked for", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		infra.HTTPError(recorder, request(t), infra.NewHTTPStatusError(
+			http.StatusNotFound,
+			"this host is not mapped in the uncors configuration",
+			nil,
+		))
+
+		body := testutils.ReadBody(t, recorder)
+
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+		assert.Contains(t, body, "Error 404")
+		assert.Contains(t, body, "this host is not mapped")
+		assert.Contains(t, body, "GET http://api.local/users")
 	})
 
-	t.Run("write correct headers", func(t *testing.T) {
+	// The client is the wrong audience for a stack trace, and ReadMemStats stops
+	// the world — neither belongs on a path any request can reach.
+	t.Run("leaks neither a stack trace nor memory statistics", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		infra.HTTPError(recorder, request(t), errUpstream)
+
+		body := testutils.ReadBody(t, recorder)
+
+		assert.NotContains(t, body, "goroutine ")
+		assert.NotContains(t, body, "Stack trace")
+		assert.NotContains(t, body, "Memory usage")
+		assert.NotContains(t, body, "TotalAlloc")
+	})
+
+	t.Run("writes nothing when the client is already gone", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		infra.HTTPError(recorder, request(t), context.Canceled)
+
+		assert.Empty(t, testutils.ReadBody(t, recorder))
+	})
+
+	t.Run("writes correct headers", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		infra.HTTPError(recorder, request(t), errUpstream)
+
 		header := recorder.Header()
 
-		assert.NotNil(t, header[headers.ContentType])
-		assert.NotNil(t, header[headers.ContentEncoding])
-		assert.NotNil(t, header[headers.CacheControl])
-		assert.NotNil(t, header[headers.Pragma])
-		assert.NotNil(t, header[headers.XContentTypeOptions])
-		assert.Nil(t, header[headers.SetCookie])
-	})
-
-	t.Run("Should include stack trace", func(t *testing.T) {
-		assert.Regexp(t, "Stack trace: goroutine \\d+ \\[running\\]:", body)
-	})
-
-	t.Run("Should include memory usage", func(t *testing.T) {
-		assert.Contains(t, body, "Memory usage:")
-		assert.Regexp(t, "Alloc = [\\d\\.]+ [Mk]B", body)
-		assert.Regexp(t, "TotalAlloc = [\\d\\.]+ [Mk]B", body)
-		assert.Regexp(t, "Sys = [\\d\\.]+ [Mk]B", body)
-		assert.Regexp(t, "NumGC = [\\d\\.]+", body)
+		require.NotNil(t, header[headers.ContentType])
+		assert.Equal(t, "nosniff", header.Get(headers.XContentTypeOptions))
+		assert.Empty(t, header[headers.SetCookie])
 	})
 }


### PR DESCRIPTION
Fixes review finding **A14 — The 500 error page dumps a goroutine stack trace and process memory stats to the HTTP client**.

Every handler error rendered the same 500 page carrying a goroutine stack trace
(of `HTTPError` itself, so it described nothing) and `runtime.ReadMemStats` —
a stop-the-world call on a path any request could reach, including every request
to an unmapped host. The detail went to the HTTP client and nowhere else.

- `infra.HTTPStatusError` plus `StatusFor` map failures onto real statuses: an
  unmapped host is 404, an unreachable upstream 502, a timeout 504, a rewrite
  loop 508, a client that went away writes nothing at all.
- The detail is logged, where a developer looks; the page keeps the branding and
  gains the request line and a one-line summary — no stack trace, no memory
  statistics, no local filesystem paths.
- `runtime.ReadMemStats` leaves the request path; memory statistics already have
  a home in the TUI widget.

Behaviour change: an unreachable upstream now answers 502 and an unmapped host
404, where both used to answer 500.

---

### Review

One commit, `1dfced0`. Step **14 of 33** in the review stack.

This PR targets **`fix/a13-slog-diagnostics`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
