### PR TITLE
docs+test: make the HAR documentation true and prove it (D05)

### DIFF
--- a/docs/HAR-Collector.md
+++ b/docs/HAR-Collector.md
@@ -130,6 +130,25 @@ mappings:
 > new entries are silently dropped rather than slowing down your requests. This is
 > uncommon in normal development use.
 
+## What Is Recorded
+
+Everything the mapping answers, including responses uncors produced itself:
+proxied responses, mocks, scripts, static files, cached hits and the CORS
+preflights uncors answers locally. If a request reached the mapping, it is in the
+archive.
+
+Two things are deliberately left out:
+
+ - **Security-sensitive headers** — `Cookie`, `Set-Cookie`, `Authorization`,
+   `WWW-Authenticate` and the `Proxy-*` pair — unless
+   `capture-secure-headers: true` is set.
+ - **Request bodies.** Only their size is recorded; HAR `postData` is not
+   written, so a large upload is never buffered.
+
+Response bodies larger than 5 MiB are recorded up to that point, and the entry is
+marked with a `comment` saying the body was truncated — a partial body is never
+presented as a complete one.
+
 ## Viewing Captured HAR Files
 
 Open the generated file with any of these tools:
@@ -170,7 +189,9 @@ mappings:
 
 ### Combine with Other Features
 
-HAR recording works alongside mocking, caching, and static file serving:
+HAR recording works alongside mocking, caching and static file serving. Every
+response the mapping produces is recorded — the mocked `/api/feature-flags`, the
+files served from `./dist`, the cached `/api/config` and everything proxied:
 
 ```yaml
 mappings:

--- a/tests/integration/har/har_test.go
+++ b/tests/integration/har/har_test.go
@@ -5,6 +5,7 @@ package har_test
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,4 +70,74 @@ func TestHARMiddleware(t *testing.T) {
 	assert.Equal(t, http.MethodGet, entry.Request.Method)
 	assert.Contains(t, entry.Request.URL, "/recorded/path")
 	assert.Equal(t, http.StatusOK, entry.Response.Status)
+}
+
+// "records every request that passes through a mapping" used to mean "everything
+// the mapping proxied": mocks and scripts bypassed the recorder entirely, so a
+// developer comparing a HAR against what their frontend sent would conclude the
+// requests were never made.
+func TestHARRecordsLocallyProducedResponses(t *testing.T) {
+	const harPath = "/har/local.har"
+
+	backend := integration.NewBackend(t, nil)
+	env := integration.New(t, backend, &config.UncorsConfig{
+		Mappings: config.Mappings{{
+			From: hosts.Parse("https://local.har.local"),
+			To:   backend.AsHost(),
+			HAR:  config.HARConfig{File: harPath},
+			Mocks: config.Mocks{
+				{
+					Matcher:  config.RequestMatcher{Path: "/api/mocked"},
+					Response: config.Response{Code: http.StatusOK, Raw: `{"mocked": true}`},
+				},
+			},
+			Scripts: config.Scripts{
+				{
+					Matcher: config.RequestMatcher{Path: "/api/scripted"},
+					Script:  `response:WriteHeader(200) response:WriteString("scripted")`,
+				},
+			},
+		}},
+	})
+
+	for _, path := range []string{"/api/mocked", "/api/scripted", "/api/proxied"} {
+		result := env.Do(t, integration.NewRequest(t, http.MethodGet, env.URL("local.har.local", path)))
+		require.NoError(t, result.Response.Body.Close())
+		require.Equal(t, http.StatusOK, result.Response.StatusCode, path)
+	}
+
+	require.Eventually(t, func() bool {
+		data, err := afero.ReadFile(env.Fs, harPath)
+		if err != nil {
+			return false
+		}
+
+		var parsed harFile
+		if json.Unmarshal(data, &parsed) != nil {
+			return false
+		}
+
+		recorded := map[string]bool{}
+		for _, entry := range parsed.Log.Entries {
+			recorded[entry.Request.URL] = true
+		}
+
+		for _, path := range []string{"/api/mocked", "/api/scripted", "/api/proxied"} {
+			if !containsPath(recorded, path) {
+				return false
+			}
+		}
+
+		return true
+	}, 2*time.Second, 20*time.Millisecond, "every response the mapping produced must be recorded")
+}
+
+func containsPath(recorded map[string]bool, path string) bool {
+	for url := range recorded {
+		if strings.HasSuffix(url, path) {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Fixes review finding **D05 — HAR documentation overstates what is recorded and when the file is closed**.

The HAR docs claimed the collector records every request that passes through a
mapping, closes its writers on reload, and updates the file after every request.
Mocks and scripts bypassed the recorder entirely (A06), a reload leaked a second
writer over the same file (A02), and writes were batched (A15). A user comparing
a HAR against what their frontend sent would have concluded the requests were
never made — the worst failure mode for an evidence-gathering feature.

With those fixed, this closes the documentation side:

- The docs now state what is recorded (everything the mapping answers, preflights
  included) and what is deliberately left out (secure headers, request bodies,
  the tail of a body past the capture limit — which is marked as truncated).
- The "combine with other features" example says what the archive will contain.
- An integration test asserts that a mocked path, a scripted path and a proxied
  path all appear in the produced archive, so the central claim cannot silently
  become false again.

---

### Review

One commit, `2418d3f`. Step **25 of 33** in the review stack.

This PR targets **`docs/d04-spa-with-mocks`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
