### PR TITLE
fix(cache): stop blocking on writes and key entries correctly (A16)

### DIFF
--- a/docs/Response-Caching.md
+++ b/docs/Response-Caching.md
@@ -90,6 +90,28 @@ cache-config:
  3. **Evicted** (after `expiration-time` or when `max-size` is reached) - Cache
     entry is removed; next request fetches fresh data from upstream
 
+## What Is and Is Not Cached
+
+A cached entry is identified by the request method, the full host (including the
+port), the path, the sorted query string, the `Accept-Encoding` header and — for
+methods with a body, such as `POST` — a hash of that body. Two `POST`s to the
+same path with different bodies are therefore different entries.
+
+A response is **not** stored when:
+
+ - it is not a 2xx response;
+ - it carries `Set-Cookie`;
+ - its `Cache-Control` contains `no-store` or `private`;
+ - the request carried `Authorization` and the response is not marked `public`;
+ - it carries a `Vary` on anything other than `Accept-Encoding` — honouring those
+   would need a variant index, and serving one variant to every client would be
+   worse than not caching;
+ - its body was larger than the capture limit, or the request body was larger
+   than 1 MiB.
+
+These rules exist so that a cached response is never served to a client the
+upstream did not produce it for.
+
 ## Examples
 
 ### Cache API Responses

--- a/internal/handler/cache/cache.go
+++ b/internal/handler/cache/cache.go
@@ -20,8 +20,13 @@ func CalcCost(value *contracts.CachedResponse) int64 {
 }
 
 const (
-	numCounters = 1e5
 	bufferItems = 64
+	// expectedEntrySize is the response size the counter budget is sized around.
+	// Ristretto wants roughly ten counters per item it expects to hold, so the
+	// budget has to follow MaxSize rather than being a fixed number.
+	expectedEntrySize = 4 << 10 // 4 KiB
+	countersPerEntry  = 10
+	minNumCounters    = 1 << 10
 )
 
 type RistrettoCache struct {
@@ -31,7 +36,7 @@ type RistrettoCache struct {
 
 func NewRistrettoCache(maxSize int64, ttl time.Duration) *RistrettoCache {
 	storage, err := ristretto.NewCache(&ristretto.Config[string, contracts.CachedResponse]{
-		NumCounters: numCounters,
+		NumCounters: numCountersFor(maxSize),
 		MaxCost:     maxSize,
 		BufferItems: bufferItems,
 	})
@@ -49,13 +54,26 @@ func (cs *RistrettoCache) Get(key string) (contracts.CachedResponse, bool) {
 	return cs.storage.Get(key)
 }
 
+// Set admits a response. Admission is asynchronous by design — that is the
+// reason ristretto is here — so this never blocks the request that produced the
+// response.
 func (cs *RistrettoCache) Set(key string, value contracts.CachedResponse) {
 	cs.storage.SetWithTTL(key, value, CalcCost(&value), cs.ttl)
+}
+
+// Wait blocks until pending admissions have been processed. Tests need it to be
+// deterministic; the request path must not pay for that.
+func (cs *RistrettoCache) Wait() {
 	cs.storage.Wait()
 }
 
-func (cs *RistrettoCache) Wait() {
-	cs.storage.Wait()
+func numCountersFor(maxSize int64) int64 {
+	counters := maxSize / expectedEntrySize * countersPerEntry
+	if counters < minNumCounters {
+		return minNumCounters
+	}
+
+	return counters
 }
 
 // Close releases the underlying cache. It satisfies io.Closer so the app can

--- a/internal/handler/cache/correctness_test.go
+++ b/internal/handler/cache/correctness_test.go
@@ -1,0 +1,149 @@
+package cache_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/evg4b/uncors/internal/handler/cache"
+	"github.com/evg4b/uncors/internal/infra"
+	"github.com/evg4b/uncors/testing/testutils"
+	"github.com/go-http-utils/headers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type cacheProbe struct {
+	handler *testutils.CountableHandler
+	wrapped http.Handler
+	storage *cache.RistrettoCache
+}
+
+func newProbe(t *testing.T, methods []string, respond http.HandlerFunc) *cacheProbe {
+	t.Helper()
+
+	storage := cache.NewRistrettoCache(1024*1024, time.Minute)
+
+	t.Cleanup(func() {
+		require.NoError(t, storage.Close())
+	})
+
+	handler := testutils.NewCounter(respond)
+
+	middleware := cache.NewMiddleware(
+		cache.WithCacheStorage(storage),
+		cache.WithMethods(methods),
+		cache.WithGlobs(config.CacheGlobs{"/api/**"}),
+	)
+
+	return &cacheProbe{handler: handler, wrapped: middleware.Wrap(handler), storage: storage}
+}
+
+func (p *cacheProbe) do(t *testing.T, request *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	p.wrapped.ServeHTTP(infra.NewResponseRecorder(recorder), request)
+	p.storage.Wait()
+
+	return recorder
+}
+
+func post(t *testing.T, path, body string) *http.Request {
+	t.Helper()
+
+	return httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, strings.NewReader(body))
+}
+
+func get(t *testing.T, path string) *http.Request {
+	t.Helper()
+
+	return httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil)
+}
+
+// Two POSTs to the same path used to share a cache entry, so the second request
+// was answered with the first one's response.
+func TestCacheKeyIncludesTheRequestBody(t *testing.T) {
+	probe := newProbe(t, []string{http.MethodPost}, func(writer http.ResponseWriter, request *http.Request) {
+		body := make([]byte, request.ContentLength)
+		_, _ = request.Body.Read(body)
+
+		_, _ = writer.Write([]byte("answer for " + string(body)))
+	})
+
+	first := probe.do(t, post(t, "/api/search", "alpha"))
+	second := probe.do(t, post(t, "/api/search", "beta"))
+	repeat := probe.do(t, post(t, "/api/search", "alpha"))
+
+	assert.Equal(t, "answer for alpha", first.Body.String())
+	assert.Equal(t, "answer for beta", second.Body.String())
+	assert.Equal(t, "answer for alpha", repeat.Body.String())
+	assert.Equal(t, 2, probe.handler.Count(), "only the repeated body is served from the cache")
+}
+
+func TestCacheKeyIncludesThePort(t *testing.T) {
+	probe := newProbe(t, []string{http.MethodGet}, func(writer http.ResponseWriter, request *http.Request) {
+		//nolint:gosec // G705: a test handler echoing the host it was called on
+		_, _ = writer.Write([]byte("from " + request.Host))
+	})
+
+	first := probe.do(t, get(t, "http://api.local:3000/api/data"))
+	second := probe.do(t, get(t, "http://api.local:4000/api/data"))
+
+	assert.Equal(t, "from api.local:3000", first.Body.String())
+	assert.Equal(t, "from api.local:4000", second.Body.String())
+	assert.Equal(t, 2, probe.handler.Count(), "mappings on different ports are different resources")
+}
+
+func TestCacheRespectsResponseDirectives(t *testing.T) {
+	tests := []struct {
+		name   string
+		header http.Header
+		cached bool
+	}{
+		{name: "plain response", header: http.Header{}, cached: true},
+		{name: "no-store", header: http.Header{headers.CacheControl: {"no-store"}}, cached: false},
+		{name: "private", header: http.Header{headers.CacheControl: {"private, max-age=60"}}, cached: false},
+		{name: "set-cookie", header: http.Header{headers.SetCookie: {"session=abc"}}, cached: false},
+		{name: "vary on accept-encoding", header: http.Header{headers.Vary: {"Accept-Encoding"}}, cached: true},
+		{name: "vary on anything else", header: http.Header{headers.Vary: {"Accept-Language"}}, cached: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			probe := newProbe(t, []string{http.MethodGet}, func(writer http.ResponseWriter, _ *http.Request) {
+				testutils.CopyHeaders(testCase.header, writer.Header())
+				writer.WriteHeader(http.StatusOK)
+				_, _ = writer.Write([]byte("body"))
+			})
+
+			probe.do(t, get(t, "/api/data"))
+			probe.do(t, get(t, "/api/data"))
+
+			expected := 2
+			if testCase.cached {
+				expected = 1
+			}
+
+			assert.Equal(t, expected, probe.handler.Count())
+		})
+	}
+}
+
+// Replaying an authenticated response to whoever asks next is a data leak.
+func TestCacheSkipsAuthenticatedRequests(t *testing.T) {
+	probe := newProbe(t, []string{http.MethodGet}, func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte("secret"))
+	})
+
+	authorised := get(t, "/api/profile")
+	authorised.Header.Set(headers.Authorization, "Bearer token")
+
+	probe.do(t, authorised)
+	probe.do(t, get(t, "/api/profile"))
+
+	assert.Equal(t, 2, probe.handler.Count())
+}

--- a/internal/handler/cache/middleware.go
+++ b/internal/handler/cache/middleware.go
@@ -1,9 +1,13 @@
 package cache
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
-	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -14,8 +18,13 @@ import (
 	"github.com/evg4b/uncors/internal/helpers"
 	"github.com/evg4b/uncors/internal/infra"
 	"github.com/evg4b/uncors/internal/urlt"
+	"github.com/go-http-utils/headers"
 	"github.com/samber/lo"
 )
+
+// maxCacheableBodySize bounds the request body the cache is willing to hash.
+// A larger request is served without caching rather than buffered.
+const maxCacheableBodySize = 1 << 20 // 1 MiB
 
 type Middleware struct {
 	cache     contracts.Cache
@@ -53,7 +62,15 @@ func (m *Middleware) Wrap(next http.Handler) http.Handler {
 }
 
 func (m *Middleware) cacheRequest(writer http.ResponseWriter, request *http.Request, next http.Handler) {
-	cacheKey := m.extractCacheKey(request.Method, request.URL)
+	cacheKey, keyable := m.extractCacheKey(request)
+	if !keyable {
+		// A request we cannot identify exactly must not be served from, or
+		// stored in, the cache: that is how one POST body ends up answered with
+		// another one's response.
+		next.ServeHTTP(writer, request)
+
+		return
+	}
 
 	if cachedResponse := m.getCachedResponse(cacheKey); cachedResponse != nil {
 		m.writeCachedResponse(writer, cachedResponse)
@@ -73,17 +90,11 @@ func (m *Middleware) cacheRequest(writer http.ResponseWriter, request *http.Requ
 
 	next.ServeHTTP(writer, request)
 
-	m.storeResponse(cacheKey, capturer.Captured())
+	m.storeResponse(cacheKey, request, capturer.Captured())
 }
 
-func (m *Middleware) storeResponse(key string, capture contracts.ResponseCapture) {
-	if !infra.Is2xxCode(capture.StatusCode) {
-		return
-	}
-
-	// Storing a body we only saw the beginning of would serve a corrupted
-	// response on the next hit, so oversized responses are simply not cached.
-	if capture.Truncated {
+func (m *Middleware) storeResponse(key string, request *http.Request, capture contracts.ResponseCapture) {
+	if !m.isStorable(request, capture) {
 		return
 	}
 
@@ -117,11 +128,63 @@ func (m *Middleware) writeCachedResponse(writer http.ResponseWriter, cachedRespo
 	writer.WriteHeader(cachedResponse.Code)
 
 	if len(cachedResponse.Body) > 0 {
+		// The body is the upstream's own response, replayed verbatim.
+		//nolint:gosec // G705
 		_, err := writer.Write(cachedResponse.Body)
 		if err != nil {
-			panic(err)
+			// A client that hung up mid-response is normal.
+			slog.Debug("cache: failed to write the cached response", "err", err)
 		}
 	}
+}
+
+// isStorable applies the minimum HTTP caching rules. Without them a response
+// carrying Set-Cookie, or one produced for an authenticated request, would be
+// replayed to whoever asked next.
+func (m *Middleware) isStorable(request *http.Request, capture contracts.ResponseCapture) bool {
+	if !infra.Is2xxCode(capture.StatusCode) {
+		return false
+	}
+
+	// Storing a body we only saw the beginning of would serve a corrupted
+	// response on the next hit.
+	if capture.Truncated {
+		return false
+	}
+
+	if capture.Header.Get(headers.SetCookie) != "" {
+		return false
+	}
+
+	cacheControl := strings.ToLower(capture.Header.Get(headers.CacheControl))
+	if strings.Contains(cacheControl, "no-store") || strings.Contains(cacheControl, "private") {
+		return false
+	}
+
+	if request.Header.Get(headers.Authorization) != "" && !strings.Contains(cacheControl, "public") {
+		return false
+	}
+
+	return varyIsHandled(capture.Header.Get(headers.Vary))
+}
+
+// varyIsHandled reports whether the response's Vary is one the cache key already
+// accounts for. Accept-Encoding is part of the key; anything else would need a
+// variant index, so those responses are not cached at all rather than being
+// served to the wrong client.
+func varyIsHandled(vary string) bool {
+	for field := range strings.SplitSeq(vary, ",") {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+
+		if !strings.EqualFold(field, headers.AcceptEncoding) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (m *Middleware) isCacheableRequest(request *http.Request) (bool, error) {
@@ -143,19 +206,68 @@ func (m *Middleware) isCacheableRequest(request *http.Request) (bool, error) {
 	return false, nil
 }
 
-func (m *Middleware) extractCacheKey(method string, url *url.URL) string {
-	values := urlt.URL_Query(url)
+// extractCacheKey identifies a request completely enough to answer it from the
+// cache. The host keeps its port (two mappings on different ports are different
+// resources), the negotiated encoding is included because it is the one Vary the
+// cache honours, and a request body is hashed in — without it, two POSTs to the
+// same path are indistinguishable.
+//
+// It reports false when the request cannot be identified exactly, which is the
+// signal to bypass the cache entirely.
+func (m *Middleware) extractCacheKey(request *http.Request) (string, bool) {
+	bodyHash, ok := m.requestBodyHash(request)
+	if !ok {
+		return "", false
+	}
+
+	values := urlt.URL_Query(request.URL)
 
 	items := make([]string, 0, len(values))
 	for key, value := range values {
 		sort.Strings(value)
+
 		valuesKey := key + "=" + strings.Join(value, ",")
 		items = append(items, valuesKey)
 	}
 
 	sort.Strings(items)
 
-	return fmt.Sprintf("[%s]%s%s?%s", method, urlt.URL_Hostname(url), url.Path, strings.Join(items, ";"))
+	key := fmt.Sprintf("[%s]%s%s?%s|enc=%s",
+		request.Method,
+		request.URL.Host,
+		request.URL.Path,
+		strings.Join(items, ";"),
+		request.Header.Get(headers.AcceptEncoding))
+
+	if bodyHash != "" {
+		key += "|body=" + bodyHash
+	}
+
+	return key, true
+}
+
+// requestBodyHash reads the request body, hashes it into the key and puts it
+// back for the handler. Bodies larger than the cap are not cached at all.
+func (m *Middleware) requestBodyHash(request *http.Request) (string, bool) {
+	if request.Body == nil || request.Body == http.NoBody {
+		return "", true
+	}
+
+	body, err := io.ReadAll(io.LimitReader(request.Body, maxCacheableBodySize+1))
+	if err != nil {
+		return "", false
+	}
+
+	_ = request.Body.Close()
+	request.Body = io.NopCloser(bytes.NewReader(body))
+
+	if int64(len(body)) > maxCacheableBodySize {
+		return "", false
+	}
+
+	sum := sha256.Sum256(body)
+
+	return hex.EncodeToString(sum[:]), true
 }
 
 func (m *Middleware) getCachedResponse(cacheKey string) *contracts.CachedResponse {

--- a/internal/handler/cache/middleware_test.go
+++ b/internal/handler/cache/middleware_test.go
@@ -33,8 +33,10 @@ func TestCacheMiddleware(t *testing.T) {
 		headers.ContentEncoding: {"deflate, gzip"},
 	}
 
+	storage := cache.NewRistrettoCache(1024*1024, time.Minute)
+
 	middleware := cache.NewMiddleware(
-		cache.WithCacheStorage(cache.NewRistrettoCache(1024*1024, time.Minute)),
+		cache.WithCacheStorage(storage),
 		cache.WithMethods([]string{http.MethodGet}),
 		cache.WithGlobs(config.CacheGlobs{
 			"/translations",
@@ -111,6 +113,10 @@ func TestCacheMiddleware(t *testing.T) {
 						rec,
 						httptest.NewRequestWithContext(t.Context(), testCase.method, testCase.path, nil),
 					)
+					// Admission is asynchronous on the request path; only the
+					// test needs it to have landed before the next request.
+					storage.Wait()
+
 					assert.Equal(t, expectedHeader, recorder.Header())
 					assert.Equal(t, expectedBody, testutils.ReadBody(t, recorder))
 				})
@@ -175,6 +181,10 @@ func TestCacheMiddleware(t *testing.T) {
 						rec,
 						httptest.NewRequestWithContext(t.Context(), testCase.method, testCase.path, nil),
 					)
+					// Admission is asynchronous on the request path; only the
+					// test needs it to have landed before the next request.
+					storage.Wait()
+
 					assert.Equal(t, expectedHeader, recorder.Header())
 					assert.Equal(t, expectedBody, testutils.ReadBody(t, recorder))
 				})
@@ -189,8 +199,10 @@ func TestCacheMiddleware(t *testing.T) {
 
 		testHandler.Reset()
 
+		storage := cache.NewRistrettoCache(1024*1024, time.Minute)
+
 		middleware := cache.NewMiddleware(
-			cache.WithCacheStorage(cache.NewRistrettoCache(1024*1024, time.Minute)),
+			cache.WithCacheStorage(storage),
 			cache.WithMethods([]string{http.MethodGet}),
 			cache.WithGlobs(config.CacheGlobs{cacheGlob}),
 		)
@@ -215,8 +227,10 @@ func TestCacheMiddleware(t *testing.T) {
 
 		testHandler.Reset()
 
+		storage := cache.NewRistrettoCache(1024*1024, time.Minute)
+
 		middleware := cache.NewMiddleware(
-			cache.WithCacheStorage(cache.NewRistrettoCache(1024*1024, time.Minute)),
+			cache.WithCacheStorage(storage),
 			cache.WithMethods(methods),
 			cache.WithGlobs(config.CacheGlobs{cacheGlob}),
 		)


### PR DESCRIPTION
Fixes review finding **A16 — The response cache blocks the request goroutine on every write and keys entries on the URL alone**.

`Set` called `ristretto.Wait()` on the request path, which turned the one thing
ristretto is chosen for — asynchronous batched admission — into a synchronous
write on every cacheable response. The key was method+hostname+path+query, so
two POSTs to the same path shared an entry (the second request was answered with
the first one's body, in a documented feature), mappings on different ports
collided, and `Vary`, `Set-Cookie`, `no-store` and `Authorization` were ignored
entirely.

- `Set` no longer waits; `Wait()` stays public for tests, which now call it.
- The key includes the port, `Accept-Encoding` and a hash of the request body;
  a request that cannot be identified exactly bypasses the cache instead of
  guessing.
- Responses carrying `Set-Cookie`, `no-store`/`private`, an unsupported `Vary`,
  or produced for an authenticated request are not stored — replaying those to
  the next client is a data leak, not a cache hit.
- `NumCounters` is derived from `max-size` instead of being fixed at 1e5, and a
  client that hangs up mid-response is logged rather than panicking the handler.
- docs/Response-Caching.md documents what is and is not cached.

---

### Review

One commit, `5bdf210`. Step **16 of 33** in the review stack.

This PR targets **`perf/a15-har-journal`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
