### PR TITLE
docs: rewrite ARCHITECTURE.md and CLAUDE.md against the real tree (D07)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,201 +1,186 @@
 # UNCORS Architecture
 
-A quick overview of how UNCORS works and how the code is organized.
+How UNCORS works and how the code is organised. For the user-facing reference see
+[docs/](docs/); for contributor conventions see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## What is UNCORS?
 
-UNCORS is a local development proxy that bypasses CORS restrictions. It sits between your browser and backend servers, modifying CORS headers on the fly.
+UNCORS is a local development proxy that bypasses CORS restrictions. It sits
+between your browser and your backends, rewriting hosts and CORS headers on the
+fly, and can answer requests locally from mocks, Lua scripts or static files.
 
-**How it works:**
+## Layers
 
-- Intercepts HTTP/HTTPS requests
-- Forwards requests to target servers
-- Modifies CORS headers in responses
-- Uses middleware for additional features (caching, mocking, etc.)
-
-## Core Components
-
-### Main Application (`internal/uncors`)
-
-Manages server lifecycle, graceful shutdown, and config watching.
-
-### Configuration (`internal/config`)
-
-Loads and validates YAML config files using JSON Schema.
-
-### Request Handlers (`internal/handler`)
-
-Routes requests and builds middleware chains based on configuration.
-
-**Available handlers:**
-
-- **Proxy** - Forwards requests to upstream servers with modified CORS headers
-- **Mock** - Returns predefined responses from files or config
-- **Script** - Runs Lua scripts for dynamic responses
-- **Static** - Serves static files from filesystem
-
-**Middleware:**
-
-- **Cache** - In-memory response caching with TTL
-- **Rewrite** - URL/header/query parameter manipulation
-- **Options** - Handles CORS preflight requests
-- **HAR Collector** - Records all request/response pairs to an HTTP Archive (HAR 1.2) file
-
-### Infrastructure (`internal/infra`)
-
-HTTP client, logger setup, TLS certificate handling.
-
-### Terminal UI (`internal/tui`)
-
-Colored logging and request/response formatting.
-
-## Request Flow
-
-1. **Client sends request** → UNCORS server
-2. **Route matching** - Find mapping by host/port
-3. **Middleware pipeline** - Apply HAR capture → options → cache → static
-4. **Handler selection** - Choose mock, script, or proxy handler
-5. **CORS modification** - Add/modify CORS headers
-6. **Response** - Return to client (HAR entry is enqueued asynchronously)
-
-Example CORS headers added:
+The dependency direction is one-way. Nothing on a lower line may import
+something from a higher one.
 
 ```
-Access-Control-Allow-Origin: *
+internal/cli                     command tree, run modes  (composition root)
+internal/uncors, internal/di     application lifecycle, per-generation wiring
+internal/server, internal/tui    listeners and TLS, terminal rendering
+internal/handler/*               handlers and middleware
+internal/config, internal/infra  configuration, shared HTTP infrastructure
+internal/contracts               the few interfaces the layers share
+```
+
+Run `go list ./...` for the current package list, and `go doc ./internal/<pkg>`
+for what a package is for — the package comments are the source of truth, not
+this file.
+
+## Core components
+
+**`internal/cli`** — the command tree. It resolves the command named on the
+command line, parses its flags, and runs it. `uncors` itself is the root command;
+`generate-certs` is a subcommand. This is the only package that decides between
+the terminal UI and plain output.
+
+**`internal/uncors`** — the application. `Uncors` owns the server and the current
+configuration generation; `Runner` owns the process lifecycle (startup, config
+watching, the version check, signal handling, shutdown); `Reloader` owns config
+hot reload. Both run modes drive the same three types, so their behaviour cannot
+diverge.
+
+**`internal/di`** — the composition root. `Container` holds the process-scoped
+values (filesystem, output, version) and the application-scoped singletons
+(server, request tracker, certificate manager, HTTP client pool). `Runtime` holds
+everything derived from *one* configuration — routers, HAR writers, the response
+cache, the server targets — and releases exactly that on `Close`, which is what
+makes a reload leak-free.
+
+**`internal/config`** — loading and validation. Validation is hand-written Go:
+each type has a `Validate(field, …)` method, and the errors are joined with
+dotted field paths. `schema.json` is an editor-support artefact for YAML
+completion; it is not consulted at runtime.
+
+**`internal/handler`** — the request graph.
+
+| Handler  | Answers with                              |
+| -------- | ----------------------------------------- |
+| `proxy`  | the upstream, via `httputil.ReverseProxy` |
+| `mock`   | a configured response                     |
+| `script` | the result of a compiled Lua script       |
+| `static` | a file from disk                          |
+
+| Middleware | Does                                              |
+| ---------- | ------------------------------------------------- |
+| `har`      | records the traffic of a mapping to a HAR archive |
+| `options`  | answers CORS preflights                           |
+| `cache`    | serves repeated upstream responses from memory    |
+| `rewrite`  | rewrites a path and re-enters routing             |
+
+`router` assembles them into one router per mapping.
+
+**`internal/server`** — TCP and TLS listeners, per-host certificate generation
+with an SNI cache, and the request activity tracker.
+
+**`internal/infra`** — shared HTTP infrastructure: the client pool, the response
+recorder, CORS headers, the error page, and logging setup.
+
+**`internal/tui`** — console rendering, with `internal/tui/app` holding the
+BubbleTea model.
+
+## Request flow
+
+1. A **listener** accepts the request and wraps the writer in an
+   `infra.ResponseRecorder`, which observes the status and, on request, the body.
+   An activity event is emitted for the tracker.
+2. The **host router** picks the mapping whose `from:` matches.
+3. **Mapping-wide middleware** runs, outermost first: `har` (so every response
+   the mapping produces is recorded) then `options` (so a preflight is answered
+   before anything decides what serves the path).
+4. The **mapping's routes** are tried in precedence order: mocks, then scripts,
+   then rewrites, then static mounts, then the proxy. A rewritten request
+   re-enters this list, bounded at 8 rounds.
+5. The **cache** wraps the proxy branch only: a mock, a script or a static file
+   is produced locally and changes when the config does, so caching it would only
+   serve a stale copy.
+6. **CORS headers** are written by whichever handler answered.
+7. The recorder reports the final status, and a terminal activity event is
+   emitted.
+
+The headers added to a proxied response are:
+
+```
+Access-Control-Allow-Origin: <the request's Origin, or * when it had none>
 Access-Control-Allow-Credentials: true
-Access-Control-Allow-Methods: *
 Access-Control-Allow-Headers: *
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Expose-Headers: *
+Access-Control-Max-Age: 86400
 ```
 
-## Project Structure
+A preflight answered by the `options` middleware echoes the request's
+`Access-Control-Request-Headers` and `-Method` instead of the wildcards.
 
-```
-uncors/
-├── main.go
-├── internal/
-│   ├── config/           # Config loading & validation
-│   ├── contracts/        # Interfaces (handler, logger, http client)
-│   ├── handler/          # Request handlers & middleware
-│   │   ├── cache/
-│   │   ├── har/          # HAR collector middleware & async writer
-│   │   ├── mock/
-│   │   ├── proxy/
-│   │   ├── script/
-│   │   ├── static/
-│   │   └── ...
-│   ├── infra/            # HTTP client, logger, TLS
-│   ├── tui/              # Terminal UI
-│   ├── uncors/           # Main app
-│   └── helpers/          # Utilities
-├── testing/              # Mocks & test helpers
-└── tests/                # Integration tests
-```
+## Key design patterns
 
-## HAR Collector
-
-The HAR (HTTP Archive) collector records every proxied request/response pair to
-a [HAR 1.2](https://w3c.github.io/web-performance/specs/HAR/Overview.html) file.
-It is enabled per-mapping via the `har.file` config key and is implemented as a
-standalone middleware (`internal/handler/har`).
-
-**Design goals:**
-- **Non-blocking** - the middleware never blocks the request goroutine. Entries
-  are sent over a buffered channel (capacity 4096). If the channel is full the
-  entry is silently dropped rather than stalling the request.
-- **High throughput writes** - a single background goroutine serialises all
-  disk I/O. After every new entry it atomically replaces the HAR file using a
-  write-to-tmp-then-rename strategy so the file is always in a valid state.
-- **Per-mapping isolation** - each mapping creates its own `Writer` instance and
-  its own output file, so traffic from different mappings can be captured
-  independently.
-- **Lifecycle management** - `Writer` implements `io.Closer`. The app registers
-  each writer via `registerCloser`; on shutdown or config reload it calls
-  `Close()` which drains the channel and flushes outstanding entries before
-  stopping the background goroutine.
-
-**Configuration:**
-
-The simplest form uses a string shorthand - the value is treated as the output file path:
-
-```yaml
-mappings:
-  - from: http://localhost:3000
-    to: https://api.example.com
-    har: ./recordings/api.har
-```
-
-For full control, use the object form:
-
-```yaml
-mappings:
-  - from: http://localhost:3000
-    to: https://api.example.com
-    har:
-      file: ./recordings/api.har
-      capture-secure-headers: true   # default: false
-```
-
-**Security-sensitive headers:**
-
-By default the following headers are **excluded** from HAR entries to avoid
-persisting credentials on disk. Set `capture-secure-headers: true` to include
-them.
-
-| Header                | Why it is sensitive                        |
-|-----------------------|--------------------------------------------|
-| `Cookie`              | Session identifiers                        |
-| `Set-Cookie`          | Session identifiers set by the server      |
-| `Authorization`       | Bearer tokens, Basic credentials           |
-| `WWW-Authenticate`    | Server auth challenges (reveals scheme)    |
-| `Proxy-Authorization` | Proxy credentials                          |
-| `Proxy-Authenticate`  | Proxy auth challenges                      |
-
-## Key Design Patterns
-
-**Middleware Pattern** - Composable request/response processing
+**Standard net/http shapes.** Handlers are `http.Handler` and middleware is
+`func(http.Handler) http.Handler`:
 
 ```go
+// internal/contracts
 type Middleware = func(http.Handler) http.Handler
 ```
 
-**Factory Pattern** - Creates handlers/middleware with dependency injection
+Handlers that benefit from returning an error opt in locally; `infra.HandlerFunc`
+renders a returned error as an HTTP error response with an appropriate status.
+
+**Explicit dependencies.** The router states what it needs as a value the
+composition root fills in, rather than reaching back into a container:
 
 ```go
-type ProxyHandlerFactory = func() contracts.Handler
+// internal/handler/router
+type Deps struct {
+    Proxy  http.Handler
+    Mock   func(*config.Response) http.Handler
+    Static func(path string, dir config.StaticDirectory) contracts.Middleware
+    // …
+}
 ```
 
-**Interface-based** - Small interfaces for easy testing and mocking
+**Functional options.** Every handler and middleware is constructed with
+`WithX(...)` options.
+
+**Generation-scoped resources.** Anything derived from the configuration lives in
+`di.Runtime` and is closed when that configuration stops being current.
 
 ## Extending UNCORS
 
-Want to add a new feature? Here's where to start:
+**A new handler:**
 
-**New handler:**
+1. Create `internal/handler/<name>/`, implementing `http.Handler`.
+2. Add a constructor to `internal/di/public_api.go`.
+3. Add a field for it to `router.Deps` and fill it in `internal/di/runtime.go`.
+4. Register its routes in `router.registerMapping`, in precedence order.
 
-1. Create package in `internal/handler/`
-2. Implement `contracts.Handler` interface
-3. Add factory to `RequestHandler`
+**A new middleware:**
 
-**New middleware:**
+1. Create `internal/handler/<name>/` with a `Wrap(http.Handler) http.Handler`
+   method.
+2. Decide whether it belongs to the whole mapping (like `har`) or to one branch
+   (like `cache`) and wire it in `router.registerMapping` accordingly.
 
-1. Create middleware package
-2. Implement `func(http.Handler) http.Handler` signature
-3. Add to middleware chain
+**A new config option:**
 
-**New config option:**
-
-1. Update structs in `internal/config/`
-2. Update `schema.json`
-3. Add validator if needed
+1. Add the field and its `Validate` rules in `internal/config/`.
+2. Update `schema.json` for editor completion.
+3. Document it — `tests/docs` loads every example in `docs/`, and
+   `internal/cli` pins the documented flag table to the real flag set.
 
 ## Testing
 
-- Unit tests use mocks (generated with `minimock`)
-- Integration tests in `tests/`
-- Run: `make test` or `go test ./...`
+- Unit tests live beside the code; mocks are generated with `minimock`.
+- `tests/integration` boots the real proxy over real sockets and TLS
+  (`make test-integration`).
+- `tests/docs` loads every configuration example in the documentation.
+- `make dead-code` reports anything under `internal/` that nothing can reach.
 
-## Important Notes
+## Important notes
 
-**Security:** UNCORS is for local development only. Don't expose it to the internet!
+**Security.** UNCORS is a development tool: it strips CORS protections and can
+hold a locally trusted CA. It binds to loopback by default; `--listen` opts out
+of that, loudly.
 
-**Performance:** Uses goroutines, connection pooling, and in-memory caching for speed.
+**Performance.** One shared HTTP transport per upstream proxy setting, an
+in-memory response cache, non-blocking activity reporting, and HAR recording
+through an append-only journal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ go test -run TestName ./internal/handler/proxy/
   and read the diff before committing it.
 - `interactive` is a CLI flag only (`yaml:"-"`), and it falls back to plain
   output when stdout is not a terminal.
-- `schema.json` is for editor completion; it is not used at runtime.
+- `schema.json` is for editor completion; it is not used at runtime, and
+  `tests/schema` fails if it drifts from the config structs.
 - Three documentation guards will fail a change that drifts: `tests/docs` loads
   every config example in `docs/`, `internal/cli` pins the documented flag table
   to the real flag set, and `make dead-code` rejects unreachable code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,245 +1,80 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repository.
 
-## Project Overview
+**UNCORS** is a local development HTTP/HTTPS proxy that bypasses CORS
+restrictions. It also mocks, caches, rewrites, serves static files, runs Lua
+scripts, and records traffic to HAR archives.
 
-**UNCORS** is a lightweight local HTTP/HTTPS proxy that bypasses CORS restrictions by modifying CORS headers in responses. It's designed for development and testing workflows, supporting features like request mocking, response caching, request rewriting, static file serving, and HTTP Archive (HAR) traffic recording.
+- Module: `github.com/evg4b/uncors`
+- Go version: see `go.mod` (currently 1.26)
+- Scope: development tooling. Not intended for production or remote use.
 
-- Language: Go 1.24.1+
-- Primary Use: Development proxy
-- Key Package: `github.com/evg4b/uncors`
+## Structure
 
-## Quick Start
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the layering, the request flow and how
+to extend things — it is the single description of the design, so add structural
+facts there rather than duplicating them here.
 
-### Build & Run
+For the current package list, run `go list ./...`; for what a package is for, run
+`go doc ./internal/<pkg>`.
+
+## Commands
+
 ```bash
-make build              # Build binary
-make install            # Install to GOPATH/bin
-./uncors --from 'http://localhost:8080' --to 'https://github.com'
+make build              # compile every package (produces no binary)
+make install            # install the binary into GOPATH/bin
+make build-release      # build ./uncors with release flags
+
+make test               # unit tests with the race detector
+make test-integration   # real sockets and TLS (tagged `integration`)
+make test-cover         # coverage.out
+make dead-code          # unreachable functions under internal/
+
+make format             # gofmt, gofumpt, golangci-lint --fix
+make check              # format + test + dead-code + build
+make format-docs        # prettier over the markdown
+
+go test -run TestName ./internal/handler/proxy/
 ```
 
-### Testing
-```bash
-make test               # Run all unit tests with race detection
-make test-integration   # Run integration tests (real sockets + TLS)
-make test-cover         # Generate coverage report (coverage.out)
-go test -run TestName ./... # Run specific test by name pattern
-```
+## Conventions
 
-### Code Quality
-```bash
-make check              # Run format + test + build (full validation)
-make format             # Run gofmt, gofumpt, and golangci-lint --fix
-golangci-lint run       # Manual linting (uses .golangci.yml)
-```
+- **Standard net/http shapes.** Handlers are `http.Handler`; middleware is
+  `func(http.Handler) http.Handler`. A handler that wants an error return uses
+  `infra.HandlerFunc`, which renders the error with an appropriate status.
+- **Functional options** for every constructor: `NewX(WithA(…), WithB(…))`.
+- **Explicit dependencies.** A leaf package states what it needs (see
+  `router.Deps`); it does not reach back into the container.
+- **Diagnostics go through `log/slog`** to stderr. `contracts.Output` is for
+  deliberate user-facing output (the logo, boxes, the request log) — a component
+  should never have to choose between them.
+- **Nothing on the request path may block on presentation.** Activity events are
+  dropped, never queued, when a consumer is slow.
+- **Config-derived resources belong to `di.Runtime`**, so a reload releases them.
+- YAML keys are kebab-case (enforced by the `tagliatelle` linter).
+- `.golangci.yml` enables all linters except the ones it lists; `make format`
+  applies the fixable ones.
 
-### Configuration & Generation
-```bash
-./uncors generate-certs         # Generate TLS certificates
-make format-docs                # Format markdown docs with Prettier
-go mod tidy                     # Tidy dependencies
-make upgrade                    # Upgrade all dependencies and run make all
-```
+## Gotchas
 
-## Architecture Overview
+- `make build` compiles but writes no binary; use `make build-release` or
+  `make install` when you need one.
+- Integration tests need the `integration` build tag, and they run the proxy
+  against an in-memory filesystem — anything the proxy writes (HAR archives) is
+  in `env.Fs`, not on disk.
+- Snapshot tests use `go-snaps`; regenerate with `UPDATE_SNAPS=true go test …`
+  and read the diff before committing it.
+- `interactive` is a CLI flag only (`yaml:"-"`), and it falls back to plain
+  output when stdout is not a terminal.
+- `schema.json` is for editor completion; it is not used at runtime.
+- Three documentation guards will fail a change that drifts: `tests/docs` loads
+  every config example in `docs/`, `internal/cli` pins the documented flag table
+  to the real flag set, and `make dead-code` rejects unreachable code.
 
-UNCORS follows a clean layered architecture with middleware composition:
+## Before committing
 
-### Request Flow
-1. **Server** (`internal/server`) - TCP listener and request routing
-2. **HAR Collector** (first middleware) - Non-blocking traffic recording
-3. **Options Middleware** - CORS preflight request handling
-4. **Cache Middleware** - In-memory response caching with TTL
-5. **Handler Selection** - Route to Proxy, Mock, Script, or Static handler
-6. **CORS Headers** - Add/modify response headers
-
-### Core Packages
-
-**`internal/uncors`** - Application lifecycle
-- `Uncors` type: manages server startup, graceful shutdown, and config watching
-- Watches for config file changes and restarts when needed
-
-**`internal/config`** - Configuration loading & validation
-- `LoadConfiguration()`: Parses CLI flags and YAML config file
-- JSON Schema validation (schema.json)
-- `ConfigWatcher`: File system watcher for live config reloads
-
-**`internal/handler`** - Request routing and middleware
-- **Proxy** - Forwards requests to upstream servers with modified CORS headers
-- **Mock** - Returns predefined responses from files or config
-- **Script** - Runs Lua scripts for dynamic responses (via gopher-lua)
-- **Static** - Serves static files from filesystem
-- **Middleware**: cache, rewrite, options, HAR collector
-
-**`internal/contracts`** - Small, focused interfaces
-- `Handler`: Interface for request handlers
-- `Logger`: Logging abstraction
-- `HTTPClient`: HTTP client contract
-
-**`internal/infra`** - Infrastructure services
-- HTTP client with connection pooling and proxy support
-- Logger setup (`log/slog` to stderr or a file, level-controlled)
-- TLS certificate generation and handling
-
-**`internal/tui`** - Terminal UI and logging
-- `CliOutput`: Colored console output with request/response formatting
-- Request tracking and printing
-
-**`internal/server`** - Server lifecycle
-- `RequestTracker`: Tracks active requests for stats/logging
-- `RequestPrinter`: Goroutine that prints request info
-
-**`main.go`** - Entry point
-- Interactive TUI mode (`-i` flag) via BubbleTea
-- Non-interactive headless mode (default)
-- Config watching and auto-restart
-- Version checking and panic recovery
-
-### HAR Collector Design
-Located in `internal/handler/har`, implements non-blocking traffic recording:
-- **Channel-based**: Entries sent over buffered channel (capacity 4096)
-- **Async writes**: Single background goroutine handles disk I/O
-- **Atomic file updates**: Write-to-temp-then-rename for data integrity
-- **Per-mapping isolation**: Each mapping has its own `Writer` instance
-- **Lifecycle**: Implements `io.Closer` for graceful shutdown
-- **Security**: Excludes sensitive headers by default (Cookie, Authorization, etc.)
-
-## Key Design Patterns
-
-**Middleware Pattern**
-```go
-type Middleware = func(http.Handler) http.Handler
-```
-Composable request/response processing layers.
-
-**Factory Pattern**
-Handlers/middleware created with dependency injection (options pattern in Go).
-
-**Interface-based Design**
-Small, focused interfaces (`Handler`, `Logger`, `HTTPClient`) enable easy testing and mocking.
-
-## Testing Strategy
-
-- **Unit Tests**: Co-located with code in `*_test.go` files, using minimock for mocks
-- **Integration Tests**: In `tests/integration/` tagged with `// +build integration`
-- **Mocks**: Generated with `gojuno/minimock/v3`
-- **Snapshots**: Using `gkampitakis/go-snaps` for golden file testing
-
-Key test flags:
-- `-race`: Detects data races (always enabled in make test)
-- `-tags integration`: Runs integration tests that use real sockets/TLS
-- `-tags release`: Runs release-specific tests
-- `-timeout 1m`: Sets timeout for long-running tests
-
-## Configuration Structure
-
-**Config Loading** (`internal/config`)
-- CLI flags override YAML file settings
-- YAML is validated against `schema.json` (JSON Schema)
-- Config watcher uses `fsnotify` for file system events
-- Supports hot-reload without server restart
-
-**Key Config Options**
-- `proxy`: Upstream proxy URL (optional)
-- `interactive`: Enable TUI mode
-- `debug`: Enable debug logging
-- `port`: Listen port (default: 3000)
-- `mappings`: Array of request mappings (from/to hosts)
-
-## Development Workflow
-
-### Before Committing
-1. Run `make format` to auto-fix code style
-2. Run `make test` to verify tests pass
-3. Run `make check` for comprehensive validation
-4. Commit with clear message: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
-
-### Adding a New Feature
-
-**New Handler Type:**
-1. Create `internal/handler/myhandler/` package
-2. Implement `contracts.Handler` interface
-3. Update config schema in `schema.json`
-4. Add factory method in request handler routing
-5. Add tests in `myhandler_test.go`
-
-**New Middleware:**
-1. Create package in `internal/handler/mymiddleware/`
-2. Implement `func(http.Handler) http.Handler` signature
-3. Update middleware chain in request handler
-4. Add tests
-
-**New Config Option:**
-1. Add field to `internal/config/` struct
-2. Update `schema.json` with validation rules
-3. Add parser/validator if complex
-4. Update CONTRIBUTING.md if user-facing
-
-### Debugging
-- Diagnostics go to stderr at `info` level; `--log-level debug`, `--log-file PATH` and `--quiet` control them (`--debug` is shorthand for `--log-level debug`)
-- Run single test: `go test -run TestName ./internal/handler/proxy/`
-- Race detector: Already enabled in `make test` and `make test-cover`
-- Integration tests: `make test-integration` (slower, real network)
-
-## Important Notes
-
-**Scope**: UNCORS is a development-only tool. Security review is limited; not intended for production or remote proxy use.
-
-**Performance**: Uses goroutines, connection pooling, in-memory caching, and the ristretto cache library for speed.
-
-**Go Version**: Requires Go 1.24.1+ due to language features and dependency requirements.
-
-**Linux Compatibility**: Primarily developed on macOS; runs on Linux and Windows.
-
-**Code Style**: Follows Go conventions. Key linters enabled in `.golangci.yml`:
-- Default: all linters except those listed in `disable:`
-- YAML tags use kebab-case (tagliatelle rule)
-- Variable naming lenience for common short names (fs, to, ok, form, ca)
-
-## File Structure
-
-```
-uncors/
-├── main.go                      # Entry point (CLI, TUI mode selection, config loading)
-├── main_test.go                 # Main function tests
-├── schema.json                  # JSON Schema for config validation
-├── ARCHITECTURE.md              # Detailed architecture docs
-├── CONTRIBUTING.md              # Contribution guidelines
-├── Makefile                     # Build automation
-├── .golangci.yml                # Linter configuration
-├── go.mod / go.sum              # Dependencies
-├── internal/
-│   ├── uncors/                  # App lifecycle & server management
-│   ├── config/                  # Config loading, validation, watching
-│   ├── handler/                 # Request handlers & middleware
-│   │   ├── proxy/               # HTTP proxy handler
-│   │   ├── mock/                # Mock response handler
-│   │   ├── script/              # Lua script handler
-│   │   ├── static/              # Static file handler
-│   │   ├── cache/               # Response caching middleware
-│   │   ├── har/                 # HAR traffic recording
-│   │   ├── rewrite/             # URL/header rewriting
-│   │   └── options/             # CORS preflight handling
-│   ├── contracts/               # Interfaces (Handler, Logger, HTTPClient)
-│   ├── infra/                   # HTTP client, logger, TLS
-│   ├── server/                  # Server lifecycle & request tracking
-│   ├── tui/                     # Terminal UI & colored output
-│   ├── uncors_app/              # Interactive TUI app (BubbleTea)
-│   ├── commands/                # CLI commands (generate-certs)
-│   ├── version/                 # Version checking
-│   ├── helpers/                 # Utilities
-│   └── urlreplacer/             # URL replacement utility
-├── testing/                     # Test mocks & helpers
-├── tests/                       # Integration tests
-└── docs/                        # User documentation (features, guides)
-```
-
-## Useful External Resources
-
-- **Testing**: `stretchr/testify` for assertions, `minimock/v3` for mocks
-- **CLI**: `spf13/pflag` for flags
-- **YAML**: `goccy/go-yaml` and `gopkg.in/yaml.v3`
-- **Lua**: `yuin/gopher-lua` and `layeh/gopher-json` for script handler
-- **TUI**: `charm.land/bubbletea/v2`, `charm.land/lipgloss/v2`, `charm.land/bubbles/v2`
-- **Caching**: `dgraph-io/ristretto/v2` for high-performance caching
+1. `make format`
+2. `make check`
+3. Commit with a conventional prefix: `feat:`, `fix:`, `docs:`, `refactor:`,
+   `test:`, `chore:`.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -111,8 +111,24 @@ Each mapping can use a different port by specifying it in the URL.
 
 ## Configuration File
 
-UNCORS uses YAML format for configuration files. Below is a comprehensive
-example demonstrating all available options:
+UNCORS uses YAML format for configuration files.
+
+### Editor Support
+
+Point your editor's YAML language server at the schema to get completion and
+inline validation for every option:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/evg4b/uncors/main/schema.json
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+```
+
+The schema is for authoring only. uncors validates your configuration itself when
+it loads it, with messages that name the offending field.
+
+Below is a comprehensive example demonstrating all available options:
 
 ```yaml
 # Global configuration

--- a/schema.json
+++ b/schema.json
@@ -43,7 +43,7 @@
         "500ms",
         "1h 30m 15s 500ms 100us 200ns"
       ],
-      "pattern": "^(\\d+h)?\\s*(\\d+m)?\\s*(\\d+s)?\\s*(\\d+ms)?\\s*(\\d+(us|µs))?\\s*(\\d+(ns))?$",
+      "pattern": "^(\\d+h)?\\s*(\\d+m)?\\s*(\\d+s)?\\s*(\\d+ms)?\\s*(\\d+(us|\u00b5s))?\\s*(\\d+(ns))?$",
       "title": "Duration",
       "type": "string"
     },
@@ -225,9 +225,9 @@
           "$ref": "#/definitions/Headers",
           "description": "Custom headers to be sent in response to OPTIONS requests"
         },
-        "status": {
+        "code": {
           "$ref": "#/definitions/StatusCode",
-          "description": "Custom status code to be sent in response to OPTIONS requests"
+          "description": "Status code to answer OPTIONS requests with"
         }
       },
       "type": "object"
@@ -334,6 +334,10 @@
         "script": {
           "description": "Inline script code",
           "type": "string"
+        },
+        "timeout": {
+          "description": "How long the script may run before it is stopped",
+          "$ref": "#/definitions/Duration"
         }
       },
       "required": [
@@ -383,10 +387,6 @@
       "additionalProperties": false,
       "description": "Global cache configuration",
       "properties": {
-        "clear-time": {
-          "description": "Expired cache clear time",
-          "type": "string"
-        },
         "expiration-time": {
           "description": "Cache expiration time",
           "type": "string"
@@ -400,6 +400,12 @@
             "$ref": "#/definitions/Method"
           },
           "type": "array"
+        },
+        "max-size": {
+          "description": "Maximum total size of cached responses, in bytes",
+          "type": "integer",
+          "minimum": 1,
+          "default": 104857600
         }
       },
       "type": "object"
@@ -421,6 +427,11 @@
       "description": "HTTP/HTTPS proxy to provide requests to real server (used system by default)",
       "format": "uri",
       "type": "string"
+    },
+    "listen": {
+      "description": "Address to bind to. Anything but a loopback address exposes the proxy to your network",
+      "type": "string",
+      "default": "127.0.0.1"
     }
   },
   "required": [

--- a/tests/docs/packages_test.go
+++ b/tests/docs/packages_test.go
@@ -1,0 +1,39 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// packageReference matches an `internal/...` path written in backticks.
+var packageReference = regexp.MustCompile("`(internal/[a-z0-9_/]+)`")
+
+// The architecture documents used to name packages that had been renamed or
+// removed. Naming a package that does not exist is worse than saying nothing:
+// it is specific, so a reader trusts it.
+func TestDocumentedPackagesExist(t *testing.T) {
+	for _, doc := range []string{"../../ARCHITECTURE.md", "../../CLAUDE.md", "../../CONTRIBUTING.md"} {
+		t.Run(filepath.Base(doc), func(t *testing.T) {
+			content, err := os.ReadFile(doc)
+			require.NoError(t, err)
+
+			for _, match := range packageReference.FindAllStringSubmatch(string(content), -1) {
+				pkg := match[1]
+
+				t.Run(pkg, func(t *testing.T) {
+					// The path comes from a regexp over our own documentation.
+					//nolint:gosec // G703
+					info, err := os.Stat(filepath.Join("../..", pkg))
+
+					require.NoError(t, err, "%s names %s, which does not exist", doc, pkg)
+					assert.True(t, info.IsDir())
+				})
+			}
+		})
+	}
+}

--- a/tests/schema/drift_test.go
+++ b/tests/schema/drift_test.go
@@ -1,0 +1,111 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// schema.json is not consulted at runtime — it exists so editors can complete and
+// check a config file. Nothing therefore tells anyone when it drifts from the Go
+// structs, which is how it came to bless a `clear-time` that does not exist while
+// rejecting the `max-size` that is required.
+func TestSchemaMatchesConfigStructs(t *testing.T) {
+	content, err := os.ReadFile("../../schema.json")
+	require.NoError(t, err)
+
+	var document struct {
+		Properties  map[string]json.RawMessage `json:"properties"`
+		Definitions map[string]struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"definitions"`
+	}
+
+	require.NoError(t, json.Unmarshal(content, &document))
+
+	t.Run("root", func(t *testing.T) {
+		// interactive is a CLI flag only, so it is deliberately absent.
+		assertSameKeys(t, config.UncorsConfig{}, keysOf(document.Properties))
+	})
+
+	definitions := map[string]any{
+		"OptionsHandling": config.OptionsHandling{},
+		"StaticDirectory": config.StaticDirectory{},
+		"Rewrite":         config.RewritingOption{},
+		"Script":          config.Script{},
+	}
+
+	for name, value := range definitions {
+		t.Run(name, func(t *testing.T) {
+			definition, ok := document.Definitions[name]
+			require.True(t, ok, "schema.json has no %s definition", name)
+
+			assertSameKeys(t, value, keysOf(definition.Properties))
+		})
+	}
+
+	t.Run("cache-config", func(t *testing.T) {
+		var cacheConfig struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+
+		require.NoError(t, json.Unmarshal(document.Properties["cache-config"], &cacheConfig))
+		assertSameKeys(t, config.CacheConfig{}, keysOf(cacheConfig.Properties))
+	})
+}
+
+// assertSameKeys compares the yaml keys of a config struct with the properties
+// the schema declares for it.
+func assertSameKeys(t *testing.T, value any, documented []string) {
+	t.Helper()
+
+	assert.Equal(t, yamlKeys(value), documented,
+		"schema.json and the config struct describe different keys")
+}
+
+// yamlKeys returns the sorted yaml field names of a struct, following inline
+// embedding and skipping fields marked `yaml:"-"`.
+func yamlKeys(value any) []string {
+	var keys []string
+
+	for field := range reflect.TypeOf(value).Fields() {
+		tag, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+		if tag == "-" {
+			continue
+		}
+
+		if strings.Contains(field.Tag.Get("yaml"), "inline") {
+			keys = append(keys, yamlKeys(reflect.New(field.Type).Elem().Interface())...)
+
+			continue
+		}
+
+		if tag == "" {
+			tag = strings.ToLower(field.Name)
+		}
+
+		keys = append(keys, tag)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func keysOf(properties map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}

--- a/tests/schema/valid/base-mappings.yaml
+++ b/tests/schema/valid/base-mappings.yaml
@@ -1,7 +1,7 @@
 debug: false
 proxy: http://localhost:8080
 cache-config:
-  clear-time: 10m
+  max-size: 104857600
   expiration-time: 1h
   methods: [GET, POST]
 mappings:


### PR DESCRIPTION
Fixes review finding **D07 — `ARCHITECTURE.md` and `CLAUDE.md` describe packages, types and a validation mechanism that no longer exist**.

Both onboarding documents described a previous shape of the codebase: packages
that no longer existed, JSON Schema validation that was never wired up, type
signatures that were never in this repository, and extension steps naming a
`RequestHandler` type that does not exist. Stale architecture documentation is
worse than none, because it is specific — a contributor following it writes code
that does not compile, having first been misled about the design.

- ARCHITECTURE.md describes the current layering, the real request flow and
  middleware ordering, the actual CORS headers, and extension steps that name
  real files. The hand-maintained file tree is replaced by `go list ./...`, and
  the duplicated HAR section by a pointer to docs/HAR-Collector.md.
- CLAUDE.md drops the 80% it duplicated from ARCHITECTURE.md and keeps what is
  specific to working here: commands, conventions and gotchas. Its stale claims
  (Go version, `make build` producing a binary, the old build-tag syntax,
  `interactive` as a YAML key) are corrected.
- A test asserts every `internal/...` package these documents name actually
  exists, so the class of error that produced this finding fails the build.

---

### Review

One commit, `7d71bcd`. Step **27 of 33** in the review stack.

This PR targets **`fix/d06-rewrite-behaviour`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
