### PR TITLE
fix(schema): correct schema.json and stop it drifting again (D08)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ go test -run TestName ./internal/handler/proxy/
   and read the diff before committing it.
 - `interactive` is a CLI flag only (`yaml:"-"`), and it falls back to plain
   output when stdout is not a terminal.
-- `schema.json` is for editor completion; it is not used at runtime.
+- `schema.json` is for editor completion; it is not used at runtime, and
+  `tests/schema` fails if it drifts from the config structs.
 - Three documentation guards will fail a change that drifts: `tests/docs` loads
   every config example in `docs/`, `internal/cli` pins the documented flag table
   to the real flag set, and `make dead-code` rejects unreachable code.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -111,8 +111,24 @@ Each mapping can use a different port by specifying it in the URL.
 
 ## Configuration File
 
-UNCORS uses YAML format for configuration files. Below is a comprehensive
-example demonstrating all available options:
+UNCORS uses YAML format for configuration files.
+
+### Editor Support
+
+Point your editor's YAML language server at the schema to get completion and
+inline validation for every option:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/evg4b/uncors/main/schema.json
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+```
+
+The schema is for authoring only. uncors validates your configuration itself when
+it loads it, with messages that name the offending field.
+
+Below is a comprehensive example demonstrating all available options:
 
 ```yaml
 # Global configuration

--- a/schema.json
+++ b/schema.json
@@ -43,7 +43,7 @@
         "500ms",
         "1h 30m 15s 500ms 100us 200ns"
       ],
-      "pattern": "^(\\d+h)?\\s*(\\d+m)?\\s*(\\d+s)?\\s*(\\d+ms)?\\s*(\\d+(us|µs))?\\s*(\\d+(ns))?$",
+      "pattern": "^(\\d+h)?\\s*(\\d+m)?\\s*(\\d+s)?\\s*(\\d+ms)?\\s*(\\d+(us|\u00b5s))?\\s*(\\d+(ns))?$",
       "title": "Duration",
       "type": "string"
     },
@@ -225,9 +225,9 @@
           "$ref": "#/definitions/Headers",
           "description": "Custom headers to be sent in response to OPTIONS requests"
         },
-        "status": {
+        "code": {
           "$ref": "#/definitions/StatusCode",
-          "description": "Custom status code to be sent in response to OPTIONS requests"
+          "description": "Status code to answer OPTIONS requests with"
         }
       },
       "type": "object"
@@ -334,6 +334,10 @@
         "script": {
           "description": "Inline script code",
           "type": "string"
+        },
+        "timeout": {
+          "description": "How long the script may run before it is stopped",
+          "$ref": "#/definitions/Duration"
         }
       },
       "required": [
@@ -383,10 +387,6 @@
       "additionalProperties": false,
       "description": "Global cache configuration",
       "properties": {
-        "clear-time": {
-          "description": "Expired cache clear time",
-          "type": "string"
-        },
         "expiration-time": {
           "description": "Cache expiration time",
           "type": "string"
@@ -400,6 +400,12 @@
             "$ref": "#/definitions/Method"
           },
           "type": "array"
+        },
+        "max-size": {
+          "description": "Maximum total size of cached responses, in bytes",
+          "type": "integer",
+          "minimum": 1,
+          "default": 104857600
         }
       },
       "type": "object"
@@ -421,6 +427,11 @@
       "description": "HTTP/HTTPS proxy to provide requests to real server (used system by default)",
       "format": "uri",
       "type": "string"
+    },
+    "listen": {
+      "description": "Address to bind to. Anything but a loopback address exposes the proxy to your network",
+      "type": "string",
+      "default": "127.0.0.1"
     }
   },
   "required": [

--- a/tests/schema/drift_test.go
+++ b/tests/schema/drift_test.go
@@ -1,0 +1,111 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// schema.json is not consulted at runtime — it exists so editors can complete and
+// check a config file. Nothing therefore tells anyone when it drifts from the Go
+// structs, which is how it came to bless a `clear-time` that does not exist while
+// rejecting the `max-size` that is required.
+func TestSchemaMatchesConfigStructs(t *testing.T) {
+	content, err := os.ReadFile("../../schema.json")
+	require.NoError(t, err)
+
+	var document struct {
+		Properties  map[string]json.RawMessage `json:"properties"`
+		Definitions map[string]struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"definitions"`
+	}
+
+	require.NoError(t, json.Unmarshal(content, &document))
+
+	t.Run("root", func(t *testing.T) {
+		// interactive is a CLI flag only, so it is deliberately absent.
+		assertSameKeys(t, config.UncorsConfig{}, keysOf(document.Properties))
+	})
+
+	definitions := map[string]any{
+		"OptionsHandling": config.OptionsHandling{},
+		"StaticDirectory": config.StaticDirectory{},
+		"Rewrite":         config.RewritingOption{},
+		"Script":          config.Script{},
+	}
+
+	for name, value := range definitions {
+		t.Run(name, func(t *testing.T) {
+			definition, ok := document.Definitions[name]
+			require.True(t, ok, "schema.json has no %s definition", name)
+
+			assertSameKeys(t, value, keysOf(definition.Properties))
+		})
+	}
+
+	t.Run("cache-config", func(t *testing.T) {
+		var cacheConfig struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+
+		require.NoError(t, json.Unmarshal(document.Properties["cache-config"], &cacheConfig))
+		assertSameKeys(t, config.CacheConfig{}, keysOf(cacheConfig.Properties))
+	})
+}
+
+// assertSameKeys compares the yaml keys of a config struct with the properties
+// the schema declares for it.
+func assertSameKeys(t *testing.T, value any, documented []string) {
+	t.Helper()
+
+	assert.Equal(t, yamlKeys(value), documented,
+		"schema.json and the config struct describe different keys")
+}
+
+// yamlKeys returns the sorted yaml field names of a struct, following inline
+// embedding and skipping fields marked `yaml:"-"`.
+func yamlKeys(value any) []string {
+	var keys []string
+
+	for field := range reflect.TypeOf(value).Fields() {
+		tag, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+		if tag == "-" {
+			continue
+		}
+
+		if strings.Contains(field.Tag.Get("yaml"), "inline") {
+			keys = append(keys, yamlKeys(reflect.New(field.Type).Elem().Interface())...)
+
+			continue
+		}
+
+		if tag == "" {
+			tag = strings.ToLower(field.Name)
+		}
+
+		keys = append(keys, tag)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func keysOf(properties map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}

--- a/tests/schema/valid/base-mappings.yaml
+++ b/tests/schema/valid/base-mappings.yaml
@@ -1,7 +1,7 @@
 debug: false
 proxy: http://localhost:8080
 cache-config:
-  clear-time: 10m
+  max-size: 104857600
   expiration-time: 1h
   methods: [GET, POST]
 mappings:


### PR DESCRIPTION
Fixes review finding **D08 — `schema.json` is out of sync with the config structs and is never used at runtime**.

`schema.json` is not read at runtime — it exists so editors can complete and
check a config file — and nothing told anyone when it stopped matching the Go
structs. It had drifted in four places: it blessed a `clear-time` that does not
exist, omitted the `max-size` that is required to be positive, spelled
`options-handling.code` as `status`, and predated `listen` and the script
`timeout`.

- Those five entries are fixed, and the fixture that relied on `clear-time` with
  them.
- A test compares the schema's properties against the yaml tags of the config
  structs, so the next added or renamed option fails the build until the schema
  follows.
- docs/Configuration.md and the project's own `.uncors.yaml` show the
  `# yaml-language-server: $schema=…` line, which is the one audience the file
  could serve and was never told it existed. The docs also state the split:
  schema for authoring, uncors's own validators at load.

---

### Review

One commit, `a17408c`. Step **28 of 33** in the review stack.

This PR targets **`docs/d07-architecture-rewrite`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
