### PR TITLE
fix(config): accept the durations the docs document, and test every example (D02)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -40,15 +40,19 @@ mappings:
 
 **Common configuration patterns:**
 
+Basic proxy with caching:
+
 ```yaml
-# Basic proxy with caching
 mappings:
   - from: http://api.local:3000
     to: https://api.example.com
     cache:
       - /api/**
+```
 
-# Proxy with static files (SPA)
+Proxy with static files (SPA):
+
+```yaml
 mappings:
   - from: http://app.local:3000
     to: https://api.example.com
@@ -56,8 +60,11 @@ mappings:
       - path: /
         dir: ./dist
         index: index.html
+```
 
-# Proxy with mocked endpoints
+Proxy with mocked endpoints:
+
+```yaml
 mappings:
   - from: http://api.local:3000
     to: https://api.example.com
@@ -110,7 +117,7 @@ example demonstrating all available options:
 ```yaml
 # Global configuration
 debug: false
-proxy: localhost:8080
+proxy: http://localhost:8080
 
 # Mappings configuration
 mappings:

--- a/docs/Real-World-Examples.md
+++ b/docs/Real-World-Examples.md
@@ -594,34 +594,34 @@ cd my-project
 
 ```yaml
 mappings:
-  - from: http://[YOUR-DOMAIN]:3000
-    to: https://[TARGET-API]
+  - from: http://your-domain.local:3000
+    to: https://target-api.example.com
 ```
 
 ### Proxy with Mocking
 
 ```yaml
 mappings:
-  - from: http://[YOUR-DOMAIN]:3000
-    to: https://[TARGET-API]
+  - from: http://your-domain.local:3000
+    to: https://target-api.example.com
     mocks:
-      - path: /api/[ENDPOINT]
+      - path: /api/your-endpoint
         response:
           code: 200
           headers:
             Content-Type: application/json
-          raw: "[JSON-RESPONSE]"
+          raw: '{"example": "response"}'
 ```
 
 ### SPA with API
 
 ```yaml
 mappings:
-  - from: http://[YOUR-DOMAIN]:3000
-    to: https://[TARGET-API]
+  - from: http://your-domain.local:3000
+    to: https://target-api.example.com
     statics:
       - path: /
-        dir: [PATH-TO-BUILD]
+        dir: ./dist
         index: index.html
 ```
 
@@ -633,21 +633,21 @@ cache-config:
   expiration-time: 10m
 
 mappings:
-  - from: http://[YOUR-DOMAIN]:3000
-    to: https://[TARGET-API]
+  - from: http://your-domain.local:3000
+    to: https://target-api.example.com
 
     statics:
       - path: /
-        dir: [BUILD-DIR]
+        dir: ./dist
         index: index.html
 
     mocks:
-      - path: /api/[ENDPOINT]
+      - path: /api/your-endpoint
         response:
           code: 200
           headers:
             Content-Type: application/json
-          file: ./mocks/[FILE].json
+          file: ./mocks/your-endpoint.json
 
     cache:
       - /api/**

--- a/internal/config/cache_config.go
+++ b/internal/config/cache_config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"time"
 )
 
 type CacheGlobs []string
@@ -14,9 +13,9 @@ func (g CacheGlobs) Clone() CacheGlobs {
 }
 
 type CacheConfig struct {
-	ExpirationTime time.Duration `yaml:"expiration-time"`
-	MaxSize        int64         `yaml:"max-size"`
-	Methods        []string      `yaml:"methods"`
+	ExpirationTime Duration `yaml:"expiration-time"`
+	MaxSize        int64    `yaml:"max-size"`
+	Methods        []string `yaml:"methods"`
 }
 
 func (c *CacheConfig) Clone() *CacheConfig {

--- a/internal/config/cache_config_test.go
+++ b/internal/config/cache_config_test.go
@@ -31,7 +31,7 @@ func TestCacheGlobsClone(t *testing.T) {
 
 func TestCacheConfigClone(t *testing.T) {
 	cacheConfig := &config.CacheConfig{
-		ExpirationTime: 5 * time.Minute,
+		ExpirationTime: config.Duration(5 * time.Minute),
 		MaxSize:        50 * 1024 * 1024,
 		Methods:        []string{http.MethodGet, http.MethodPost},
 	}
@@ -56,7 +56,7 @@ func TestCacheConfigValidator(t *testing.T) {
 
 	t.Run("should not register errors for", func(t *testing.T) {
 		err := (&config.CacheConfig{
-			ExpirationTime: 5 * time.Minute,
+			ExpirationTime: config.Duration(5 * time.Minute),
 			MaxSize:        100 * 1024 * 1024,
 			Methods:        []string{http.MethodGet, http.MethodPost},
 		}).Validate(field)
@@ -75,24 +75,32 @@ func TestCacheConfigValidator(t *testing.T) {
 				error: "test.expiration-time must be greater than 0",
 			},
 			{
-				name:  "zero max size",
-				value: config.CacheConfig{ExpirationTime: 5 * time.Minute, MaxSize: 0, Methods: []string{http.MethodGet}},
+				name: "zero max size",
+				value: config.CacheConfig{
+					ExpirationTime: config.Duration(5 * time.Minute),
+					MaxSize:        0,
+					Methods:        []string{http.MethodGet},
+				},
 				error: "test.max-size must be greater than 0",
 			},
 			{
-				name:  "negative max size",
-				value: config.CacheConfig{ExpirationTime: 5 * time.Minute, MaxSize: -1, Methods: []string{http.MethodGet}},
+				name: "negative max size",
+				value: config.CacheConfig{
+					ExpirationTime: config.Duration(5 * time.Minute),
+					MaxSize:        -1,
+					Methods:        []string{http.MethodGet},
+				},
 				error: "test.max-size must be greater than 0",
 			},
 			{
 				name:  "empty methods",
-				value: config.CacheConfig{ExpirationTime: 5 * time.Minute, MaxSize: 100 * 1024 * 1024},
+				value: config.CacheConfig{ExpirationTime: config.Duration(5 * time.Minute), MaxSize: 100 * 1024 * 1024},
 				error: "methods must not be empty",
 			},
 			{
 				name: "invalid method",
 				value: config.CacheConfig{
-					ExpirationTime: 5 * time.Minute,
+					ExpirationTime: config.Duration(5 * time.Minute),
 					MaxSize:        100 * 1024 * 1024,
 					Methods:        []string{"invalid"},
 				},
@@ -101,7 +109,7 @@ func TestCacheConfigValidator(t *testing.T) {
 			{
 				name: "invalid second method",
 				value: config.CacheConfig{
-					ExpirationTime: 5 * time.Minute,
+					ExpirationTime: config.Duration(5 * time.Minute),
 					MaxSize:        100 * 1024 * 1024,
 					Methods:        []string{http.MethodGet, "invalid", http.MethodPost},
 				},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -155,7 +155,7 @@ func TestLoadConfiguration(t *testing.T) {
 					Proxy: hosts.Localhost.HTTPPort(8080).String(),
 					Debug: true,
 					CacheConfig: config.CacheConfig{
-						ExpirationTime: time.Hour,
+						ExpirationTime: config.Duration(time.Hour),
 						MaxSize:        52428800,
 						Methods: []string{
 							http.MethodGet,
@@ -238,7 +238,7 @@ func TestLoadConfiguration(t *testing.T) {
 					Proxy: "http://newproxy:9999",
 					Debug: false,
 					CacheConfig: config.CacheConfig{
-						ExpirationTime: time.Hour, MaxSize: 52428800,
+						ExpirationTime: config.Duration(time.Hour), MaxSize: 52428800,
 						Methods: []string{http.MethodGet, http.MethodPost},
 					},
 					Listen:      config.DefaultListenAddress,
@@ -383,7 +383,7 @@ func TestUncorsConfigValidator(t *testing.T) {
 					},
 					CacheConfig: config.CacheConfig{
 						MaxSize:        100 * 1024 * 1024,
-						ExpirationTime: 10 * time.Minute,
+						ExpirationTime: config.Duration(10 * time.Minute),
 						Methods:        []string{http.MethodGet},
 					},
 				},
@@ -410,7 +410,7 @@ func TestUncorsConfigValidator(t *testing.T) {
 					Mappings: []config.Mapping{},
 					CacheConfig: config.CacheConfig{
 						MaxSize:        100 * 1024 * 1024,
-						ExpirationTime: 10 * time.Minute,
+						ExpirationTime: config.Duration(10 * time.Minute),
 						Methods:        []string{http.MethodGet},
 					},
 				},

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -10,7 +10,7 @@ const (
 	defaultHTTPSPort = 443
 	// DefaultListenAddress keeps the proxy reachable only from this machine.
 	DefaultListenAddress  = "127.0.0.1"
-	DefaultExpirationTime = 30 * time.Minute
+	DefaultExpirationTime = Duration(30 * time.Minute)
 	DefaultMaxSize        = 100 * 1024 * 1024 // 100 MB
 )
 

--- a/internal/config/duration.go
+++ b/internal/config/duration.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Duration is a configuration duration.
+//
+// It exists so that the format uncors documents is the format uncors accepts:
+// the documented `1m 30s` and `2s 500ms` spellings are what a reader copies, and
+// time.ParseDuration rejects the space. Owning the type also lets a bad value
+// say what a good one looks like.
+//
+//nolint:recvcheck // UnmarshalYAML has to take a pointer; the rest reads better as a value
+type Duration time.Duration
+
+func (d Duration) String() string {
+	return time.Duration(d).String()
+}
+
+func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
+	var raw string
+
+	err := value.Decode(&raw)
+	if err != nil {
+		return fmt.Errorf("invalid duration: %w", err)
+	}
+
+	parsed, err := ParseDuration(raw)
+	if err != nil {
+		return err
+	}
+
+	*d = parsed
+
+	return nil
+}
+
+func (d Duration) MarshalYAML() (any, error) {
+	return d.String(), nil
+}
+
+// ParseDuration reads a duration, tolerating the spaces between components that
+// the documentation uses: "1m 30s" means the same as "1m30s".
+func ParseDuration(raw string) (Duration, error) {
+	compact := strings.Join(strings.Fields(raw), "")
+
+	parsed, err := time.ParseDuration(compact)
+	if err != nil {
+		return 0, &ValidationError{
+			fmt.Sprintf("%q is not a valid duration (expected for example 500ms, 30s, 1m30s or 1h 30m)", raw),
+		}
+	}
+
+	return Duration(parsed), nil
+}

--- a/internal/config/duration_test.go
+++ b/internal/config/duration_test.go
@@ -15,12 +15,19 @@ func TestCacheConfigDurationUnmarshal(t *testing.T) {
 		tests := []struct {
 			name     string
 			input    string
-			expected time.Duration
+			expected config.Duration
 		}{
 			{
 				name:     "duration without spaces",
 				input:    "expiration-time: 3h6m13s",
-				expected: 3*time.Hour + 6*time.Minute + 13*time.Second,
+				expected: config.Duration(3*time.Hour + 6*time.Minute + 13*time.Second),
+			},
+			// The documentation writes multi-unit durations with spaces, so the
+			// spelling a reader copies has to be the spelling uncors accepts.
+			{
+				name:     "duration with spaces",
+				input:    "expiration-time: 1h 30m",
+				expected: config.Duration(time.Hour + 30*time.Minute),
 			},
 		}
 
@@ -50,7 +57,8 @@ func TestCacheConfigDurationUnmarshal(t *testing.T) {
 
 		err := yaml.Unmarshal([]byte("expiration-time: notaduration"), &cfg)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot unmarshal !!str `notadur...` into time.Duration")
+		assert.Contains(t, err.Error(), "is not a valid duration")
+		assert.Contains(t, err.Error(), "1m30s", "the error should show what a valid value looks like")
 	})
 
 	t.Run("returns error when max-size is not a number", func(t *testing.T) {
@@ -73,17 +81,27 @@ func TestResponseDelayUnmarshal(t *testing.T) {
 		tests := []struct {
 			name     string
 			input    string
-			expected time.Duration
+			expected config.Duration
 		}{
 			{
 				name:     "millisecond delay",
 				input:    "delay: 200ms",
-				expected: 200 * time.Millisecond,
+				expected: config.Duration(200 * time.Millisecond),
 			},
 			{
-				name:     "a houd with 500 milliseconds",
+				name:     "an hour with 500 milliseconds",
 				input:    "delay: \"1h500ms\"",
-				expected: 1*time.Hour + 500*time.Millisecond,
+				expected: config.Duration(time.Hour + 500*time.Millisecond),
+			},
+			{
+				name:     "the documented spaced spellings",
+				input:    "delay: 1m 30s",
+				expected: config.Duration(time.Minute + 30*time.Second),
+			},
+			{
+				name:     "milliseconds with a space",
+				input:    "delay: 2s 500ms",
+				expected: config.Duration(2*time.Second + 500*time.Millisecond),
 			},
 		}
 
@@ -101,7 +119,7 @@ func TestResponseDelayUnmarshal(t *testing.T) {
 
 		err := yaml.Unmarshal([]byte("delay: notaduration"), &resp)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot unmarshal !!str `notadur...` into time.Duration")
+		assert.Contains(t, err.Error(), "is not a valid duration")
 	})
 
 	t.Run("zero delay when field absent", func(t *testing.T) {

--- a/internal/config/mock_test.go
+++ b/internal/config/mock_test.go
@@ -76,7 +76,7 @@ func TestMockValidator(t *testing.T) {
 			Response: config.Response{
 				Code:  200,
 				Raw:   "test",
-				Delay: 1 * time.Second,
+				Delay: config.Duration(1 * time.Second),
 			},
 		}).Validate("mock", afero.NewMemMapFs())
 

--- a/internal/config/response.go
+++ b/internal/config/response.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/evg4b/uncors/internal/helpers"
 	"github.com/spf13/afero"
@@ -12,7 +11,7 @@ import (
 type Response struct {
 	Code    int               `yaml:"code"`
 	Headers map[string]string `yaml:"headers"`
-	Delay   time.Duration     `yaml:"delay"`
+	Delay   Duration          `yaml:"delay"`
 	Raw     string            `yaml:"raw"`
 	File    string            `yaml:"file"`
 }

--- a/internal/config/response_test.go
+++ b/internal/config/response_test.go
@@ -34,7 +34,7 @@ file: ./body.json
 				"Content-Type": "application/json",
 				"X-Custom":     "value",
 			},
-			Delay: 200 * time.Millisecond,
+			Delay: config.Duration(200 * time.Millisecond),
 			Raw:   `{"ok":true}`,
 			File:  "./body.json",
 		}, actual)
@@ -50,12 +50,12 @@ file: ./body.json
 	})
 
 	t.Run("parses delay with embedded spaces", func(t *testing.T) {
-		const input = `delay: "1s500ms"`
+		const input = `delay: "1s 500ms"`
 
 		var actual config.Response
 
 		require.NoError(t, yaml.Unmarshal([]byte(input), &actual))
-		assert.Equal(t, 1500*time.Millisecond, actual.Delay)
+		assert.Equal(t, config.Duration(1500*time.Millisecond), actual.Delay)
 	})
 
 	t.Run("returns error for invalid delay", func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestResponseClone(t *testing.T) {
 		},
 		Raw:   "this is plain text",
 		File:  "~/projects/uncors/response/demo.json",
-		Delay: time.Hour,
+		Delay: config.Duration(time.Hour),
 	}
 
 	clonedResponse := response.Clone()
@@ -136,8 +136,11 @@ func TestResponseValidator(t *testing.T) {
 			name  string
 			value config.Response
 		}{
-			{name: "with file", value: config.Response{Code: 200, File: file, Delay: 3 * time.Second}},
-			{name: "with raw", value: config.Response{Code: 200, Raw: `{ "test": "test" }`, Delay: 3 * time.Second}},
+			{name: "with file", value: config.Response{Code: 200, File: file, Delay: config.Duration(3 * time.Second)}},
+			{
+				name:  "with raw",
+				value: config.Response{Code: 200, Raw: `{ "test": "test" }`, Delay: config.Duration(3 * time.Second)},
+			},
 			{name: "without delay", value: config.Response{Code: 200, Raw: `{ "test": "test" }`}},
 		}
 		for _, test := range tests {
@@ -155,27 +158,27 @@ func TestResponseValidator(t *testing.T) {
 		}{
 			{
 				name:  "code",
-				value: config.Response{Code: 0, File: file, Delay: 3 * time.Second},
+				value: config.Response{Code: 0, File: file, Delay: config.Duration(3 * time.Second)},
 				error: "test.code code must be in range 100-599",
 			},
 			{
 				name:  "file",
-				value: config.Response{Code: 200, File: "testdata/unknown.txt", Delay: 3 * time.Second},
+				value: config.Response{Code: 200, File: "testdata/unknown.txt", Delay: config.Duration(3 * time.Second)},
 				error: "test.file testdata/unknown.txt does not exist",
 			},
 			{
 				name:  "delay",
-				value: config.Response{Code: 200, File: file, Delay: -1 * time.Second},
+				value: config.Response{Code: 200, File: file, Delay: config.Duration(-1 * time.Second)},
 				error: "test.delay must be greater than or equal to 0",
 			},
 			{
 				name:  "both empty",
-				value: config.Response{Code: 200, Delay: 3 * time.Second},
+				value: config.Response{Code: 200, Delay: config.Duration(3 * time.Second)},
 				error: "test.raw or test.file must be set",
 			},
 			{
 				name:  "both set",
-				value: config.Response{Code: 200, File: file, Raw: "test", Delay: 3 * time.Second},
+				value: config.Response{Code: 200, File: file, Raw: "test", Delay: config.Duration(3 * time.Second)},
 				error: "only one of test.raw or test.file must be set",
 			},
 		}

--- a/internal/config/script.go
+++ b/internal/config/script.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/samber/lo"
 	"github.com/spf13/afero"
@@ -14,7 +13,7 @@ type Script struct {
 	Script  string         `yaml:"script"`
 	File    string         `yaml:"file"`
 	// Timeout bounds how long the script may run. Zero means the default.
-	Timeout time.Duration `yaml:"timeout"`
+	Timeout Duration `yaml:"timeout"`
 }
 
 func (s *Script) Clone() Script {

--- a/internal/config/validate_primitives.go
+++ b/internal/config/validate_primitives.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/evg4b/uncors/internal/urlpattern"
@@ -112,7 +111,7 @@ func ValidateStatus(field string, value int) error {
 	return nil
 }
 
-func ValidateDuration(field string, value time.Duration, allowZero bool) error {
+func ValidateDuration(field string, value Duration, allowZero bool) error {
 	if allowZero {
 		if value < 0 {
 			return &ValidationError{fmt.Sprintf("%s must be greater than or equal to 0", field)}

--- a/internal/config/validate_primitives_test.go
+++ b/internal/config/validate_primitives_test.go
@@ -140,18 +140,18 @@ func TestValidateDuration(t *testing.T) {
 	const field = "test-field"
 
 	runOK(t, "positive without allowZero", func() error {
-		return config.ValidateDuration(field, time.Second, false)
+		return config.ValidateDuration(field, config.Duration(time.Second), false)
 	})
 	runOK(t, "zero with allowZero", func() error {
 		return config.ValidateDuration(field, 0, true)
 	})
 
 	runErr(t, "negative without allowZero", "test-field must be greater than 0",
-		func() error { return config.ValidateDuration(field, -time.Second, false) })
+		func() error { return config.ValidateDuration(field, config.Duration(-time.Second), false) })
 	runErr(t, "zero without allowZero", "test-field must be greater than 0",
 		func() error { return config.ValidateDuration(field, 0, false) })
 	runErr(t, "negative with allowZero", "test-field must be greater than or equal to 0",
-		func() error { return config.ValidateDuration(field, -time.Second, true) })
+		func() error { return config.ValidateDuration(field, config.Duration(-time.Second), true) })
 }
 
 // ---- ValidateMethod ------------------------------------------------------

--- a/internal/di/runtime.go
+++ b/internal/di/runtime.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/contracts"
@@ -82,7 +83,8 @@ func (r *Runtime) Close() error {
 // cache-config.
 func (r *Runtime) Cache() contracts.Cache {
 	if r.cacheStore == nil {
-		r.cacheStore = register(r, cache.NewRistrettoCache(r.cacheConfig.MaxSize, r.cacheConfig.ExpirationTime))
+		ttl := time.Duration(r.cacheConfig.ExpirationTime)
+		r.cacheStore = register(r, cache.NewRistrettoCache(r.cacheConfig.MaxSize, ttl))
 	}
 
 	return r.cacheStore

--- a/internal/di/runtime_test.go
+++ b/internal/di/runtime_test.go
@@ -16,7 +16,7 @@ import (
 
 func harConfiguration() *config.UncorsConfig {
 	return &config.UncorsConfig{
-		CacheConfig: config.CacheConfig{MaxSize: 100, ExpirationTime: time.Minute},
+		CacheConfig: config.CacheConfig{MaxSize: 100, ExpirationTime: config.Duration(time.Minute)},
 		Mappings: config.Mappings{
 			{
 				From:  hosts.Localhost.HTTP(),

--- a/internal/handler/mock/handler.go
+++ b/internal/handler/mock/handler.go
@@ -120,7 +120,7 @@ func (h *Handler) waitDelay(writer http.ResponseWriter, request *http.Request) b
 		writer.WriteHeader(http.StatusServiceUnavailable)
 
 		return true
-	case <-h.after(h.response.Delay):
+	case <-h.after(time.Duration(h.response.Delay)):
 		return false
 	}
 }

--- a/internal/handler/mock/handler_test.go
+++ b/internal/handler/mock/handler_test.go
@@ -348,7 +348,7 @@ func TestHandler(t *testing.T) {
 					name: "3s delay",
 					response: config.Response{
 						Code:  http.StatusCreated,
-						Delay: 3 * time.Second,
+						Delay: config.Duration(3 * time.Second),
 						Raw:   "Ok",
 					},
 					shouldBeCalled: true,
@@ -358,7 +358,7 @@ func TestHandler(t *testing.T) {
 					name: "15h delay",
 					response: config.Response{
 						Code:  http.StatusCreated,
-						Delay: 15 * time.Hour,
+						Delay: config.Duration(15 * time.Hour),
 						Raw:   "Ok",
 					},
 					shouldBeCalled: true,
@@ -368,7 +368,7 @@ func TestHandler(t *testing.T) {
 					name: "0s delay",
 					response: config.Response{
 						Code:  http.StatusCreated,
-						Delay: 0 * time.Second,
+						Delay: config.Duration(0 * time.Second),
 						Raw:   "Ok",
 					},
 					shouldBeCalled: false,
@@ -385,7 +385,7 @@ func TestHandler(t *testing.T) {
 					name: "incorrect delay",
 					response: config.Response{
 						Code:  http.StatusCreated,
-						Delay: -13 * time.Minute,
+						Delay: config.Duration(-13 * time.Minute),
 						Raw:   "Ok",
 					},
 					shouldBeCalled: false,
@@ -420,7 +420,7 @@ func TestHandler(t *testing.T) {
 			handler := mock.NewMockHandler(
 				mock.WithResponse(&config.Response{
 					Code:  http.StatusOK,
-					Delay: 1 * time.Hour,
+					Delay: config.Duration(1 * time.Hour),
 					Raw:   "Text content",
 				}),
 				mock.WithFileSystem(fileSystem),

--- a/internal/handler/script/handler.go
+++ b/internal/handler/script/handler.go
@@ -46,7 +46,7 @@ func NewHandler(options ...HandlerOption) (*Handler, error) {
 		return nil, err
 	}
 
-	handler.timeout = handler.script.Timeout
+	handler.timeout = time.Duration(handler.script.Timeout)
 	if handler.timeout <= 0 {
 		handler.timeout = defaultTimeout
 	}

--- a/internal/handler/script/handler_test.go
+++ b/internal/handler/script/handler_test.go
@@ -448,7 +448,7 @@ response:WriteString("OK")
 			script.WithOutput(mocks.NoopOutput()),
 			script.WithScript(&config.Script{
 				Script:  "while true do end",
-				Timeout: 100 * time.Millisecond,
+				Timeout: config.Duration(100 * time.Millisecond),
 			}),
 			script.WithFileSystem(testutils.FsFromMap(t, map[string]string{})),
 		)

--- a/internal/uncors/app_test.go
+++ b/internal/uncors/app_test.go
@@ -517,7 +517,7 @@ func TestUncorsWithComplexConfiguration(t *testing.T) {
 		},
 		CacheConfig: config.CacheConfig{
 			Methods:        []string{"GET"},
-			ExpirationTime: 1 * time.Minute,
+			ExpirationTime: config.Duration(1 * time.Minute),
 			MaxSize:        100 * 1024 * 1024,
 		},
 	})

--- a/internal/uncors/handler_test.go
+++ b/internal/uncors/handler_test.go
@@ -360,7 +360,7 @@ func TestHandlerWithCache(t *testing.T) {
 		},
 		CacheConfig: config.CacheConfig{
 			Methods:        []string{http.MethodGet},
-			ExpirationTime: time.Minute,
+			ExpirationTime: config.Duration(time.Minute),
 			MaxSize:        100 * 1024 * 1024,
 		},
 	}

--- a/tests/docs/docs_test.go
+++ b/tests/docs/docs_test.go
@@ -1,0 +1,121 @@
+// Package docs_test parses every configuration example in the documentation, so
+// that a documented config which cannot be loaded fails the build.
+//
+// This is the check that would have caught a documented duration spelling that
+// did not parse and a documented flag that did not exist.
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// yamlBlock matches a fenced ```yaml block.
+var yamlBlock = regexp.MustCompile("(?s)```yaml\n(.*?)```")
+
+// configLike recognises the blocks that are meant to be loadable uncors
+// configuration. Skipped are unrelated YAML (a CI workflow), skeletons that use
+// "..." as a placeholder for omitted content, and the Migration Guide, whose
+// examples deliberately show formats that no longer parse.
+func configLike(path, block string) bool {
+	if filepath.Base(path) == "Migration-Guide.md" {
+		return false
+	}
+
+	if strings.Contains(block, "...") {
+		return false
+	}
+
+	// A block without mappings is a fragment illustrating one section, not a
+	// configuration a user could run.
+	return strings.Contains(block, "mappings:")
+}
+
+func TestDocumentedConfigurationsLoad(t *testing.T) {
+	files, err := filepath.Glob("../../docs/*.md")
+	require.NoError(t, err)
+
+	files = append(files, "../../README.md")
+
+	for _, path := range files {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			content, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			for index, match := range yamlBlock.FindAllStringSubmatch(string(content), -1) {
+				block := match[1]
+				if !configLike(path, block) {
+					continue
+				}
+
+				t.Run("example "+strconv.Itoa(index), func(t *testing.T) {
+					loadExample(t, block)
+				})
+			}
+		})
+	}
+}
+
+// loadExample runs one documented example through the real loader. Examples
+// refer to files and directories that do not exist on this machine, so they are
+// loaded against a filesystem that reports every path as present.
+func loadExample(t *testing.T, block string) {
+	t.Helper()
+
+	fs := everythingExistsFs{Fs: afero.NewMemMapFs()}
+
+	require.NoError(t, afero.WriteFile(fs, "/docs-example.yaml", []byte(block), 0o600))
+
+	flags, err := config.ParseFlags([]string{"--config", "/docs-example.yaml"})
+	require.NoError(t, err)
+
+	_, err = config.LoadConfiguration(fs, flags)
+	require.NoError(t, err, "this configuration is documented but does not load:\n%s", block)
+}
+
+// everythingExistsFs reports any path as an existing file, so that examples
+// referring to ./dist or ~/mocks validate on a machine that has neither.
+type everythingExistsFs struct {
+	afero.Fs
+}
+
+func (fs everythingExistsFs) Stat(name string) (os.FileInfo, error) {
+	info, err := fs.Fs.Stat(name)
+	if err == nil {
+		return info, nil
+	}
+
+	return stubFileInfo{name: filepath.Base(name)}, nil
+}
+
+func (fs everythingExistsFs) Open(name string) (afero.File, error) {
+	file, err := fs.Fs.Open(name)
+	if err == nil {
+		return file, nil
+	}
+
+	return fs.Create(name)
+}
+
+type stubFileInfo struct {
+	os.FileInfo
+
+	name string
+}
+
+func (i stubFileInfo) Name() string { return i.name }
+func (i stubFileInfo) Size() int64  { return 0 }
+
+// IsDir guesses from the name: documented static roots are "./dist", documented
+// mock bodies are "./body.json".
+func (i stubFileInfo) IsDir() bool {
+	return !strings.Contains(i.name, ".")
+}

--- a/tests/integration/cache/cache_test.go
+++ b/tests/integration/cache/cache_test.go
@@ -21,7 +21,7 @@ func TestCacheMiddleware(t *testing.T) {
 		CacheConfig: config.CacheConfig{
 			Methods:        []string{http.MethodGet},
 			MaxSize:        10 * 1024 * 1024,
-			ExpirationTime: 5 * time.Minute,
+			ExpirationTime: config.Duration(5 * time.Minute),
 		},
 		Mappings: config.Mappings{{
 			From:  hosts.Parse("https://cache.local"),


### PR DESCRIPTION
Fixes review finding **D02 — Every documented multi-unit duration (`1m 30s`, `1h 30m`, `2s 500ms`) fails to parse**.

`delay: 1m 30s` and `expiration-time: 1h 30m` are the canonical spellings in the
reference pages, and `time.ParseDuration` rejects the space — so a config copied
from the documentation aborted startup with `cannot unmarshal !!str '1m 30s'`.

- `config.Duration` owns the format: it accepts the spaced spelling the docs use,
  and a bad value now says what a good one looks like instead of naming a Go
  type.
- A new test loads every configuration example in docs/ and README.md through the
  real loader. It is the check that would have caught this, the `--debug` drift
  (D01) and the broken examples in D04/D10 automatically.
- It found real defects, now fixed: a "quick reference" block that concatenated
  three configs into invalid YAML, `proxy: localhost:8080` (no scheme), and
  `[PLACEHOLDER]` values that YAML reads as sequences.

---

### Review

One commit, `041ae3b`. Step **22 of 33** in the review stack.

This PR targets **`docs/d01-cli-surface`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
