### PR TITLE
docs+config: make the CLI surface self-describing and typo-proof (D01)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ UNCORS follows a clean layered architecture with middleware composition:
 
 **`internal/infra`** - Infrastructure services
 - HTTP client with connection pooling and proxy support
-- Logger setup (logs to stderr or file with debug flag)
+- Logger setup (`log/slog` to stderr or a file, level-controlled)
 - TLS certificate generation and handling
 
 **`internal/tui`** - Terminal UI and logging
@@ -177,7 +177,7 @@ Key test flags:
 4. Update CONTRIBUTING.md if user-facing
 
 ### Debugging
-- Enable debug logs: `./uncors -d` (writes to `uncors.log`)
+- Diagnostics go to stderr at `info` level; `--log-level debug`, `--log-file PATH` and `--quiet` control them (`--debug` is shorthand for `--log-level debug`)
 - Run single test: `go test -run TestName ./internal/handler/proxy/`
 - Race detector: Already enabled in `make test` and `make test-cover`
 - Integration tests: `make test-integration` (slower, real network)

--- a/internal/cli/docs_test.go
+++ b/internal/cli/docs_test.go
@@ -1,0 +1,60 @@
+package cli_test
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// documentedFlag matches a `| --name | -s | description |` row of the CLI table.
+var documentedFlag = regexp.MustCompile(`^\|\s*` + "`" + `(--[a-z-]+)` + "`")
+
+// The CLI reference in the docs is hand-written, which is how it came to
+// document a --debug flag that did not exist while omitting --interactive. This
+// pins the table to the actual flag set.
+func TestDocumentedFlagsMatchTheFlagSet(t *testing.T) {
+	const docPath = "../../docs/Configuration.md"
+
+	content, err := os.ReadFile(docPath)
+	require.NoError(t, err)
+
+	documented := map[string]bool{}
+
+	for line := range strings.SplitSeq(string(content), "\n") {
+		match := documentedFlag.FindStringSubmatch(strings.TrimSpace(line))
+		if match != nil {
+			documented[match[1]] = true
+		}
+	}
+
+	set := pflag.NewFlagSet("uncors", pflag.ContinueOnError)
+	config.DefineFlags(set)
+
+	// --version is defined by the command layer for every command.
+	actual := map[string]bool{"--version": true}
+
+	set.VisitAll(func(flag *pflag.Flag) {
+		actual["--"+flag.Name] = true
+	})
+
+	assert.Equal(t, sortedKeys(actual), sortedKeys(documented),
+		"docs/Configuration.md must document exactly the flags uncors accepts")
+}
+
+func sortedKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
@@ -63,7 +65,32 @@ func readYAMLFile(fs afero.Fs, cfg *UncorsConfig, path string) error {
 		return fmt.Errorf("failed to read config file '%s': While parsing config: %w", path, err)
 	}
 
+	warnAboutUnknownFields(fs, path)
+
 	return nil
+}
+
+// warnAboutUnknownFields reports keys the configuration does not have. A
+// misspelled or removed key is otherwise accepted in silence, and the user is
+// left believing they enabled something they did not — which is worse than an
+// error. It is a warning rather than a failure because upgrading configs are
+// likely to carry keys from older versions.
+func warnAboutUnknownFields(fs afero.Fs, path string) {
+	file, err := fs.Open(path)
+	if err != nil {
+		return
+	}
+
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	decoder.KnownFields(true)
+
+	err = decoder.Decode(&UncorsConfig{})
+	if err != nil && !errors.Is(err, io.EOF) {
+		slog.Warn("the configuration file contains unknown keys, which uncors ignores",
+			"path", path, "detail", err)
+	}
 }
 
 func applyFlagOverrides(cfg *UncorsConfig, flags *pflag.FlagSet) error {


### PR DESCRIPTION
Fixes review finding **D01 — The documented `--debug` flag and `debug:` config key do not exist, and `--interactive` is undocumented**.

The documented flag surface had drifted from the flag set — the durable problem
behind a `--debug` that did not exist and an `--interactive` that was never
documented. The logging and listen flags (A13, A18) and the discoverable
`--version` and subcommand help (A11) closed the content gap; this closes the
drift.

- A test pins docs/Configuration.md's CLI table to the actual flag set, so a new
  or renamed flag fails the build until it is documented.
- The YAML decoder now reports keys the configuration does not have. A
  misspelled or removed key (`cert-file`, `http-port` from older versions) used
  to be accepted in silence, leaving the user believing they had enabled
  something. It warns rather than fails, because upgrading configs are likely to
  carry them.
- CLAUDE.md describes the diagnostics that exist.

---

### Review

One commit, `6decdad`. Step **21 of 33** in the review stack.

This PR targets **`chore/a20-dead-code-guard`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
