### PR TITLE
fix(script): compile once, bound execution, state the sandbox (A19)

### DIFF
--- a/docs/Script-Handler.md
+++ b/docs/Script-Handler.md
@@ -504,7 +504,31 @@ response:WriteString('{"random": ' .. random .. ', "min": ' .. min .. ', "max": 
 
 ## Available Libraries
 
-The script handler provides access to standard libraries:
+Scripts run in a VM with an explicit library set: `base`, `package` (for
+`require`), `string`, `table`, `math`, `os` and `json`.
+
+> [!WARNING]
+> `os` is available, so a script can read the clock and the environment and can
+> call `os.execute`. A uncors config that contains scripts is executable code —
+> review one before running a config file someone else wrote. `io`, `debug` and
+> `coroutine` are **not** available, so a script cannot read or write files.
+
+Each script is compiled once, when the configuration is loaded: a syntax error
+is reported there, with the file and line, rather than failing every request that
+reaches the route. Editing a script file takes effect when the configuration is
+reloaded.
+
+Every run is bounded by a timeout — five seconds by default — and is cancelled
+when the client goes away:
+
+```yaml
+scripts:
+  - path: /api/slow
+    timeout: 30s
+    file: ./scripts/report.lua
+```
+
+The script handler provides access to these standard libraries:
 
 ### Math Library
 

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/spf13/afero"
@@ -12,6 +13,8 @@ type Script struct {
 	Matcher RequestMatcher `yaml:",inline"`
 	Script  string         `yaml:"script"`
 	File    string         `yaml:"file"`
+	// Timeout bounds how long the script may run. Zero means the default.
+	Timeout time.Duration `yaml:"timeout"`
 }
 
 func (s *Script) Clone() Script {
@@ -19,6 +22,7 @@ func (s *Script) Clone() Script {
 		Matcher: s.Matcher.Clone(),
 		Script:  s.Script,
 		File:    s.File,
+		Timeout: s.Timeout,
 	}
 }
 

--- a/internal/di/public_api.go
+++ b/internal/di/public_api.go
@@ -98,15 +98,20 @@ func (c *Container) MockHandler(response *config.Response) http.Handler {
 	))
 }
 
-func (c *Container) ScriptHandler(scriptConfig *config.Script) http.Handler {
+func (c *Container) ScriptHandler(scriptConfig *config.Script) (http.Handler, error) {
 	prefix := styles.RewriteStyle.Render("SCRIPT")
 	output := c.CliOutput()
 
-	return infra.WithPrefix(prefix, script.NewHandler(
+	handler, err := script.NewHandler(
 		script.WithOutput(output.NewPrefixOutput(prefix)),
 		script.WithScript(scriptConfig),
 		script.WithFileSystem(c.fs),
-	))
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return infra.WithPrefix(prefix, handler), nil
 }
 
 func (c *Container) RewriteMiddleware(rewriting *config.RewritingOption) contracts.Middleware {

--- a/internal/di/public_api_test.go
+++ b/internal/di/public_api_test.go
@@ -132,8 +132,9 @@ func TestContainer(t *testing.T) {
 			Matcher: config.RequestMatcher{Path: "/api"},
 			Script:  `response:set_status(200)`,
 		}
-		handler := container.ScriptHandler(script)
+		handler, err := container.ScriptHandler(script)
 
+		require.NoError(t, err)
 		assert.NotNil(t, handler)
 		assert.Implements(t, (*http.Handler)(nil), handler)
 	})

--- a/internal/handler/router/factories.go
+++ b/internal/handler/router/factories.go
@@ -26,6 +26,8 @@ type Deps struct {
 	Cache func(globs config.CacheGlobs) contracts.Middleware
 	// Mock answers with a configured response.
 	Mock func(response *config.Response) http.Handler
-	// Script answers with the result of a Lua script.
-	Script func(scriptConfig *config.Script) http.Handler
+	// Script answers with the result of a Lua script. It reports a script that
+	// does not compile, so a syntax error fails the configuration rather than
+	// every request that reaches the route.
+	Script func(scriptConfig *config.Script) (http.Handler, error)
 }

--- a/internal/handler/router/router.go
+++ b/internal/handler/router/router.go
@@ -35,8 +35,15 @@ func NewRouter(mappings config.Mappings, deps Deps) (*Router, error) {
 		deps:   deps,
 	}
 
+	errs := make([]error, 0, len(mappings))
+
 	for _, mapping := range mappings {
-		instance.registerMapping(mapping)
+		errs = append(errs, instance.registerMapping(mapping))
+	}
+
+	err := errors.Join(errs...)
+	if err != nil {
+		return nil, err
 	}
 
 	setDefaultHandler(instance.Router, infra.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) error {
@@ -56,7 +63,7 @@ func NewRouter(mappings config.Mappings, deps Deps) (*Router, error) {
 // a router of its own so that its cross-cutting middleware wraps every route it
 // contains — mocks, scripts, statics and the proxy fallback alike — rather than
 // decorating one branch and silently skipping the others.
-func (r *Router) registerMapping(mapping config.Mapping) {
+func (r *Router) registerMapping(mapping config.Mapping) error {
 	mappingRouter := mux.NewRouter()
 	routes := mappingRouter.Host(mapping.From.Hostname).Subrouter()
 
@@ -77,10 +84,19 @@ func (r *Router) registerMapping(mapping config.Mapping) {
 			registerRoute(createRoute(routes, def.Matcher), r.deps.Mock(&def.Response))
 		})
 
+	var scriptErrs []error
+
 	registerMatchedRoutes(mapping.Scripts,
 		func(s *config.Script) *config.RequestMatcher { return &s.Matcher },
 		func(def *config.Script) {
-			registerRoute(createRoute(routes, def.Matcher), r.deps.Script(def))
+			handler, err := r.deps.Script(def)
+			if err != nil {
+				scriptErrs = append(scriptErrs, err)
+
+				return
+			}
+
+			registerRoute(createRoute(routes, def.Matcher), handler)
 		})
 
 	// A rewritten request re-enters the mapping's routes, so that it can be
@@ -102,6 +118,8 @@ func (r *Router) registerMapping(mapping config.Mapping) {
 
 	r.Router.Host(mapping.From.Hostname).
 		Handler(r.wrapMapping(mapping, mappingRouter))
+
+	return errors.Join(scriptErrs...)
 }
 
 // wrapMapping applies the middleware that belongs to the whole mapping rather

--- a/internal/handler/script/errors.go
+++ b/internal/handler/script/errors.go
@@ -2,4 +2,9 @@ package script
 
 import "errors"
 
-var ErrScriptFileNotFound = errors.New("script file not found")
+var (
+	ErrScriptFileNotFound      = errors.New("script file not found")
+	ErrScriptCompilationFailed = errors.New("script compilation failed")
+	ErrScriptTimeout           = errors.New("script exceeded its timeout")
+	ErrScriptNotConfigured     = errors.New("neither script nor file is configured")
+)

--- a/internal/handler/script/handler.go
+++ b/internal/handler/script/handler.go
@@ -1,8 +1,11 @@
 package script
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/spf13/afero"
 	lua "github.com/yuin/gopher-lua"
@@ -13,14 +16,42 @@ import (
 	"github.com/evg4b/uncors/internal/infra"
 )
 
+// defaultTimeout bounds how long a script may run. Without one, a `while true do
+// end` pins a goroutine and an OS thread until the process is restarted.
+const defaultTimeout = 5 * time.Second
+
 type Handler struct {
 	script *config.Script
 	output contracts.ErrorOutput
 	fs     afero.Fs
+
+	proto   *lua.FunctionProto
+	timeout time.Duration
 }
 
-func NewHandler(options ...HandlerOption) *Handler {
-	return helpers.ApplyOptions(&Handler{}, options)
+// NewHandler compiles the script. The source is fixed for the lifetime of a
+// configuration, so compiling it here reports a syntax error once, at load, with
+// a location — instead of re-reading and re-compiling on every request and
+// failing each of them.
+func NewHandler(options ...HandlerOption) (*Handler, error) {
+	handler := helpers.ApplyOptions(&Handler{}, options)
+
+	source, name, err := handler.source()
+	if err != nil {
+		return nil, err
+	}
+
+	handler.proto, err = compileScript(source, name)
+	if err != nil {
+		return nil, err
+	}
+
+	handler.timeout = handler.script.Timeout
+	if handler.timeout <= 0 {
+		handler.timeout = defaultTimeout
+	}
+
+	return handler, nil
 }
 
 func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -41,21 +72,51 @@ func (h *Handler) Serve(writer http.ResponseWriter, request *http.Request) error
 	return nil
 }
 
+// source returns the script text and a name to report errors against.
+func (h *Handler) source() (string, string, error) {
+	if h.script == nil {
+		return "", "", ErrScriptNotConfigured
+	}
+
+	if h.script.Script != "" {
+		return h.script.Script, "<inline script>", nil
+	}
+
+	if h.script.File == "" {
+		return "", "", ErrScriptNotConfigured
+	}
+
+	content, err := afero.ReadFile(h.fs, h.script.File)
+	if err != nil {
+		return "", "", fmt.Errorf("%w: %s", ErrScriptFileNotFound, err.Error())
+	}
+
+	return string(content), h.script.File, nil
+}
+
 func (h *Handler) executeScript(writer http.ResponseWriter, request *http.Request) error {
+	// The script runs under the request's context plus its own deadline, so a
+	// client that goes away or a script that never returns both end the run.
+	ctx, cancel := context.WithTimeout(request.Context(), h.timeout)
+	defer cancel()
+
 	luaState := newLuaState()
 	defer luaState.Close()
+
+	luaState.SetContext(ctx)
 
 	origin := request.Header.Get("Origin")
 	infra.WriteCorsHeaders(writer.Header(), origin)
 
-	reqTable := createRequestTable(luaState, request)
-	respTable := createResponseTable(luaState, writer)
-
-	luaState.SetGlobal("request", reqTable)
-	luaState.SetGlobal("response", respTable)
+	luaState.SetGlobal("request", createRequestTable(luaState, request))
+	luaState.SetGlobal("response", createResponseTable(luaState, writer))
 
 	err := h.runScript(luaState)
 	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("%w of %s", ErrScriptTimeout, h.timeout)
+		}
+
 		return fmt.Errorf("script error: %w", err)
 	}
 
@@ -63,16 +124,9 @@ func (h *Handler) executeScript(writer http.ResponseWriter, request *http.Reques
 }
 
 func (h *Handler) runScript(luaState *lua.LState) error {
-	if h.script.Script != "" {
-		return luaState.DoString(h.script.Script)
-	}
+	luaState.Push(luaState.NewFunctionFromProto(h.proto))
 
-	scriptContent, err := afero.ReadFile(h.fs, h.script.File)
-	if err != nil {
-		return fmt.Errorf("%w: %s", ErrScriptFileNotFound, err.Error())
-	}
-
-	return luaState.DoString(string(scriptContent))
+	return luaState.PCall(0, lua.MultRet, nil) //nolint:wrapcheck // wrapped by the caller
 }
 
 type HandlerOption = func(*Handler)

--- a/internal/handler/script/handler_test.go
+++ b/internal/handler/script/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/handler/script"
@@ -33,13 +34,14 @@ func runScriptTests(t *testing.T, tests []scriptTestCase) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			handler := script.NewHandler(
+			handler, err := script.NewHandler(
 				script.WithOutput(mocks.NoopOutput()),
 				script.WithScript(&config.Script{
 					Script: testCase.script,
 				}),
 				script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 			)
+			require.NoError(t, err)
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test/path", nil)
 			req.Header.Set(headers.UserAgent, "TestAgent/1.0")
@@ -222,13 +224,14 @@ response:WriteString("Error response")
 
 		for _, testCase := range tests {
 			t.Run(testCase.name, func(t *testing.T) {
-				handler := script.NewHandler(
+				handler, err := script.NewHandler(
 					script.WithOutput(mocks.NoopOutput()),
 					script.WithScript(&config.Script{
 						File: testCase.file,
 					}),
 					script.WithFileSystem(fileSystem),
 				)
+				require.NoError(t, err)
 
 				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 				recorder := httptest.NewRecorder()
@@ -313,13 +316,14 @@ response:WriteString("Body: " .. request.body)
 
 				testCase.setupRequest(req)
 
-				handler := script.NewHandler(
+				handler, err := script.NewHandler(
 					script.WithOutput(mocks.NoopOutput()),
 					script.WithScript(&config.Script{
 						Script: testCase.script,
 					}),
 					script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 				)
+				require.NoError(t, err)
 
 				recorder := httptest.NewRecorder()
 				handler.ServeHTTP(infra.NewResponseRecorder(recorder), req)
@@ -330,7 +334,7 @@ response:WriteString("Body: " .. request.body)
 	})
 
 	t.Run("path parameters", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -342,6 +346,7 @@ response:WriteString("id: " .. id .. ", action: " .. action)
 			}),
 			script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123/edit", nil)
 		req = testutils.SetMuxVars(req, map[string]string{
@@ -357,7 +362,7 @@ response:WriteString("id: " .. id .. ", action: " .. action)
 	})
 
 	t.Run("CORS headers", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -367,6 +372,7 @@ response:WriteString("OK")
 			}),
 			script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 		req.Header.Set("Origin", hosts.Example.HTTP().String())
@@ -382,60 +388,80 @@ response:WriteString("OK")
 		assert.Equal(t, testconstants.AllMethods, recorder.Header().Get(headers.AccessControlAllowMethods))
 	})
 
-	t.Run("error handling", func(t *testing.T) {
+	// A missing file and a script that does not compile are configuration
+	// errors: they are reported once, when the handler is built, instead of on
+	// every request that reaches the route.
+	t.Run("configuration errors are reported at construction", func(t *testing.T) {
 		tests := []struct {
-			name         string
-			script       config.Script
-			expectedCode int
+			name     string
+			script   config.Script
+			expected error
 		}{
 			{
-				name: "script file not found",
-				script: config.Script{
-					File: "nonexistent.lua",
-				},
-				expectedCode: http.StatusInternalServerError,
+				name:     "script file not found",
+				script:   config.Script{File: "nonexistent.lua"},
+				expected: script.ErrScriptFileNotFound,
 			},
 			{
-				name: "lua syntax error",
-				script: config.Script{
-					Script: "this is not valid lua code ###",
-				},
-				expectedCode: http.StatusInternalServerError,
+				name:     "lua syntax error",
+				script:   config.Script{Script: "this is not valid lua code ###"},
+				expected: script.ErrScriptCompilationFailed,
 			},
 			{
-				name: "lua runtime error",
-				script: config.Script{
-					Script: `
-local x = nil
-response:WriteString(x.field)  -- This will cause an error
-`,
-				},
-				expectedCode: http.StatusInternalServerError,
+				name:     "nothing configured",
+				script:   config.Script{},
+				expected: script.ErrScriptNotConfigured,
 			},
 		}
 
 		for _, testCase := range tests {
 			t.Run(testCase.name, func(t *testing.T) {
-				handler := script.NewHandler(
+				_, err := script.NewHandler(
 					script.WithOutput(mocks.NoopOutput()),
 					script.WithScript(&testCase.script),
 					script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 				)
 
-				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
-				recorder := httptest.NewRecorder()
-
-				responseWriter := infra.NewResponseRecorder(recorder)
-
-				handlerErr := handler.Serve(responseWriter, req)
-
-				assert.Error(t, handlerErr)
+				require.ErrorIs(t, err, testCase.expected)
 			})
 		}
 	})
 
+	t.Run("a runtime error fails the request", func(t *testing.T) {
+		handler, err := script.NewHandler(
+			script.WithOutput(mocks.NoopOutput()),
+			script.WithScript(&config.Script{Script: "local x = nil\nresponse:WriteString(x.field)"}),
+			script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
+		)
+		require.NoError(t, err)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+		recorder := httptest.NewRecorder()
+
+		require.Error(t, handler.Serve(infra.NewResponseRecorder(recorder), req))
+	})
+
+	// A script that never returns used to pin a goroutine and an OS thread until
+	// the process was restarted.
+	t.Run("a runaway script is stopped by its timeout", func(t *testing.T) {
+		handler, err := script.NewHandler(
+			script.WithOutput(mocks.NoopOutput()),
+			script.WithScript(&config.Script{
+				Script:  "while true do end",
+				Timeout: 100 * time.Millisecond,
+			}),
+			script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
+		)
+		require.NoError(t, err)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+		recorder := httptest.NewRecorder()
+
+		require.ErrorIs(t, handler.Serve(infra.NewResponseRecorder(recorder), req), script.ErrScriptTimeout)
+	})
+
 	t.Run("default response status", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -445,6 +471,7 @@ response:WriteString("Default status")
 			}),
 			script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 		recorder := httptest.NewRecorder()
@@ -456,7 +483,7 @@ response:WriteString("Default status")
 	})
 
 	t.Run("empty response body", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -466,6 +493,7 @@ response:WriteHeader(204)
 			}),
 			script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 		recorder := httptest.NewRecorder()
@@ -477,7 +505,7 @@ response:WriteHeader(204)
 	})
 
 	t.Run("complex script with table library", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -490,6 +518,7 @@ response:WriteString(result)
 			}),
 			script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 		recorder := httptest.NewRecorder()
@@ -584,13 +613,14 @@ response:WriteString("old and new")
 
 		for _, testCase := range tests {
 			t.Run(testCase.name, func(t *testing.T) {
-				handler := script.NewHandler(
+				handler, err := script.NewHandler(
 					script.WithOutput(mocks.NoopOutput()),
 					script.WithScript(&config.Script{
 						Script: testCase.script,
 					}),
 					script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 				)
+				require.NoError(t, err)
 
 				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 				recorder := httptest.NewRecorder()
@@ -612,19 +642,28 @@ response:WriteString("old and new")
 
 func TestScriptHandlerOptions(t *testing.T) {
 	t.Run("WithOutput", func(t *testing.T) {
-		handler := script.NewHandler(script.WithOutput(mocks.NoopOutput()))
+		handler, err := script.NewHandler(
+			script.WithOutput(mocks.NoopOutput()),
+			script.WithScript(&config.Script{Script: "response:WriteHeader(200)"}),
+		)
+		require.NoError(t, err)
 		require.NotNil(t, handler)
 	})
 
 	t.Run("WithScript", func(t *testing.T) {
 		scriptConfig := &config.Script{Script: "response:WriteHeader(200)"}
-		handler := script.NewHandler(script.WithScript(scriptConfig))
+		handler, err := script.NewHandler(script.WithScript(scriptConfig))
+		require.NoError(t, err)
 		require.NotNil(t, handler)
 	})
 
 	t.Run("WithFileSystem", func(t *testing.T) {
 		fs := testutils.FsFromMap(t, map[string]string{})
-		handler := script.NewHandler(script.WithFileSystem(fs))
+		handler, err := script.NewHandler(
+			script.WithFileSystem(fs),
+			script.WithScript(&config.Script{Script: "response:WriteHeader(200)"}),
+		)
+		require.NoError(t, err)
 		require.NotNil(t, handler)
 	})
 
@@ -632,11 +671,12 @@ func TestScriptHandlerOptions(t *testing.T) {
 		scriptConfig := &config.Script{Script: "response:WriteHeader(200)"}
 		fs := testutils.FsFromMap(t, map[string]string{})
 
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(scriptConfig),
 			script.WithFileSystem(fs),
 		)
+		require.NoError(t, err)
 
 		require.NotNil(t, handler)
 
@@ -703,10 +743,11 @@ end
 
 		for _, testCase := range tests {
 			t.Run(testCase.name, func(t *testing.T) {
-				handler := script.NewHandler(
+				handler, err := script.NewHandler(
 					script.WithOutput(mocks.NoopOutput()),
 					script.WithScript(&config.Script{Script: testCase.script}),
 				)
+				require.NoError(t, err)
 
 				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 				parsedQuery := req.URL.Query()
@@ -781,10 +822,11 @@ end
 
 		for _, testCase := range tests {
 			t.Run(testCase.name, func(t *testing.T) {
-				handler := script.NewHandler(
+				handler, err := script.NewHandler(
 					script.WithOutput(mocks.NoopOutput()),
 					script.WithScript(&config.Script{Script: testCase.script}),
 				)
+				require.NoError(t, err)
 
 				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 
@@ -806,7 +848,7 @@ end
 
 func TestScriptHandler_ResponseMetatableEdgeCases(t *testing.T) {
 	t.Run("response metatable prevents status field writes", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -816,6 +858,7 @@ response:WriteString("Status not writable")
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -827,7 +870,7 @@ response:WriteString("Status not writable")
 	})
 
 	t.Run("response metatable prevents body field writes", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -837,6 +880,7 @@ response:WriteString("Actual body")
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -848,7 +892,7 @@ response:WriteString("Actual body")
 	})
 
 	t.Run("response metatable allows custom fields", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -858,6 +902,7 @@ response:WriteString("Custom: " .. response.custom_field)
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -869,7 +914,7 @@ response:WriteString("Custom: " .. response.custom_field)
 	})
 
 	t.Run("response WriteHeader idempotency", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -879,6 +924,7 @@ response:WriteString("First status wins")
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -890,7 +936,7 @@ response:WriteString("First status wins")
 	})
 
 	t.Run("response Write without explicit WriteHeader", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -898,6 +944,7 @@ response:Write("Auto status")
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -909,7 +956,7 @@ response:Write("Auto status")
 	})
 
 	t.Run("response WriteString without explicit WriteHeader", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -917,6 +964,7 @@ response:WriteString("Auto status with string")
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -928,7 +976,7 @@ response:WriteString("Auto status with string")
 	})
 
 	t.Run("response headers metatable Get method", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -939,6 +987,7 @@ response:WriteString("Value: " .. value)
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -950,7 +999,7 @@ response:WriteString("Value: " .. value)
 	})
 
 	t.Run("response headers metatable Set method", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -960,6 +1009,7 @@ response:WriteString("Header set")
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -971,7 +1021,7 @@ response:WriteString("Header set")
 	})
 
 	t.Run("response headers access via index", func(t *testing.T) {
-		handler := script.NewHandler(
+		handler, err := script.NewHandler(
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script: `
@@ -982,6 +1032,7 @@ response:WriteString("CT: " .. ct)
 `,
 			}),
 		)
+		require.NoError(t, err)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 		recorder := httptest.NewRecorder()

--- a/internal/handler/script/lua_state.go
+++ b/internal/handler/script/lua_state.go
@@ -1,22 +1,63 @@
 package script
 
 import (
+	"fmt"
+	"strings"
+
 	lua "github.com/yuin/gopher-lua"
+	"github.com/yuin/gopher-lua/parse"
 	luajson "layeh.com/gopher-json"
 )
 
+// newLuaState builds the VM a script runs in.
+//
+// The library set is stated here rather than inherited from lua.NewState's
+// defaults: a user needs to know what a config file someone else wrote is able
+// to do, and "whatever OpenLibs happens to include" is not an answer. base,
+// package (for require), string, table, math, os and json are open; io, debug,
+// coroutine and channel are not, so a script cannot read or write files.
 func newLuaState() *lua.LState {
-	luaState := lua.NewState()
-	loadStandardLibraries(luaState)
+	luaState := lua.NewState(lua.Options{SkipOpenLibs: true})
 
-	return luaState
-}
+	for _, library := range []struct {
+		name   string
+		loader lua.LGFunction
+	}{
+		{lua.BaseLibName, lua.OpenBase},
+		{lua.LoadLibName, lua.OpenPackage},
+		{lua.StringLibName, lua.OpenString},
+		{lua.TabLibName, lua.OpenTable},
+		{lua.MathLibName, lua.OpenMath},
+		{lua.OsLibName, lua.OpenOs},
+	} {
+		luaState.Push(luaState.NewFunction(library.loader))
+		luaState.Push(lua.LString(library.name))
+		luaState.Call(1, 0)
+	}
 
-func loadStandardLibraries(luaState *lua.LState) {
 	luaState.SetGlobal("_G", luaState.Get(lua.GlobalsIndex))
 	luaState.PreloadModule("math", lua.OpenMath)
 	luaState.PreloadModule("string", lua.OpenString)
 	luaState.PreloadModule("table", lua.OpenTable)
 	luaState.PreloadModule("os", lua.OpenOs)
 	luajson.Preload(luaState)
+
+	return luaState
+}
+
+// compileScript turns the script source into a reusable function prototype.
+// Compiling at construction means a syntax error is reported once, with a
+// location, instead of on every request that reaches the route.
+func compileScript(source, name string) (*lua.FunctionProto, error) {
+	chunk, err := parse.Parse(strings.NewReader(source), name)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrScriptCompilationFailed, err)
+	}
+
+	proto, err := lua.Compile(chunk, name)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrScriptCompilationFailed, err)
+	}
+
+	return proto, nil
 }


### PR DESCRIPTION
Fixes review finding **A19 — Lua scripts are re-parsed on every request, with no timeout and no cancellation**.

Every request that matched a script route built a fresh VM, re-read the file
from disk and re-compiled the source. A syntax error was therefore discovered
per request and rendered as a 500; a `while true do end` pinned a goroutine and
an OS thread until the process was restarted; and the library set was whatever
`OpenLibs` happened to include.

- Scripts are compiled at handler construction, so a syntax error or a missing
  file fails the configuration once, with a location, and the request path loses
  a disk read and a full compile.
- Every run is bounded: the VM gets the request's context plus a timeout
  (5s by default, `timeout:` per script), so a runaway script is stopped and a
  client that goes away cancels the run.
- The sandbox is stated rather than inherited: base, package, string, table,
  math, os and json are open; io, debug, coroutine and channel are not. The docs
  say so, including that `os` means a config with scripts is executable code.

---

### Review

One commit, `c0da625`. Step **19 of 33** in the review stack.

This PR targets **`feat/a18-listen-address`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
