### PR TITLE
perf(har): record through a journal instead of rewriting the archive (A15)

### DIFF
--- a/docs/HAR-Collector.md
+++ b/docs/HAR-Collector.md
@@ -23,8 +23,7 @@ mappings:
     har: ./recordings/api.har
 ```
 
-UNCORS creates the file on the first request and keeps it updated atomically
-after each subsequent request.
+UNCORS creates the file on the first request and refreshes it as you browse.
 
 ## Configuration
 
@@ -107,12 +106,24 @@ mappings:
 
 ## File Lifecycle
 
- - **Created** on the first captured request (parent directory must exist).
- - **Updated atomically** after every request - UNCORS writes to a temporary
-   file then renames it, so the `.har` file is always in a valid, complete state
-   even if you open it mid-session.
- - **Flushed and closed** on shutdown or when the configuration is reloaded. All
-   buffered entries are written before the file handle is released.
+ - **Created** on the first captured request; parent directories are created
+   for you.
+ - **Recorded continuously** into a `<name>.har.jsonl` journal next to the
+   archive. Appending one entry costs the same whether it is the first or the
+   ten-thousandth, so a long session does not get slower.
+ - **Rebuilt** from that journal at most a few times per second, written to a
+   temporary file and renamed over the target. The `.har` file is therefore
+   always valid and complete if you open it mid-session, though it may be a
+   fraction of a second behind the newest request.
+ - **Finalised and closed** on shutdown and when the configuration is reloaded:
+   every pending entry is written, and the journal is removed.
+ - **Bounded** at 100,000 entries per archive. Beyond that, entries are dropped
+   and a warning is logged rather than letting one session grow without limit.
+
+> [!TIP]
+> A `.har.jsonl` file left next to your archive means the process was killed
+> before it could finalise the recording. It holds one JSON entry per line and
+> can be recovered by hand.
 
 > [!NOTE]
 > If the internal write buffer (4,096 entries) fills up during a traffic spike,

--- a/internal/di/runtime.go
+++ b/internal/di/runtime.go
@@ -101,7 +101,11 @@ func (r *Runtime) cacheMiddleware(globs config.CacheGlobs) contracts.Middleware 
 }
 
 func (r *Runtime) harMiddleware(harConfig *config.HARConfig) contracts.Middleware {
-	writer := register(r, har.NewWriter(harConfig.File))
+	writer := register(r, har.NewWriter(
+		r.container.fs,
+		harConfig.File,
+		har.WithCreatorVersion(r.container.version),
+	))
 
 	return har.NewMiddleware(
 		har.WithWriter(writer),

--- a/internal/handler/har/middleware_test.go
+++ b/internal/handler/har/middleware_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/evg4b/uncors/internal/handler/har"
 	"github.com/evg4b/uncors/internal/infra"
 	"github.com/evg4b/uncors/testing/testutils"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +37,7 @@ func newHARMiddleware(t *testing.T, opts ...har.MiddlewareOption) (*har.Middlewa
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "test.har")
-	harWriter := har.NewWriter(path)
+	harWriter := har.NewWriter(afero.NewOsFs(), path)
 	opts = append([]har.MiddlewareOption{har.WithWriter(harWriter)}, opts...)
 	mdlw := har.NewMiddleware(opts...)
 

--- a/internal/handler/har/writer.go
+++ b/internal/handler/har/writer.go
@@ -2,16 +2,22 @@ package har
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"log/slog"
-	"os"
 	"path/filepath"
+	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/spf13/afero"
 )
 
 const (
-	harVersion     = "1.2"
-	creatorName    = "uncors"
-	creatorVersion = "dev"
+	harVersion  = "1.2"
+	creatorName = "uncors"
 	// entryChanBuffer is the capacity of the entry channel.
 	// Senders never block as long as fewer than this many entries are in-flight.
 	entryChanBuffer = 4096
@@ -19,25 +25,79 @@ const (
 	harFileMode = 0o600
 	// harDirMode is the permission bits used when creating parent directories.
 	harDirMode = 0o755
+	// materialiseInterval is how often the .har document is rebuilt from the
+	// journal, so that it stays usable while a session is still running. It
+	// bounds the rebuild rate by wall clock rather than by traffic, which is
+	// what keeps a busy session from rewriting the archive per request.
+	materialiseInterval = 250 * time.Millisecond
+	// defaultMaxEntries bounds a long running recording. Entries beyond it are
+	// dropped rather than growing the archive without limit.
+	defaultMaxEntries = 100_000
 )
 
-// Writer asynchronously appends HAR entries to a file.
+// writerSeq makes each writer's temporary file unique, so that two writers over
+// the same path can never rename each other's partial output over the target.
+var writerSeq atomic.Uint64
+
+// Writer records HAR entries to a file.
+//
+// Entries are appended to a journal as they arrive, which costs the same for the
+// first entry and the ten thousandth, and the .har document is rebuilt from that
+// journal on a slow timer and on Close. Holding the whole archive in memory and
+// re-serialising it after every batch made both memory and I/O grow with the
+// length of the session.
 type Writer struct {
-	path    string
+	fs             afero.Fs
+	path           string
+	journalPath    string
+	tempPath       string
+	creatorVersion string
+	maxEntries     int
+
 	entries chan Entry
 	done    chan struct{}
 	once    sync.Once
 	wg      sync.WaitGroup
-	mu      sync.Mutex
-	all     []Entry
+
+	journal   afero.File
+	encoder   *json.Encoder
+	count     int
+	dirty     bool
+	truncated bool
+}
+
+// WriterOption configures a Writer.
+type WriterOption = func(*Writer)
+
+// WithCreatorVersion records which uncors build produced the archive.
+func WithCreatorVersion(version string) WriterOption {
+	return func(w *Writer) {
+		w.creatorVersion = version
+	}
+}
+
+// WithMaxEntries bounds how many entries an archive keeps.
+func WithMaxEntries(maxEntries int) WriterOption {
+	return func(w *Writer) {
+		w.maxEntries = maxEntries
+	}
 }
 
 // NewWriter creates a Writer that records entries to path.
-func NewWriter(path string) *Writer {
+func NewWriter(fs afero.Fs, path string, options ...WriterOption) *Writer {
 	writer := &Writer{
-		path:    path,
-		entries: make(chan Entry, entryChanBuffer),
-		done:    make(chan struct{}),
+		fs:             fs,
+		path:           path,
+		journalPath:    path + ".jsonl",
+		tempPath:       fmt.Sprintf("%s.%d.tmp", path, writerSeq.Add(1)),
+		creatorVersion: "dev",
+		maxEntries:     defaultMaxEntries,
+		entries:        make(chan Entry, entryChanBuffer),
+		done:           make(chan struct{}),
+	}
+
+	for _, option := range options {
+		option(writer)
 	}
 
 	writer.wg.Add(1)
@@ -45,6 +105,13 @@ func NewWriter(path string) *Writer {
 	go writer.run()
 
 	return writer
+}
+
+// TempPath is the file this writer stages the archive in before publishing it.
+// It is unique per writer, so two writers over the same path can never rename
+// each other's partial output over the target.
+func (w *Writer) TempPath() string {
+	return w.tempPath
 }
 
 // AddEntry enqueues an entry for writing.
@@ -69,18 +136,24 @@ func (w *Writer) Close() error {
 func (w *Writer) run() {
 	defer w.wg.Done()
 
+	ticker := time.NewTicker(materialiseInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case entry := <-w.entries:
-			// Batch: append the triggering entry plus everything else already
-			// queued, then rewrite the file once instead of once per entry.
-			w.append(entry)
-			w.drain()
-			w.flush()
+			w.record(entry)
+
+		case <-ticker.C:
+			w.materialise(false)
 
 		case <-w.done:
 			w.drain()
-			w.flush()
+			// The archive is always written on close, even when nothing was
+			// recorded: an empty but valid HAR file is what a user who enabled
+			// recording expects to find.
+			w.materialise(true)
+			w.closeJournal()
 
 			return
 		}
@@ -92,58 +165,205 @@ func (w *Writer) drain() {
 	for {
 		select {
 		case entry := <-w.entries:
-			w.append(entry)
+			w.record(entry)
 		default:
 			return
 		}
 	}
 }
 
-func (w *Writer) append(entry Entry) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+func (w *Writer) record(entry Entry) {
+	if w.maxEntries > 0 && w.count >= w.maxEntries {
+		if !w.truncated {
+			w.truncated = true
 
-	w.all = append(w.all, entry)
+			slog.Warn("har: entry limit reached, further entries are dropped",
+				"path", w.path, "limit", w.maxEntries)
+		}
+
+		return
+	}
+
+	err := w.appendJournal(entry)
+	if err != nil {
+		slog.Error("har: cannot record entry", "path", w.journalPath, "err", err)
+
+		return
+	}
+
+	w.count++
+	w.dirty = true
 }
 
-func (w *Writer) flush() {
-	w.mu.Lock()
-	snapshot := make([]Entry, len(w.all))
-	copy(snapshot, w.all)
-	w.mu.Unlock()
+func (w *Writer) appendJournal(entry Entry) error {
+	if w.journal == nil {
+		err := w.fs.MkdirAll(filepath.Dir(w.path), harDirMode)
+		if err != nil {
+			return fmt.Errorf("cannot create directory: %w", err)
+		}
 
-	archive := HAR{
-		Log: Log{
-			Version: harVersion,
-			Creator: Creator{Name: creatorName, Version: creatorVersion},
-			Entries: snapshot,
-		},
+		file, err := w.fs.OpenFile(w.journalPath, journalFlags, harFileMode)
+		if err != nil {
+			return fmt.Errorf("cannot open journal: %w", err)
+		}
+
+		w.journal = file
+		w.encoder = json.NewEncoder(file)
 	}
 
-	data, err := json.MarshalIndent(archive, "", "  ")
+	err := w.encoder.Encode(entry)
 	if err != nil {
+		return fmt.Errorf("cannot append entry: %w", err)
+	}
+
+	return nil
+}
+
+// materialise rebuilds the .har document from the journal. The entries are
+// streamed rather than held, so the cost is proportional to what was recorded
+// since the process started, not to the square of it.
+func (w *Writer) materialise(force bool) {
+	if !w.dirty && !force {
 		return
 	}
 
-	err = os.MkdirAll(filepath.Dir(w.path), harDirMode)
+	w.dirty = false
+
+	if w.journal != nil {
+		err := w.journal.Sync()
+		if err != nil {
+			slog.Error("har: cannot flush journal", "path", w.journalPath, "err", err)
+
+			return
+		}
+	}
+
+	err := w.writeArchive()
 	if err != nil {
-		slog.Error("har: cannot create directory", "path", w.path, "err", err)
+		slog.Error("har: cannot write archive", "path", w.path, "err", err)
 
 		return
 	}
 
-	tmp := w.path + ".tmp"
-
-	err = os.WriteFile(tmp, data, harFileMode)
+	err = w.fs.Rename(w.tempPath, w.path)
 	if err != nil {
-		slog.Error("har: cannot write temp file", "path", tmp, "err", err)
+		slog.Error("har: cannot publish archive", "from", w.tempPath, "to", w.path, "err", err)
+		_ = w.fs.Remove(w.tempPath)
+	}
+}
 
+func (w *Writer) writeArchive() error {
+	var journal io.Reader = strings.NewReader("")
+
+	if w.journal == nil {
+		err := w.fs.MkdirAll(filepath.Dir(w.path), harDirMode)
+		if err != nil {
+			return fmt.Errorf("cannot create directory: %w", err)
+		}
+	} else {
+		source, err := w.fs.Open(w.journalPath)
+		if err != nil {
+			return fmt.Errorf("cannot read journal: %w", err)
+		}
+
+		defer source.Close()
+
+		journal = source
+	}
+
+	target, err := w.fs.OpenFile(w.tempPath, archiveFlags, harFileMode)
+	if err != nil {
+		return fmt.Errorf("cannot open archive: %w", err)
+	}
+
+	defer target.Close()
+
+	err = writeEnvelope(target, w.creatorVersion, journal)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeEnvelope streams the journal entries into the HAR document structure.
+func writeEnvelope(target io.Writer, creatorVersion string, journal io.Reader) error {
+	// The header values are marshalled rather than formatted, so that escaping
+	// is the JSON package's problem and not ours.
+	version, err := json.Marshal(harVersion)
+	if err != nil {
+		return fmt.Errorf("cannot encode har version: %w", err)
+	}
+
+	creator, err := json.Marshal(Creator{Name: creatorName, Version: creatorVersion})
+	if err != nil {
+		return fmt.Errorf("cannot encode har creator: %w", err)
+	}
+
+	_, err = fmt.Fprintf(target, `{"log":{"version":%s,"creator":%s,"entries":[`, version, creator)
+	if err != nil {
+		return fmt.Errorf("cannot write archive header: %w", err)
+	}
+
+	err = copyEntries(target, journal)
+	if err != nil {
+		return err
+	}
+
+	_, err = target.Write([]byte("]}}"))
+	if err != nil {
+		return fmt.Errorf("cannot write archive footer: %w", err)
+	}
+
+	return nil
+}
+
+// copyEntries streams the journal's entries into the archive's entries array.
+func copyEntries(target io.Writer, journal io.Reader) error {
+	decoder := json.NewDecoder(journal)
+
+	for index := 0; ; index++ {
+		var entry json.RawMessage
+
+		err := decoder.Decode(&entry)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("cannot read journal entry: %w", err)
+		}
+
+		if index > 0 {
+			_, err = target.Write([]byte(","))
+			if err != nil {
+				return fmt.Errorf("cannot write archive entry: %w", err)
+			}
+		}
+
+		_, err = target.Write(entry)
+		if err != nil {
+			return fmt.Errorf("cannot write archive entry: %w", err)
+		}
+	}
+}
+
+func (w *Writer) closeJournal() {
+	if w.journal == nil {
 		return
 	}
 
-	err = os.Rename(tmp, w.path)
+	err := w.journal.Close()
 	if err != nil {
-		slog.Error("har: cannot publish archive", "from", tmp, "to", w.path, "err", err)
-		_ = os.Remove(tmp)
+		slog.Error("har: cannot close journal", "path", w.journalPath, "err", err)
+	}
+
+	w.journal = nil
+
+	// The journal has served its purpose. One left behind means the process was
+	// killed mid-session; the recording can be recovered from it.
+	err = w.fs.Remove(w.journalPath)
+	if err != nil {
+		slog.Warn("har: cannot remove journal", "path", w.journalPath, "err", err)
 	}
 }

--- a/internal/handler/har/writer_flags.go
+++ b/internal/handler/har/writer_flags.go
@@ -1,0 +1,8 @@
+package har
+
+import "os"
+
+const (
+	journalFlags = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	archiveFlags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+)

--- a/internal/handler/har/writer_test.go
+++ b/internal/handler/har/writer_test.go
@@ -2,12 +2,14 @@ package har_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/evg4b/uncors/internal/handler/har"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +19,7 @@ func TestWriter(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "out.har")
 
-		harWriter := har.NewWriter(path)
+		harWriter := har.NewWriter(afero.NewOsFs(), path)
 		harWriter.AddEntry(har.Entry{
 			StartedDateTime: time.Now(),
 			Time:            42,
@@ -40,7 +42,7 @@ func TestWriter(t *testing.T) {
 
 	t.Run("multiple Close calls are safe", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "out.har")
-		harWriter := har.NewWriter(path)
+		harWriter := har.NewWriter(afero.NewOsFs(), path)
 
 		require.NoError(t, harWriter.Close())
 		require.NoError(t, harWriter.Close())
@@ -48,7 +50,7 @@ func TestWriter(t *testing.T) {
 
 	t.Run("AddEntry does not block when channel is full", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "out.har")
-		harWriter := har.NewWriter(path)
+		harWriter := har.NewWriter(afero.NewOsFs(), path)
 
 		for range 10_000 {
 			harWriter.AddEntry(har.Entry{})
@@ -59,7 +61,7 @@ func TestWriter(t *testing.T) {
 
 	t.Run("file is valid JSON after Close with no entries", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "empty.har")
-		harWriter := har.NewWriter(path)
+		harWriter := har.NewWriter(afero.NewOsFs(), path)
 
 		require.NoError(t, harWriter.Close())
 
@@ -77,7 +79,7 @@ func TestWriter(t *testing.T) {
 		require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
 
 		path := filepath.Join(blocker, "sub", "out.har")
-		harWriter := har.NewWriter(path)
+		harWriter := har.NewWriter(afero.NewOsFs(), path)
 		harWriter.AddEntry(har.Entry{})
 
 		require.NoError(t, harWriter.Close())
@@ -96,7 +98,7 @@ func TestWriter(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		harWriter := har.NewWriter(path)
+		harWriter := har.NewWriter(afero.NewOsFs(), path)
 		harWriter.AddEntry(har.Entry{})
 
 		require.NoError(t, harWriter.Close())
@@ -111,7 +113,7 @@ func TestWriter(t *testing.T) {
 
 		require.NoError(t, os.Mkdir(path, 0o755))
 
-		harWriter := har.NewWriter(path)
+		harWriter := har.NewWriter(afero.NewOsFs(), path)
 		harWriter.AddEntry(har.Entry{})
 
 		require.NoError(t, harWriter.Close())
@@ -123,7 +125,7 @@ func TestWriter(t *testing.T) {
 
 	t.Run("creates parent directories automatically", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "nested", "deep", "out.har")
-		harWriter := har.NewWriter(path)
+		harWriter := har.NewWriter(afero.NewOsFs(), path)
 		harWriter.AddEntry(har.Entry{
 			Request:  har.Request{Method: "GET", URL: "http://example.com/"},
 			Response: har.Response{Status: 200},
@@ -137,5 +139,78 @@ func TestWriter(t *testing.T) {
 		var archive har.HAR
 		require.NoError(t, json.Unmarshal(data, &archive))
 		assert.Len(t, archive.Log.Entries, 1)
+	})
+}
+
+// The archive used to be re-serialised in full after every batch, and every
+// entry was retained in memory for the process lifetime.
+func TestWriterScalesWithSessionLength(t *testing.T) {
+	t.Run("records many entries without retaining them", func(t *testing.T) {
+		const entries = 2000
+
+		fs := afero.NewMemMapFs()
+		path := "/har/out.har"
+
+		harWriter := har.NewWriter(fs, path, har.WithCreatorVersion("1.2.3"))
+
+		for index := range entries {
+			harWriter.AddEntry(har.Entry{
+				StartedDateTime: time.Now(),
+				Request:         har.Request{Method: "GET", URL: fmt.Sprintf("http://example.com/%d", index)},
+				Response:        har.Response{Status: 200},
+			})
+		}
+
+		require.NoError(t, harWriter.Close())
+
+		data, err := afero.ReadFile(fs, path)
+		require.NoError(t, err)
+
+		var archive har.HAR
+		require.NoError(t, json.Unmarshal(data, &archive))
+
+		assert.Len(t, archive.Log.Entries, entries)
+		assert.Equal(t, "1.2.3", archive.Log.Creator.Version, "the archive records the build that produced it")
+
+		// The journal is the writer's own working file and must not be left
+		// behind by a clean shutdown.
+		_, err = fs.Stat(path + ".jsonl")
+		assert.Error(t, err)
+	})
+
+	t.Run("bounds a runaway recording", func(t *testing.T) {
+		const limit = 10
+
+		fs := afero.NewMemMapFs()
+		path := "/har/bounded.har"
+
+		harWriter := har.NewWriter(fs, path, har.WithMaxEntries(limit))
+
+		for range limit * 5 {
+			harWriter.AddEntry(har.Entry{Request: har.Request{Method: "GET"}})
+		}
+
+		require.NoError(t, harWriter.Close())
+
+		data, err := afero.ReadFile(fs, path)
+		require.NoError(t, err)
+
+		var archive har.HAR
+		require.NoError(t, json.Unmarshal(data, &archive))
+
+		assert.Len(t, archive.Log.Entries, limit)
+	})
+
+	t.Run("two writers over one path do not clobber each other", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		path := "/har/shared.har"
+
+		first := har.NewWriter(fs, path)
+		second := har.NewWriter(fs, path)
+
+		assert.NotEqual(t, first.TempPath(), second.TempPath())
+
+		require.NoError(t, first.Close())
+		require.NoError(t, second.Close())
 	})
 }

--- a/internal/handler/router/router_test.go
+++ b/internal/handler/router/router_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/evg4b/uncors/testing/mocks"
 	"github.com/evg4b/uncors/testing/testutils"
 	"github.com/go-http-utils/headers"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,7 +63,7 @@ func newDeps(t *testing.T, container *di.Container, proxy http.Handler) router.D
 		Script:  container.ScriptHandler,
 		Cache:   cacheFactory(),
 		HAR: func(harConfig *config.HARConfig) contracts.Middleware {
-			writer := har.NewWriter(harConfig.File)
+			writer := har.NewWriter(afero.NewOsFs(), harConfig.File)
 
 			t.Cleanup(func() {
 				require.NoError(t, writer.Close())

--- a/testing/integration/env.go
+++ b/testing/integration/env.go
@@ -32,6 +32,9 @@ type Env struct {
 	// proxy. Use Hosts.DialContext when building a custom client (e.g. one that
 	// does not trust the proxy CA) so it can still reach mapped hosts by name.
 	Hosts *Hosts
+	// Fs is the filesystem the proxy runs against. Everything uncors writes —
+	// static files it serves, HAR archives it records — lives here.
+	Fs afero.Fs
 
 	routes []route
 }
@@ -82,7 +85,7 @@ func New(t *testing.T, backend *Backend, cfg *config.UncorsConfig, opts ...Optio
 	}
 
 	resolver := newHosts()
-	env := &Env{Backend: backend, Hosts: resolver}
+	env := &Env{Backend: backend, Hosts: resolver, Fs: fs}
 
 	for i := range cfg.Mappings {
 		from := &cfg.Mappings[i].From

--- a/tests/integration/har/har_test.go
+++ b/tests/integration/har/har_test.go
@@ -5,14 +5,13 @@ package har_test
 import (
 	"encoding/json"
 	"net/http"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/testing/hosts"
 	"github.com/evg4b/uncors/testing/integration"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,9 +31,9 @@ type harFile struct {
 }
 
 func TestHARMiddleware(t *testing.T) {
-	// The HAR writer uses the real filesystem and flushes on Close, so use a
-	// real temp path and shut the proxy down before reading the file.
-	harPath := filepath.Join(t.TempDir(), "out.har")
+	// The HAR writer records through the injected filesystem, which the harness
+	// keeps in memory.
+	const harPath = "/har/out.har"
 
 	backend := integration.NewBackend(t, nil)
 	env := integration.New(t, backend, &config.UncorsConfig{
@@ -53,7 +52,7 @@ func TestHARMiddleware(t *testing.T) {
 	var parsed harFile
 
 	require.Eventually(t, func() bool {
-		data, err := os.ReadFile(harPath)
+		data, err := afero.ReadFile(env.Fs, harPath)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
Fixes review finding **A15 — The HAR writer re-serialises and rewrites the entire archive after every batch**.

The writer kept every entry ever recorded in memory and re-serialised the whole
document with MarshalIndent after each batch, so recording cost grew with the
square of the session length and memory grew without bound — each entry holding
a full decoded response body. The temp file had a fixed name, so two writers over
one path renamed each other's partial output over the target, and all the I/O
bypassed the injected filesystem.

- Entries are appended to a `.har.jsonl` journal as they arrive (constant cost,
  nothing retained), and the `.har` document is streamed from that journal at a
  bounded rate and on Close.
- The temp file is unique per writer, closing the reload-corruption hazard for
  good; all I/O goes through `afero.Fs`, so the collector is testable in memory
  like everything else.
- `MarshalIndent` becomes `Marshal`, the archive records the real build version
  instead of "dev", and a recording is bounded at 100k entries with a warning
  rather than growing forever.
- docs/HAR-Collector.md now describes what actually happens.

---

### Review

One commit, `14ba12b`. Step **15 of 33** in the review stack.

This PR targets **`fix/a14-error-status-taxonomy`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
