### PR TITLE
docs+config: make the SPA-with-mocks setup work as documented (D04)

### DIFF
--- a/docs/Static-File-Serving.md
+++ b/docs/Static-File-Serving.md
@@ -70,14 +70,17 @@ mappings:
 
 ## Proxy Mode
 
-Proxy mode serves local files when they exist, but forwards unmatched requests
-to the upstream server or mock handlers.
+Proxy mode serves local files when they exist and forwards everything else
+upstream.
 
 **How it works:**
 
- 1. Requests matching the `path` prefix are checked against local files
- 2. If a file exists locally, it is served from `dir`
- 3. If no file exists, the request passes to the next handler (mock or upstream)
+ 1. Mocks, scripts and rewrites are matched first — a static mount never hides
+    them, whatever path it is mounted on (see
+    [Route Precedence](Configuration#route-precedence))
+ 2. Requests matching the `path` prefix are then checked against local files
+ 3. If a file exists locally, it is served from `dir`
+ 4. If no file exists, the request is forwarded to `to:`
 
 **Configuration:**
 
@@ -133,6 +136,8 @@ mappings:
 
 In this configuration:
 
- - SPA files are served from the root path `/`
- - The `/api/health` endpoint is mocked
- - All other `/api/*` requests are proxied to `https://api.example.com`
+ - `/api/health` is answered by the mock — mocks are matched before static
+   mounts, so mounting the SPA at `/` does not hide them
+ - Every other `/api/*` request is proxied to `https://api.example.com`
+ - Everything else is served from the SPA build, falling back to `index.html` so
+   that client-side routes work on a full page load

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,8 @@ func LoadConfiguration(fs afero.Fs, flags *Flags) (*UncorsConfig, error) {
 		return nil, err
 	}
 
+	warnAboutShadowedRoutes(cfg)
+
 	return cfg, nil
 }
 

--- a/internal/config/shadowing.go
+++ b/internal/config/shadowing.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// warnAboutShadowedRoutes reports routes that can never be reached.
+//
+// Route precedence puts mocks, scripts and rewrites ahead of static mounts, so a
+// static mount can no longer hide them. What it can still hide is another static
+// mount underneath it: the first prefix that matches wins, so `/` mounted before
+// `/assets` claims everything.
+func warnAboutShadowedRoutes(cfg *UncorsConfig) {
+	for _, mapping := range cfg.Mappings {
+		for index, static := range mapping.Statics {
+			for _, later := range mapping.Statics[index+1:] {
+				if shadows(static.Path, later.Path) {
+					slog.Warn("a static mount is unreachable: an earlier mount already covers it",
+						"host", mapping.From.String(),
+						"unreachable", later.Path,
+						"covered_by", static.Path)
+				}
+			}
+		}
+	}
+}
+
+// shadows reports whether a mount at prefix claims every path a mount at other
+// would serve.
+func shadows(prefix, other string) bool {
+	prefix = strings.TrimSuffix(prefix, "/")
+	other = strings.TrimSuffix(other, "/")
+
+	if prefix == "" {
+		return true
+	}
+
+	return other == prefix || strings.HasPrefix(other, prefix+"/")
+}

--- a/internal/config/shadowing_test.go
+++ b/internal/config/shadowing_test.go
@@ -1,0 +1,69 @@
+package config_test
+
+import (
+	"bytes"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadWithStatics(t *testing.T, statics string) string {
+	t.Helper()
+
+	restore := slog.Default()
+
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
+	logs := &bytes.Buffer{}
+	slog.SetDefault(slog.New(slog.NewTextHandler(logs, nil)))
+
+	fs := afero.NewMemMapFs()
+	configPath := "/project/.uncors.yaml"
+
+	content := `
+mappings:
+  - from: http://localhost:3000
+    to: https://api.example.com
+    statics:
+` + statics
+
+	require.NoError(t, afero.WriteFile(fs, configPath, []byte(content), 0o600))
+	require.NoError(t, fs.MkdirAll(filepath.Join("/project", "dist"), 0o755))
+	require.NoError(t, fs.MkdirAll(filepath.Join("/project", "assets"), 0o755))
+
+	flags, err := config.ParseFlags([]string{"--config", configPath})
+	require.NoError(t, err)
+
+	_, err = config.LoadConfiguration(fs, flags)
+	require.NoError(t, err)
+
+	return logs.String()
+}
+
+func TestShadowedStaticMountsAreReported(t *testing.T) {
+	t.Run("reports a mount an earlier one already covers", func(t *testing.T) {
+		logs := loadWithStatics(t, `      - path: /
+        dir: ./dist
+      - path: /assets
+        dir: ./assets
+`)
+
+		assert.Contains(t, logs, "unreachable")
+		assert.Contains(t, logs, "/assets")
+	})
+
+	t.Run("says nothing when the mounts do not overlap", func(t *testing.T) {
+		logs := loadWithStatics(t, `      - path: /assets
+        dir: ./assets
+      - path: /
+        dir: ./dist
+`)
+
+		assert.NotContains(t, logs, "unreachable")
+	})
+}


### PR DESCRIPTION
Fixes review finding **D04 — The documented "SPA with API Proxying" configuration does not work: the static handler shadows every mock**.

The flagship "SPA with API proxying" example claimed that `/api/health` was
mocked and everything else proxied. Neither was true: a static mount at `/` with
an index claimed every path in the mapping, so the SPA served index.html for its
own API calls — which shows up as "my API returns HTML" and is nearly impossible
to attribute to route ordering.

The precedence fix landed in A06; this closes the rest:

- Static-File-Serving.md no longer says a static miss can fall through to a mock
  (it goes upstream), and the SPA example describes what now happens.
- A static mount that an earlier mount already covers is reported at load. Route
  precedence means a static can no longer hide a mock, but it can still hide
  another static, and that failure is just as silent.

---

### Review

One commit, `9eea447`. Step **24 of 33** in the review stack.

This PR targets **`fix/d03-path-resolution`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
