### PR TITLE
fix(docker): make the published image and its documented command work (D09)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,9 +81,46 @@ jobs:
       - name: Build
         run: go build -tags release -v .
 
+  docker:
+    name: Docker image smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - *fast-clone
+
+      - *setup-go
+
+      # The published image is a documented installation method that no unit
+      # test covers. It has been unusable before — bound to loopback inside its
+      # own network namespace, starting a full-screen TUI against a pipe — so it
+      # is built and actually driven here.
+      - name: Build the image
+        run: |
+          CGO_ENABLED=0 go build -tags release -o uncors .
+          docker build -t uncors:ci .
+
+      - name: Proxy a request through the container
+        run: |
+          docker run --rm -d --name uncors-ci -p 3000:3000 \
+            --add-host proxied.local:127.0.0.1 \
+            uncors:ci --from 'http://proxied.local:3000' --to 'https://example.com'
+
+          for _ in $(seq 1 30); do
+            if curl -fsS -H 'Host: proxied.local' http://127.0.0.1:3000/ -o /dev/null; then
+              echo "the container served a proxied request"
+              docker rm -f uncors-ci
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "the container never served a request"
+          docker logs uncors-ci
+          docker rm -f uncors-ci
+          exit 1
+
   sonar-scan:
     name: SonarCloud Scan
-    needs: [ test, build, lint ]
+    needs: [ test, build, lint, docker ]
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ go test -run TestName ./internal/handler/proxy/
   and read the diff before committing it.
 - `interactive` is a CLI flag only (`yaml:"-"`), and it falls back to plain
   output when stdout is not a terminal.
-- `schema.json` is for editor completion; it is not used at runtime.
+- `schema.json` is for editor completion; it is not used at runtime, and
+  `tests/schema` fails if it drifts from the config structs.
 - Three documentation guards will fail a change that drifts: `tests/docs` loads
   every config example in `docs/`, `internal/cli` pins the documented flag table
   to the real flag set, and `make dead-code` rejects unreachable code.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,14 @@ npm install uncors --save-dev
 #### [Docker](https://www.docker.com/) (Cross-platform)
 
 ```bash
-docker run -p 80:3000 evg4b/uncors --from 'http://local.github.com' --to 'https://github.com'
+docker run --rm -p 3000:3000 \
+  --add-host local.github.com:127.0.0.1 \
+  evg4b/uncors --from 'http://local.github.com:3000' --to 'https://github.com'
 ```
+
+The published port must match the port in `--from`, and the mapped hostname has
+to resolve **inside** the container — see [Running in
+Docker](https://github.com/evg4b/uncors/wiki/Installation#running-in-docker).
 
 #### [Stew](https://github.com/marwanhawari/stew) (Cross-platform)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -111,8 +111,24 @@ Each mapping can use a different port by specifying it in the URL.
 
 ## Configuration File
 
-UNCORS uses YAML format for configuration files. Below is a comprehensive
-example demonstrating all available options:
+UNCORS uses YAML format for configuration files.
+
+### Editor Support
+
+Point your editor's YAML language server at the schema to get completion and
+inline validation for every option:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/evg4b/uncors/main/schema.json
+mappings:
+  - from: http://api.local:3000
+    to: https://api.example.com
+```
+
+The schema is for authoring only. uncors validates your configuration itself when
+it loads it, with messages that name the offending field.
+
+Below is a comprehensive example demonstrating all available options:
 
 ```yaml
 # Global configuration

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -99,6 +99,7 @@ Each mapping can use a different port by specifying it in the URL.
 | `--proxy`         |       | HTTP/HTTPS proxy URL for upstream requests                              |
 | `--config`        | `-c`  | Path to YAML configuration file                                         |
 | `--listen`        |       | Address to bind to (default `127.0.0.1`)                                |
+| `--ca-dir`        |       | Directory holding the local CA (default `~/.config/uncors`)             |
 | `--interactive`   |       | Render the terminal UI (default `true`, off when stdout is not a TTY)   |
 | `--log-level`     |       | Diagnostic verbosity: `debug`, `info`, `warn`, `error` (default `info`) |
 | `--log-file`      |       | Write diagnostics to a file instead of stderr                           |

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -49,7 +49,45 @@ Docker images are available on [Docker
 Hub](https://hub.docker.com/r/evg4b/uncors):
 
 ```bash
-docker run -p 80:3000 evg4b/uncors --from 'http://local.github.com' --to 'https://github.com'
+docker run --rm -p 3000:3000 \
+  --add-host local.github.com:127.0.0.1 \
+  evg4b/uncors --from 'http://local.github.com:3000' --to 'https://github.com'
+```
+
+#### Running in Docker
+
+Three things work differently inside a container:
+
+ - **The published port must match the port in `--from`.** uncors listens on the
+   port of its `from:` host (80 for `http://…` and 443 for `https://…` when no
+   port is given), so `-p 3000:3000` goes with `--from http://…:3000`.
+ - **Mapped hostnames must resolve inside the container.** Your host's `/etc/hosts`
+   is not visible there; use `--add-host name:127.0.0.1` for each mapped host.
+ - **The image binds every interface** (`--listen 0.0.0.0`) and runs without the
+   terminal UI. A container is its own network namespace, so a proxy bound to
+   loopback could not be reached through a published port at all.
+
+Mount a config file instead of passing flags:
+
+```bash
+docker run --rm -p 3000:3000 \
+  --add-host api.local:127.0.0.1 \
+  -v "$PWD/.uncors.yaml:/config.yaml:ro" \
+  evg4b/uncors --config /config.yaml
+```
+
+For `https://` mappings, mount a directory for the local CA so it survives
+between runs:
+
+```bash
+docker run --rm -p 3443:3443 \
+  -v "$HOME/.config/uncors:/ca" \
+  evg4b/uncors generate-certs --ca-dir /ca
+
+docker run --rm -p 3443:3443 \
+  --add-host api.local:127.0.0.1 \
+  -v "$HOME/.config/uncors:/ca:ro" \
+  evg4b/uncors --ca-dir /ca --from 'https://api.local:3443' --to 'https://api.example.com'
 ```
 
 ## Binary Installation

--- a/internal/cli/generate_certs.go
+++ b/internal/cli/generate_certs.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/evg4b/uncors/internal/contracts"
@@ -13,10 +12,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const (
-	defaultValidityDays = 365
-	defaultConfigDir    = ".config/uncors"
-)
+const defaultValidityDays = 365
 
 // GenerateCertsCommand handles the 'generate-certs' command.
 type GenerateCertsCommand struct {
@@ -36,16 +32,18 @@ func NewGenerateCertsCommand(options ...GenerateCertsOption) *GenerateCertsComma
 func (c *GenerateCertsCommand) DefineFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&c.validityDays, "validity-days", defaultValidityDays, "Certificate validity period in days")
 	flags.BoolVar(&c.force, "force", false, "Force overwrite existing CA certificates")
+	flags.StringVar(&c.outputDir, "ca-dir", "",
+		"Directory to write the CA into (default: $XDG_CONFIG_HOME/uncors or ~/.config/uncors)")
 }
 
 // Execute runs the generate-certs command.
 func (c *GenerateCertsCommand) Execute() error {
-	homeDir, err := os.UserHomeDir()
+	outputDir, err := server.CAPathOr(c.outputDir)
 	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
+		return err
 	}
 
-	c.outputDir = filepath.Join(homeDir, defaultConfigDir)
+	c.outputDir = outputDir
 
 	certPath := filepath.Join(c.outputDir, server.CACertFileName)
 	keyPath := filepath.Join(c.outputDir, server.CAKeyFileName)

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -89,7 +89,7 @@ func setupLogging(flags *config.Flags, interactive bool) (io.Closer, error) {
 // runHeadless starts the proxy without a terminal UI and blocks until the server
 // shuts down.
 func runHeadless(ctx context.Context, env Env, flags *config.Flags, cfg *config.UncorsConfig) error {
-	container := newContainer(env, di.WithStdout(env.Stdout))
+	container := newContainer(env, flags, di.WithStdout(env.Stdout))
 	defer container.Close()
 
 	output := container.CliOutput()
@@ -130,7 +130,7 @@ func runHeadless(ctx context.Context, env Env, flags *config.Flags, cfg *config.
 func runInteractive(env Env, flags *config.Flags, cfg *config.UncorsConfig) error {
 	output := tuiapp.NewOutput()
 
-	container := newContainer(env, di.WithOutput(output))
+	container := newContainer(env, flags, di.WithOutput(output))
 	defer container.Close()
 
 	app := tuiapp.NewUncorsApp(
@@ -150,10 +150,11 @@ func runInteractive(env Env, flags *config.Flags, cfg *config.UncorsConfig) erro
 	return nil
 }
 
-func newContainer(env Env, options ...di.ContainerOption) *di.Container {
+func newContainer(env Env, flags *config.Flags, options ...di.ContainerOption) *di.Container {
 	return di.NewContainer(append([]di.ContainerOption{
 		di.WithFs(env.Fs),
 		di.WithVersion(env.Version),
+		di.WithCADir(flags.CADir()),
 	}, options...)...)
 }
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -27,6 +27,8 @@ func DefineFlags(set *pflag.FlagSet) *Flags {
 	set.String("log-file", "", "Write diagnostics to this file instead of stderr")
 	set.Bool("quiet", false, "Report errors only (shorthand for --log-level=error)")
 	set.StringP("config", "c", "", "Path to the configuration file")
+	set.String("ca-dir", "",
+		"Directory holding the local CA (default: $XDG_CONFIG_HOME/uncors or ~/.config/uncors)")
 	set.Bool("interactive", true, "Render the terminal UI (falls back to plain output when stdout is not a terminal)")
 
 	return &Flags{set: set}
@@ -48,6 +50,13 @@ func ParseFlags(args []string) (*Flags, error) {
 // ConfigPath is the config file the flags point at, empty when none was given.
 func (f *Flags) ConfigPath() string {
 	value, _ := f.set.GetString("config")
+
+	return value
+}
+
+// CADir is the directory holding the local CA, empty for the default location.
+func (f *Flags) CADir() string {
+	value, _ := f.set.GetString("ca-dir")
 
 	return value
 }

--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -22,6 +22,7 @@ type Container struct {
 	stdout  io.Writer
 	output  contracts.Output
 	version string
+	caDir   string
 
 	cliOutput       func() contracts.Output
 	clients         func() *infra.ClientPool
@@ -47,6 +48,14 @@ func WithStdout(stdout io.Writer) ContainerOption {
 func WithOutput(output contracts.Output) ContainerOption {
 	return func(c *Container) {
 		c.output = output
+	}
+}
+
+// WithCADir sets the directory holding the local CA. Empty means the default
+// location, which follows $XDG_CONFIG_HOME and then the home directory.
+func WithCADir(caDir string) ContainerOption {
+	return func(c *Container) {
+		c.caDir = caDir
 	}
 }
 

--- a/internal/di/factories.go
+++ b/internal/di/factories.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (c *Container) newHostCertManager() *server.HostCertManager {
-	return server.NewHostCertManager(c.fs)
+	return server.NewHostCertManager(c.fs, c.caDir)
 }
 
 func (c *Container) newServer() *server.Server {

--- a/internal/di/public_api.go
+++ b/internal/di/public_api.go
@@ -41,6 +41,11 @@ func (c *Container) RequestTracker() *server.RequestTracker {
 	return c.requestTracker()
 }
 
+// CADir is the directory holding the local CA, empty for the default location.
+func (c *Container) CADir() string {
+	return c.caDir
+}
+
 func (c *Container) Server() *server.Server {
 	return c.server()
 }

--- a/internal/server/ca_path.go
+++ b/internal/server/ca_path.go
@@ -15,25 +15,43 @@ const (
 	CAKeyFileName  = "ca.key"
 )
 
-// GetCAPath returns the default path to the CA certificate directory.
+// GetCAPath returns the directory the local CA lives in.
+//
+// It follows $XDG_CONFIG_HOME before the home directory, so that a process
+// without a usable home — a container running as a numeric user, for instance —
+// still has somewhere to keep it.
 func GetCAPath() (string, error) {
+	if configDir := os.Getenv("XDG_CONFIG_HOME"); configDir != "" {
+		return filepath.Join(configDir, "uncors"), nil
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get user home directory: %w", err)
+		return "", fmt.Errorf("failed to locate the CA directory (set --ca-dir or $XDG_CONFIG_HOME): %w", err)
 	}
 
 	return filepath.Join(homeDir, ".config", "uncors"), nil
 }
 
-// CAExists checks if CA certificate files exist.
-func CAExists(fs afero.Fs) bool {
-	caDir, err := GetCAPath()
+// CAPathOr returns the configured CA directory, falling back to the default.
+func CAPathOr(caDir string) (string, error) {
+	if caDir != "" {
+		return caDir, nil
+	}
+
+	return GetCAPath()
+}
+
+// CAExists checks if CA certificate files exist in the given directory ("" for
+// the default one).
+func CAExists(fs afero.Fs, caDir string) bool {
+	resolved, err := CAPathOr(caDir)
 	if err != nil {
 		return false
 	}
 
-	certPath := filepath.Join(caDir, CACertFileName)
-	keyPath := filepath.Join(caDir, CAKeyFileName)
+	certPath := filepath.Join(resolved, CACertFileName)
+	keyPath := filepath.Join(resolved, CAKeyFileName)
 
 	_, certErr := fs.Stat(certPath)
 	_, keyErr := fs.Stat(keyPath)
@@ -41,15 +59,16 @@ func CAExists(fs afero.Fs) bool {
 	return certErr == nil && keyErr == nil
 }
 
-// LoadDefaultCA loads the CA certificate from the default location.
-func LoadDefaultCA(fs afero.Fs) (*x509.Certificate, *rsa.PrivateKey, error) {
-	caDir, err := GetCAPath()
+// LoadDefaultCA loads the CA certificate from the given directory ("" for the
+// default one).
+func LoadDefaultCA(fs afero.Fs, caDir string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	resolved, err := CAPathOr(caDir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	certPath := filepath.Join(caDir, CACertFileName)
-	keyPath := filepath.Join(caDir, CAKeyFileName)
+	certPath := filepath.Join(resolved, CACertFileName)
+	keyPath := filepath.Join(resolved, CAKeyFileName)
 
 	return LoadCA(fs, certPath, keyPath)
 }

--- a/internal/server/ca_path_test.go
+++ b/internal/server/ca_path_test.go
@@ -39,7 +39,7 @@ func TestCAExists(t *testing.T) {
 	t.Run("should return false when CA does not exist", func(_ *testing.T) {
 		// Temporarily override home dir for testing
 		// This is tricky, so we just test the function doesn't panic
-		exists := server.CAExists(afero.NewOsFs())
+		exists := server.CAExists(afero.NewOsFs(), "")
 		// May be true or false depending on system state
 		// Just verify it doesn't panic
 		_ = exists
@@ -52,7 +52,7 @@ func TestCAExists(t *testing.T) {
 		require.NoError(t, os.MkdirAll(fakeHome, 0o755))
 		t.Setenv("HOME", fakeHome)
 
-		assert.False(t, server.CAExists(afero.NewOsFs()))
+		assert.False(t, server.CAExists(afero.NewOsFs(), ""))
 
 		caDir := filepath.Join(fakeHome, configDir, uncorsDir)
 		config := server.CAConfig{
@@ -64,7 +64,7 @@ func TestCAExists(t *testing.T) {
 		require.NoError(t, err)
 
 		// CA should exist now
-		assert.True(t, server.CAExists(afero.NewOsFs()))
+		assert.True(t, server.CAExists(afero.NewOsFs(), ""))
 	})
 }
 
@@ -86,7 +86,7 @@ func TestLoadDefaultCA(t *testing.T) {
 		require.NoError(t, err)
 
 		// Load default CA
-		cert, key, err := server.LoadDefaultCA(afero.NewOsFs())
+		cert, key, err := server.LoadDefaultCA(afero.NewOsFs(), "")
 		require.NoError(t, err)
 		assert.NotNil(t, cert)
 		assert.NotNil(t, key)
@@ -100,7 +100,7 @@ func TestLoadDefaultCA(t *testing.T) {
 		t.Setenv("HOME", fakeHome)
 
 		// Try to load non-existent CA
-		_, _, err := server.LoadDefaultCA(afero.NewOsFs())
+		_, _, err := server.LoadDefaultCA(afero.NewOsFs(), "")
 		require.Error(t, err)
 	})
 
@@ -123,7 +123,7 @@ func TestLoadDefaultCA(t *testing.T) {
 		require.NoError(t, err)
 
 		// Load with provided filesystem
-		cert, key, err := server.LoadDefaultCA(fs)
+		cert, key, err := server.LoadDefaultCA(fs, "")
 		require.NoError(t, err)
 		assert.NotNil(t, cert)
 		assert.NotNil(t, key)
@@ -145,7 +145,7 @@ func TestCAExists_EdgeCases(t *testing.T) {
 		certPath := filepath.Join(caDir, "ca.crt")
 		require.NoError(t, os.WriteFile(certPath, []byte("cert"), 0o600))
 
-		exists := server.CAExists(afero.NewOsFs())
+		exists := server.CAExists(afero.NewOsFs(), "")
 		assert.False(t, exists, "should return false when only cert exists")
 	})
 
@@ -163,7 +163,7 @@ func TestCAExists_EdgeCases(t *testing.T) {
 		keyPath := filepath.Join(caDir, "ca.key")
 		require.NoError(t, os.WriteFile(keyPath, []byte("key"), 0o600))
 
-		exists := server.CAExists(afero.NewOsFs())
+		exists := server.CAExists(afero.NewOsFs(), "")
 		assert.False(t, exists, "should return false when only key exists")
 	})
 
@@ -186,7 +186,7 @@ func TestCAExists_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 
 		// Check with provided filesystem
-		exists := server.CAExists(fs)
+		exists := server.CAExists(fs, "")
 		assert.True(t, exists)
 	})
 }

--- a/internal/server/host_cert_manager.go
+++ b/internal/server/host_cert_manager.go
@@ -14,14 +14,18 @@ import (
 // certificate per host on the fly signed by the local development CA.
 type HostCertManager struct {
 	fs        afero.Fs
+	caDir     string
 	generator *CertGenerator
 	cache     map[string]*tls.Certificate
 	mutex     sync.RWMutex
 }
 
-func NewHostCertManager(fs afero.Fs) *HostCertManager {
+// NewHostCertManager creates the certificate manager. caDir is the directory
+// holding the local CA; empty means the default location.
+func NewHostCertManager(fs afero.Fs, caDir string) *HostCertManager {
 	return &HostCertManager{
 		fs:    fs,
+		caDir: caDir,
 		cache: make(map[string]*tls.Certificate),
 	}
 }
@@ -78,7 +82,7 @@ func (m *HostCertManager) ensureCA() error {
 		return nil
 	}
 
-	caCert, caKey, err := LoadDefaultCA(m.fs)
+	caCert, caKey, err := LoadDefaultCA(m.fs, m.caDir)
 	if err != nil {
 		return fmt.Errorf("failed to load CA certificate for auto-generation: %w", err)
 	}

--- a/internal/server/host_cert_manager_internal_test.go
+++ b/internal/server/host_cert_manager_internal_test.go
@@ -46,7 +46,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		_, _, err := GenerateCA(caConfig)
 		require.NoError(t, err)
 
-		manager := NewHostCertManager(fs)
+		manager := NewHostCertManager(fs, "")
 		require.NotNil(t, manager)
 
 		// Test SNI by requesting certificate for localhost
@@ -68,7 +68,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		fs := afero.NewOsFs()
 		require.NoError(t, fs.MkdirAll(fakeHome, 0o755))
 
-		manager := NewHostCertManager(fs)
+		manager := NewHostCertManager(fs, "")
 
 		cert, err := manager.getCertificate(&tls.ClientHelloInfo{ServerName: "test"})
 
@@ -97,7 +97,7 @@ func TestBuildTLSConfig(t *testing.T) {
 
 		testHost := "example.local"
 
-		manager := NewHostCertManager(fs)
+		manager := NewHostCertManager(fs, "")
 
 		// Test SNI by requesting certificate for the specific host
 		cert, err := manager.getCertificate(&tls.ClientHelloInfo{ServerName: testHost})
@@ -128,7 +128,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		_, _, err := GenerateCA(caConfig)
 		require.NoError(t, err)
 
-		manager := NewHostCertManager(fs)
+		manager := NewHostCertManager(fs, "")
 		require.NotNil(t, manager)
 
 		// Test SNI for api.local - should auto-generate cert for this host
@@ -168,7 +168,7 @@ func TestGetCertificate_EmptySNI(t *testing.T) {
 		_, _, err := GenerateCA(CAConfig{ValidityDays: 365, OutputDir: caDir, Fs: fs})
 		require.NoError(t, err)
 
-		manager := NewHostCertManager(fs)
+		manager := NewHostCertManager(fs, "")
 
 		// Mock connection with IP address
 		mockConn := &mockConn{localAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.100"), Port: 8443}}
@@ -196,7 +196,7 @@ func TestGetCertificate_EmptySNI(t *testing.T) {
 		_, _, err := GenerateCA(CAConfig{ValidityDays: 365, OutputDir: caDir, Fs: fs})
 		require.NoError(t, err)
 
-		manager := NewHostCertManager(fs)
+		manager := NewHostCertManager(fs, "")
 
 		cert, err := manager.getCertificate(&tls.ClientHelloInfo{ServerName: ""})
 
@@ -219,7 +219,7 @@ func newManagerWithCA(t *testing.T) *HostCertManager {
 	_, _, err := GenerateCA(CAConfig{ValidityDays: 365, OutputDir: caDir, Fs: fs})
 	require.NoError(t, err)
 
-	return NewHostCertManager(fs)
+	return NewHostCertManager(fs, "")
 }
 
 func TestHostCertManager_Caching(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -234,7 +234,7 @@ func (s *Server) checkTLSReadiness(pending []*PortListener) error {
 			continue
 		}
 
-		if !CAExists(s.manager.fs) {
+		if !CAExists(s.manager.fs, s.manager.caDir) {
 			errs = append(errs, &TLSError{Host: listener.address})
 
 			s.forget(listener)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -76,7 +76,7 @@ func TestServer(t *testing.T) {
 			}
 		})
 
-		manager := server.NewHostCertManager(afero.NewOsFs())
+		manager := server.NewHostCertManager(afero.NewOsFs(), "")
 		instance := server.New(manager, server.NewRequestTracker())
 		require.NoError(t, instance.Start(t.Context(), targets))
 
@@ -122,7 +122,7 @@ func TestServer(t *testing.T) {
 			}
 		})
 
-		manager := server.NewHostCertManager(fs)
+		manager := server.NewHostCertManager(fs, "")
 		instance := server.New(manager, server.NewRequestTracker())
 		require.NoError(t, instance.Start(t.Context(), targets))
 
@@ -177,7 +177,7 @@ func TestServer(t *testing.T) {
 			}
 		})
 
-		manager := server.NewHostCertManager(fs)
+		manager := server.NewHostCertManager(fs, "")
 		instance := server.New(manager, server.NewRequestTracker())
 		require.NoError(t, instance.Start(t.Context(), append(httpTargets, httpsTargets...)))
 
@@ -201,7 +201,7 @@ func TestServer(t *testing.T) {
 	t.Run("shutdown", func(t *testing.T) {
 		port := testutils.GetFreePort(t)
 
-		manager := server.NewHostCertManager(afero.NewOsFs())
+		manager := server.NewHostCertManager(afero.NewOsFs(), "")
 		instance := server.New(manager, server.NewRequestTracker())
 		require.NoError(t, instance.Start(t.Context(), []server.Target{
 			{
@@ -227,7 +227,7 @@ func TestServer(t *testing.T) {
 	t.Run("close", func(t *testing.T) {
 		port := testutils.GetFreePort(t)
 
-		manager := server.NewHostCertManager(afero.NewOsFs())
+		manager := server.NewHostCertManager(afero.NewOsFs(), "")
 		instance := server.New(manager, server.NewRequestTracker())
 		require.NoError(t, instance.Start(t.Context(), []server.Target{
 			{
@@ -251,7 +251,7 @@ func TestServer(t *testing.T) {
 	t.Run("Restart", func(t *testing.T) {
 		initial := testutils.GetFreePort(t)
 		restarted := testutils.GetFreePort(t)
-		manager := server.NewHostCertManager(afero.NewOsFs())
+		manager := server.NewHostCertManager(afero.NewOsFs(), "")
 		instance := server.New(manager, server.NewRequestTracker())
 
 		require.NoError(t, instance.Start(t.Context(), []server.Target{
@@ -281,7 +281,7 @@ func TestServer(t *testing.T) {
 
 		port := testutils.GetFreePort(t)
 
-		manager := server.NewHostCertManager(afero.NewOsFs())
+		manager := server.NewHostCertManager(afero.NewOsFs(), "")
 		instance := server.New(manager, server.NewRequestTracker())
 
 		queue.Track("server started")
@@ -342,7 +342,7 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { ln.Close() })
 
-		manager := server.NewHostCertManager(afero.NewOsFs())
+		manager := server.NewHostCertManager(afero.NewOsFs(), "")
 		instance := server.New(manager, server.NewRequestTracker())
 		err = instance.Start(t.Context(), []server.Target{
 			{
@@ -356,7 +356,7 @@ func TestServer(t *testing.T) {
 }
 
 func TestServerRestartReconcilesPorts(t *testing.T) {
-	manager := server.NewHostCertManager(afero.NewMemMapFs())
+	manager := server.NewHostCertManager(afero.NewMemMapFs(), "")
 
 	handlerFor := func(body string) http.Handler {
 		return infra.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) error {
@@ -458,7 +458,7 @@ func getBody(t *testing.T, url string) string {
 // A wildcard bind has no local address to infer a certificate host from, so a
 // client that sends no SNI has to be answered from the mapping's own hostname.
 func TestServerBindsTheConfiguredAddress(t *testing.T) {
-	manager := server.NewHostCertManager(afero.NewMemMapFs())
+	manager := server.NewHostCertManager(afero.NewMemMapFs(), "")
 	instance := server.New(manager, server.NewRequestTracker())
 
 	port := testutils.GetFreePort(t)

--- a/schema.json
+++ b/schema.json
@@ -43,7 +43,7 @@
         "500ms",
         "1h 30m 15s 500ms 100us 200ns"
       ],
-      "pattern": "^(\\d+h)?\\s*(\\d+m)?\\s*(\\d+s)?\\s*(\\d+ms)?\\s*(\\d+(us|µs))?\\s*(\\d+(ns))?$",
+      "pattern": "^(\\d+h)?\\s*(\\d+m)?\\s*(\\d+s)?\\s*(\\d+ms)?\\s*(\\d+(us|\u00b5s))?\\s*(\\d+(ns))?$",
       "title": "Duration",
       "type": "string"
     },
@@ -225,9 +225,9 @@
           "$ref": "#/definitions/Headers",
           "description": "Custom headers to be sent in response to OPTIONS requests"
         },
-        "status": {
+        "code": {
           "$ref": "#/definitions/StatusCode",
-          "description": "Custom status code to be sent in response to OPTIONS requests"
+          "description": "Status code to answer OPTIONS requests with"
         }
       },
       "type": "object"
@@ -334,6 +334,10 @@
         "script": {
           "description": "Inline script code",
           "type": "string"
+        },
+        "timeout": {
+          "description": "How long the script may run before it is stopped",
+          "$ref": "#/definitions/Duration"
         }
       },
       "required": [
@@ -383,10 +387,6 @@
       "additionalProperties": false,
       "description": "Global cache configuration",
       "properties": {
-        "clear-time": {
-          "description": "Expired cache clear time",
-          "type": "string"
-        },
         "expiration-time": {
           "description": "Cache expiration time",
           "type": "string"
@@ -400,6 +400,12 @@
             "$ref": "#/definitions/Method"
           },
           "type": "array"
+        },
+        "max-size": {
+          "description": "Maximum total size of cached responses, in bytes",
+          "type": "integer",
+          "minimum": 1,
+          "default": 104857600
         }
       },
       "type": "object"
@@ -421,6 +427,11 @@
       "description": "HTTP/HTTPS proxy to provide requests to real server (used system by default)",
       "format": "uri",
       "type": "string"
+    },
+    "listen": {
+      "description": "Address to bind to. Anything but a loopback address exposes the proxy to your network",
+      "type": "string",
+      "default": "127.0.0.1"
     }
   },
   "required": [

--- a/tests/schema/drift_test.go
+++ b/tests/schema/drift_test.go
@@ -1,0 +1,111 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/evg4b/uncors/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// schema.json is not consulted at runtime — it exists so editors can complete and
+// check a config file. Nothing therefore tells anyone when it drifts from the Go
+// structs, which is how it came to bless a `clear-time` that does not exist while
+// rejecting the `max-size` that is required.
+func TestSchemaMatchesConfigStructs(t *testing.T) {
+	content, err := os.ReadFile("../../schema.json")
+	require.NoError(t, err)
+
+	var document struct {
+		Properties  map[string]json.RawMessage `json:"properties"`
+		Definitions map[string]struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"definitions"`
+	}
+
+	require.NoError(t, json.Unmarshal(content, &document))
+
+	t.Run("root", func(t *testing.T) {
+		// interactive is a CLI flag only, so it is deliberately absent.
+		assertSameKeys(t, config.UncorsConfig{}, keysOf(document.Properties))
+	})
+
+	definitions := map[string]any{
+		"OptionsHandling": config.OptionsHandling{},
+		"StaticDirectory": config.StaticDirectory{},
+		"Rewrite":         config.RewritingOption{},
+		"Script":          config.Script{},
+	}
+
+	for name, value := range definitions {
+		t.Run(name, func(t *testing.T) {
+			definition, ok := document.Definitions[name]
+			require.True(t, ok, "schema.json has no %s definition", name)
+
+			assertSameKeys(t, value, keysOf(definition.Properties))
+		})
+	}
+
+	t.Run("cache-config", func(t *testing.T) {
+		var cacheConfig struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+
+		require.NoError(t, json.Unmarshal(document.Properties["cache-config"], &cacheConfig))
+		assertSameKeys(t, config.CacheConfig{}, keysOf(cacheConfig.Properties))
+	})
+}
+
+// assertSameKeys compares the yaml keys of a config struct with the properties
+// the schema declares for it.
+func assertSameKeys(t *testing.T, value any, documented []string) {
+	t.Helper()
+
+	assert.Equal(t, yamlKeys(value), documented,
+		"schema.json and the config struct describe different keys")
+}
+
+// yamlKeys returns the sorted yaml field names of a struct, following inline
+// embedding and skipping fields marked `yaml:"-"`.
+func yamlKeys(value any) []string {
+	var keys []string
+
+	for field := range reflect.TypeOf(value).Fields() {
+		tag, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+		if tag == "-" {
+			continue
+		}
+
+		if strings.Contains(field.Tag.Get("yaml"), "inline") {
+			keys = append(keys, yamlKeys(reflect.New(field.Type).Elem().Interface())...)
+
+			continue
+		}
+
+		if tag == "" {
+			tag = strings.ToLower(field.Name)
+		}
+
+		keys = append(keys, tag)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func keysOf(properties map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}

--- a/tests/schema/valid/base-mappings.yaml
+++ b/tests/schema/valid/base-mappings.yaml
@@ -1,7 +1,7 @@
 debug: false
 proxy: http://localhost:8080
 cache-config:
-  clear-time: 10m
+  max-size: 104857600
   expiration-time: 1h
   methods: [GET, POST]
 mappings:


### PR DESCRIPTION
Fixes review finding **D09 — The documented Docker command cannot work: wrong port mapping, loopback bind, TUI without a TTY, and no `$HOME`**.

The documented `docker run -p 80:3000 …` could not work for four independent
reasons: uncors listened on port 80 while the command published 3000, it bound
loopback inside a container's own network namespace, it started a full-screen TUI
against a pipe, and `FROM scratch` gave it no home directory, so https mappings
failed validation and `generate-certs` could not run.

The first three were fixed with `--listen` and the TTY fallback (A18, A10). This
closes the rest:

- The CA directory is configurable: `--ca-dir`, and the default now follows
  `$XDG_CONFIG_HOME` before the home directory, so a process without a usable
  home can still find it. Container users can mount a volume for it.
- The documented run command publishes the port uncors actually listens on and
  adds the host it maps, because a container cannot see your /etc/hosts.
- docs/Installation.md gains a "Running in Docker" section covering ports,
  hostname resolution, mounting a config file and mounting the CA.
- CI builds the image, runs it and curls a proxied request through it. The
  published image is a documented installation method that no unit test covers,
  and it has been unusable before.

---

### Review

One commit, `ab07d04`. Step **29 of 33** in the review stack.

This PR targets **`fix/d08-schema-drift`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
