### PR TITLE
fix(config): resolve ~ and relative paths in the configuration (D03)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -160,6 +160,22 @@ mappings:
 | `mappings`     | array   | `[]`    | List of host mapping configurations (see below)                           |
 | `cache-config` | object  | -       | Global cache behavior settings (see [Response Caching](Response-Caching)) |
 
+### File Paths
+
+Every path in the configuration — `statics.dir`, `mocks.response.file`,
+`scripts.file`, `har` — follows the same three rules:
+
+| Path              | Resolves to                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `/srv/app/dist`   | itself; absolute paths are used as they are                |
+| `~/projects/dist` | your home directory                                        |
+| `./dist`          | the directory **containing the config file**               |
+
+Resolving relative paths against the config file rather than the working
+directory is what makes a config file portable: `uncors -c ~/projects/app/.uncors.yaml`
+works the same from anywhere. Without a config file (plain `--from`/`--to`), the
+working directory is used instead.
+
 ### Listen Address
 
 By default uncors is reachable only from the machine it runs on. It disables CORS

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ func LoadConfiguration(fs afero.Fs, flags *Flags) (*UncorsConfig, error) {
 	}
 
 	cfg.Mappings = NormaliseMappings(cfg.Mappings)
+	resolvePaths(cfg, configPath)
 
 	err = cfg.Validate(fs)
 	if err != nil {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolvePaths makes every path in the configuration absolute, once, so that
+// handlers, validators and the HAR writer all see the same file.
+//
+// Three rules, and they are the ones tools like ESLint, Prettier and Docker
+// Compose converge on:
+//
+//   - an absolute path is used as it is;
+//   - "~" expands to the user's home directory, because home-relative paths in a
+//     config file are a normal expectation and the shell cannot expand these
+//     ones — they are inside the YAML, not on the command line;
+//   - a relative path resolves against the directory holding the config file, so
+//     that a config file is portable and does not depend on where uncors was
+//     started. Without a config file, the working directory is the base.
+func resolvePaths(cfg *UncorsConfig, configPath string) {
+	base := "."
+	if configPath != "" {
+		base = filepath.Dir(configPath)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+
+	resolve := func(path string) string {
+		return resolvePath(path, base, home)
+	}
+
+	for index := range cfg.Mappings {
+		mapping := &cfg.Mappings[index]
+
+		mapping.HAR.File = resolve(mapping.HAR.File)
+
+		for static := range len(mapping.Statics) {
+			mapping.Statics[static].Dir = resolve(mapping.Statics[static].Dir)
+		}
+
+		for mock := range len(mapping.Mocks) {
+			mapping.Mocks[mock].Response.File = resolve(mapping.Mocks[mock].Response.File)
+		}
+
+		for script := range len(mapping.Scripts) {
+			mapping.Scripts[script].File = resolve(mapping.Scripts[script].File)
+		}
+	}
+}
+
+func resolvePath(path, base, home string) string {
+	switch {
+	case path == "":
+		return path
+	case path == "~", strings.HasPrefix(path, "~/"):
+		if home == "" {
+			return path
+		}
+
+		return filepath.Join(home, strings.TrimPrefix(path, "~"))
+	case filepath.IsAbs(path):
+		return path
+	default:
+		return filepath.Join(base, path)
+	}
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,66 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The documentation uses `~/...` for every path-taking field. The shell expands
+// `~` on the command line, but not inside the YAML file, which is exactly where
+// the docs use it most.
+func TestConfigurationPathsAreResolved(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	const configContent = `
+mappings:
+  - from: http://localhost:3000
+    to: https://api.example.com
+    har: ./recordings/api.har
+    statics:
+      - path: /
+        dir: ~/projects/app/dist
+        index: index.html
+    mocks:
+      - path: /api/users
+        response:
+          code: 200
+          file: ./mocks/users.json
+    scripts:
+      - path: /api/script
+        file: /absolute/script.lua
+`
+
+	fs := afero.NewMemMapFs()
+
+	configDir := filepath.Join("/workspace", "project")
+	configPath := filepath.Join(configDir, ".uncors.yaml")
+
+	require.NoError(t, afero.WriteFile(fs, configPath, []byte(configContent), 0o600))
+	require.NoError(t, fs.MkdirAll(filepath.Join(home, "projects/app/dist"), 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(home, "projects/app/dist/index.html"), []byte(""), 0o600))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(configDir, "mocks/users.json"), []byte("{}"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, "/absolute/script.lua", []byte(""), 0o600))
+
+	flags, err := config.ParseFlags([]string{"--config", configPath})
+	require.NoError(t, err)
+
+	cfg, err := config.LoadConfiguration(fs, flags)
+	require.NoError(t, err)
+
+	mapping := cfg.Mappings[0]
+
+	assert.Equal(t, filepath.Join(home, "projects/app/dist"), mapping.Statics[0].Dir,
+		"~ expands to the home directory")
+	assert.Equal(t, filepath.Join(configDir, "mocks/users.json"), mapping.Mocks[0].Response.File,
+		"a relative path resolves against the config file, not the working directory")
+	assert.Equal(t, filepath.Join(configDir, "recordings/api.har"), mapping.HAR.File)
+	assert.Equal(t, "/absolute/script.lua", mapping.Scripts[0].File,
+		"an absolute path is used as it is")
+}


### PR DESCRIPTION
Fixes review finding **D03 — Documentation uses `~/…` paths throughout, but `~` is never expanded**.

Every path-taking field in the documentation uses `~/...`, and nothing expanded
it. The shell hides this on the command line — `uncors -c ~/cfg.yaml` works
because the shell expands it — but paths inside the YAML are exactly where the
docs use it most, and those failed with "directory ~/project/dist does not
exist", which reads like a typo rather than "this tool does not understand ~".

Relative paths had a second, undocumented ambiguity: they resolved against the
process working directory, so the same config file behaved differently depending
on where uncors was started.

- Paths are resolved once, at load: absolute as-is, `~` to the home directory,
  and relative against the directory holding the config file — which is what
  makes a config file portable, and what ESLint, Prettier and Docker Compose do.
- docs/Configuration.md states the three rules.

---

### Review

One commit, `321586a`. Step **23 of 33** in the review stack.

This PR targets **`fix/d02-durations-and-docs-test`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
