### PR TITLE
fix(rewrite): honour the scheme, validate variables, fix the docs (D06)

### DIFF
--- a/docs/Request-Rewriting.md
+++ b/docs/Request-Rewriting.md
@@ -22,16 +22,22 @@ mappings:
 
 ## Configuration Properties
 
-| Property | Type   | Required | Description                                   |
-| -------- | ------ | -------- | --------------------------------------------- |
-| `from`   | string | Yes      | Path pattern to match (supports wildcards)    |
-| `to`     | string | Yes      | Replacement path pattern (supports wildcards) |
-| `host`   | string | No       | Override upstream host for this rewrite rule  |
+| Property | Type   | Required | Description                                                            |
+| -------- | ------ | -------- | ---------------------------------------------------------------------- |
+| `from`   | string | Yes      | Path to match, with `{name}` **path variables**                        |
+| `to`     | string | Yes      | Replacement path; may use the variables `from` captured                |
+| `host`   | string | No       | Send this rule's requests to another host, optionally with a scheme    |
 
-## Wildcard Support
+## Path Variables
 
-Capture parts of the URL using `{variable}` syntax and reference them in the
-target path:
+Capture parts of the URL with `{name}` and reference them in the target path. A
+path variable matches **one path segment** and does not cross a `/`.
+
+> [!NOTE]
+> uncors uses three different pattern syntaxes, one per job: **path variables**
+> (`{name}`) in rewrites, **host placeholders** (`{name}`) in mapping hosts, and
+> **glob patterns** (`**`) in `cache`. A `{name}` in `to` that `from` does not
+> capture is a configuration error.
 
 ```yaml
 mappings:
@@ -90,11 +96,17 @@ mappings:
     rewrites:
       - from: /auth/{endpoint}
         to: /v1/{endpoint}
-        host: auth-service.example.com
+        host: https://auth-service.example.com
       - from: /payment/{endpoint}
         to: /v2/{endpoint}
-        host: payment-service.example.com
+        host: https://payment-service.example.com
 ```
+
+> [!IMPORTANT]
+> Include the scheme in `host` when the other service speaks a different one.
+> Without it, the incoming request's scheme is kept — so a rule reached over
+> `http://` would go out over `http://` too, and cookies coming back would not be
+> marked secure.
 
 **Request flow:**
 
@@ -106,7 +118,9 @@ mappings:
 
 ### Combining Rewrites with Other Features
 
-Rewrites, mocks, and caching can be used together in a single mapping:
+Rewrites, mocks, and caching can be used together in a single mapping. A
+rewritten request re-enters the mapping's routes, so `/old-api/health` below is
+rewritten to `/v2/api/health` and then answered by the mock at that path:
 
 ```yaml
 mappings:
@@ -123,3 +137,6 @@ mappings:
     cache:
       - /v2/api/users/**
 ```
+
+Rules that keep sending a request back into each other are stopped after eight
+rounds, and the request is answered with `508 Loop Detected`.

--- a/internal/config/rewrite.go
+++ b/internal/config/rewrite.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"regexp"
 	"slices"
 
 	"github.com/evg4b/uncors/pkg/urlt"
@@ -28,10 +30,48 @@ func (r RewritingOption) Validate(field string) error {
 
 	errs = append(errs, ValidatePath(joinPath(field, "from"), r.From, true))
 	errs = append(errs, ValidatePath(joinPath(field, "to"), r.To, true))
+	errs = append(errs, r.validateVariables(field))
 
 	if r.Host != (urlt.Host{}) {
 		errs = append(errs, ValidateHost(joinPath(field, "host"), r.Host))
 	}
 
 	return errors.Join(errs...)
+}
+
+// validateVariables reports a {name} in `to` that `from` never captures.
+// Substitution is a plain replacement, so such a variable would be left in the
+// outgoing path literally rather than failing.
+func (r RewritingOption) validateVariables(field string) error {
+	captured := make(map[string]bool)
+	for _, name := range pathVariables(r.From) {
+		captured[name] = true
+	}
+
+	var errs []error
+
+	for _, name := range pathVariables(r.To) {
+		if !captured[name] {
+			errs = append(errs, &ValidationError{
+				fmt.Sprintf("%s references {%s}, which %s does not capture",
+					joinPath(field, "to"), name, joinPath(field, "from")),
+			})
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// pathVariableRegexp matches the {name} path variables gorilla/mux captures.
+var pathVariableRegexp = regexp.MustCompile(`\{([a-zA-Z][a-zA-Z0-9_]*)[^}]*\}`)
+
+func pathVariables(path string) []string {
+	matches := pathVariableRegexp.FindAllStringSubmatch(path, -1)
+
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		names = append(names, match[1])
+	}
+
+	return names
 }

--- a/internal/config/rewrite_test.go
+++ b/internal/config/rewrite_test.go
@@ -144,3 +144,22 @@ func TestRewritingOptionValidatorIsValidWithError(t *testing.T) {
 		})
 	}
 }
+
+func TestRewritingOptionVariableValidation(t *testing.T) {
+	t.Run("accepts variables the from pattern captures", func(t *testing.T) {
+		option := config.RewritingOption{From: "/old-api/{resource}", To: "/v2/api/{resource}"}
+
+		require.NoError(t, option.Validate("rewrites[0]"))
+	})
+
+	// A {name} the from pattern never captures is left in the outgoing path
+	// literally, so the request quietly goes somewhere nobody meant.
+	t.Run("reports a variable the from pattern does not capture", func(t *testing.T) {
+		option := config.RewritingOption{From: "/old-api/{resource}", To: "/v2/api/{id}"}
+
+		err := option.Validate("rewrites[0]")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rewrites[0].to references {id}")
+	})
+}

--- a/internal/handler/rewrite/handler.go
+++ b/internal/handler/rewrite/handler.go
@@ -36,8 +36,17 @@ func (m *Middleware) rewriteRequest(request *contracts.Request) *contracts.Reque
 		return request
 	}
 
+	// The scheme travels with the host when one was configured, so that
+	// `host: https://auth.example.com` upgrades the request as written — and so
+	// that cookies forwarded to it are marked secure. Without a scheme the
+	// incoming request's own scheme is kept.
+	target := m.rewrite.Host.HostPort()
+	if m.rewrite.Host.Scheme != "" {
+		target = m.rewrite.Host.String()
+	}
+
 	return request.WithContext(
-		context.WithValue(request.Context(), RewriteHostKey, m.rewrite.Host.HostPort()),
+		context.WithValue(request.Context(), RewriteHostKey, target),
 	)
 }
 


### PR DESCRIPTION
Fixes review finding **D06 — Request-rewriting docs promise host-scheme upgrades and rewrite-then-mock chaining; neither happens**.

Three things the rewrite documentation described did not happen.

- **A `host:` scheme was dropped.** Only the host and port travelled with the
  request, so the documented `→ https://auth-service.example.com/v1/login` went
  out over the incoming request's scheme, and cookies coming back were not marked
  secure. The scheme now travels with the host when one is configured, and the
  docs say what happens when it is not.
- **Rewrite-then-mock could not work.** A rewritten request went straight
  upstream; the mock at the rewritten path was never consulted. Re-dispatch
  landed in A06, so the documented example now behaves as documented, loop bound
  included.
- **A `{name}` in `to` that `from` never captures** was substituted into the
  outgoing path literally. It is now a configuration error.

The docs also stop calling three different pattern languages "wildcards": path
variables, host placeholders and glob patterns each get their own name.

---

### Review

One commit, `b20913c`. Step **26 of 33** in the review stack.

This PR targets **`docs/d05-har-coverage`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
