### PR TITLE
fix: reconcile the remaining config and CORS claims with the code (D10)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,7 +104,7 @@ The headers added to a proxied response are:
 Access-Control-Allow-Origin: <the request's Origin, or * when it had none>
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400
 ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -169,13 +169,13 @@ mappings:
 
 ## Global Configuration Properties
 
-| Property       | Type    | Default | Description                                                               |
-| -------------- | ------- | ------- | ------------------------------------------------------------------------- |
-| `proxy`        | string  | -             | HTTP/HTTPS proxy URL for upstream requests                          |
-| `debug`        | boolean | `false`       | Enable debug logging output                                         |
-| `listen`       | string  | `127.0.0.1`   | Address to bind to (see below)                                      |
-| `mappings`     | array   | `[]`    | List of host mapping configurations (see below)                           |
-| `cache-config` | object  | -       | Global cache behavior settings (see [Response Caching](Response-Caching)) |
+| Property       | Type    | Default                | Description                                                       |
+| -------------- | ------- | ---------------------- | ----------------------------------------------------------------- |
+| `proxy`        | string  | -                      | Proxy for upstream requests; a bare `host:port` is assumed to be HTTP |
+| `debug`        | boolean | `false`                | Shorthand for `--log-level debug`                                 |
+| `listen`       | string  | `127.0.0.1`            | Address to bind to (see below)                                    |
+| `mappings`     | array   | `[]`                   | Host mappings (see below)                                         |
+| `cache-config` | object  | 30m / 100 MB / `[GET]` | Global cache behaviour (see [Response Caching](Response-Caching))  |
 
 ### File Paths
 
@@ -260,10 +260,29 @@ changes, so caching them would only serve stale copies.
 ### OPTIONS Request Handling
 
 By default, UNCORS intercepts and handles `OPTIONS` requests locally to
-facilitate CORS preflight checks. The default response includes:
+facilitate CORS preflight checks.
 
- - `Access-Control-Allow-Origin: *`
- - `Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS`
+**On a normal response**, UNCORS adds:
+
+```
+Access-Control-Allow-Origin: <the request's Origin, or * when it had none>
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Headers: *
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
+Access-Control-Expose-Headers: *
+Access-Control-Max-Age: 86400
+```
+
+**On a preflight**, the wildcards are replaced by what the request asked for:
+`Access-Control-Allow-Origin` echoes `Origin`, `-Allow-Headers` echoes
+`Access-Control-Request-Headers`, and `-Allow-Methods` echoes
+`Access-Control-Request-Method`. Each falls back to the value above when the
+request did not send its counterpart.
+
+> [!NOTE]
+> The echo is not cosmetic. `Access-Control-Allow-Credentials: true` is always
+> sent, and browsers reject that combined with a wildcard origin — so a preflight
+> has to name the origin it is answering.
 
 **Disabling OPTIONS handling:**
 
@@ -312,20 +331,21 @@ mappings:
     to: http://site.com
 ```
 
-**Scheme-agnostic mapping:**
+**Omitting the scheme:**
 
-Using `//` as the scheme creates a mapping that matches both HTTP and HTTPS
-requests.
-
-Redirect all requests to HTTPS:
+A `from:` written as `//host:port` has no explicit scheme. uncors serves it over
+**plain HTTP** — a single listener is either TLS or it is not — so `//` is a
+shorthand for "http", not a way to serve both. Serving one mapping over both
+schemes needs two mappings on two ports.
 
 ```yaml
 mappings:
-  - from: //localhost:8080
+  - from: //localhost:8080 # listens on http://localhost:8080
     to: https://site.com
 ```
 
-Preserve the original request scheme:
+A `to:` written as `//host` **does** preserve the incoming request's scheme, so
+this forwards http to http and https to https:
 
 ```yaml
 mappings:
@@ -340,10 +360,11 @@ mappings:
 ### Named Placeholder Mapping
 
 UNCORS supports named placeholders in host mappings for flexible domain
-matching. A placeholder is written as `{name}` and matches any sequence of
-characters in that hostname segment (excluding `.` and `/`). Using explicit
-names makes multi-placeholder mappings self-documenting and allows each
-placeholder to be referenced by name in the target URL.
+matching. A placeholder is written as `{name}` and matches **one hostname
+label**: any run of characters other than `.` or `/`. So `{repo}.local.com`
+matches `uncors.local.com` but not `a.b.local.com`. Using explicit names makes
+multi-placeholder mappings self-documenting and allows each placeholder to be
+referenced by name in the target URL.
 
 **Example 1: Static target with placeholder source**
 
@@ -551,3 +572,6 @@ uncors --proxy http://proxy.example.com:8080 --from http://localhost --to https:
 ```yaml
 proxy: http://proxy.example.com:8080
 ```
+
+`proxy:` accepts the same two forms as the environment variables: a full URL, or
+a bare `proxy.example.com:8080`, which is assumed to be HTTP.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -5,7 +5,6 @@
     <img alt="UNCORS logo" width="60%" src="https://raw.githubusercontent.com/evg4b/uncors/main/.github/logo.png">
   </a>
   <br />
-  <span>Version: 0.6.1</span>
 </p>
 
 

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -3,6 +3,7 @@ between versions. Breaking changes are documented with before/after examples.
 
 ## Table of Contents
 
+ - [Unreleased](#unreleased)
  - [Version 0.5.x to 0.6.x](#version-05x-to-06x)
    
     - [TLS Certificate Configuration
@@ -11,6 +12,41 @@ between versions. Breaking changes are documented with before/after examples.
     - [Fake Response Feature Removal](#fake-response-feature-removal)
  - [Version 0.4.x to 0.5.x](#version-04x-to-05x)
  - [Older Versions](#older-versions)
+
+---
+
+## Unreleased
+
+### Host placeholders match a single label
+
+**Behaviour change:** a `{name}` placeholder in a mapping host now matches one
+hostname label — any run of characters other than `.` — which is what the
+documentation has always described. It previously matched greedily across dots.
+
+```yaml
+mappings:
+  - from: http://{repo}.local.com
+    to: https://{repo}.github.com
+```
+
+`uncors.local.com` behaves as before. `a.b.local.com` no longer matches, and
+previously bound `repo` to `a.b`. In a multi-placeholder mapping such as
+`{env}.{service}.local.com`, each name now reliably captures its own label
+instead of the first one absorbing as much as it could.
+
+If you relied on a placeholder spanning several labels, add one placeholder per
+label, or use an explicit hostname.
+
+### CORS `Access-Control-Allow-Methods` no longer repeats `HEAD`
+
+The header listed `HEAD` twice. It now reads
+`GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS`. No method was
+added or removed.
+
+### Upstream errors answer 502, unmapped hosts answer 404
+
+Every failure used to be a 500 carrying a stack trace. See
+[Troubleshooting](Troubleshooting) for the status each failure now reports.
 
 ---
 

--- a/docs/Response-Caching.md
+++ b/docs/Response-Caching.md
@@ -87,8 +87,10 @@ cache-config:
  1. **Hit** - Response is returned immediately from cache
  2. **Miss** - Request is forwarded to the upstream server; response is stored
     in cache
- 3. **Evicted** (after `expiration-time` or when `max-size` is reached) - Cache
-    entry is removed; next request fetches fresh data from upstream
+ 3. **Evicted** — after `expiration-time`, or when `max-size` is reached. The
+    cache evicts by cost and keeps what is used most; a single response larger
+    than the whole budget is never admitted. The next request fetches fresh data
+    from upstream.
 
 ## What Is and Is Not Cached
 

--- a/docs/Static-File-Serving.md
+++ b/docs/Static-File-Serving.md
@@ -26,7 +26,7 @@ mappings:
 | -------- | ------ | -------- | --------------------------------------------------------------- |
 | `path`   | string | Yes      | URL path prefix for serving files (wildcards not supported)     |
 | `dir`    | string | Yes      | Local directory path containing files to serve                  |
-| `index`  | string | No       | Fallback file when requested file not found (relative to `dir`) |
+| `index`  | string | No       | Served when the path is missing or is a directory (relative to `dir`) |
 
 **Request handling behavior:**
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -216,7 +216,7 @@ use an incognito/private window.
 **Symptoms:**
 
  - UNCORS starts but doesn't apply configuration
- - "No mappings configured" error
+ - `mappings must not be empty`
  - Configuration changes not taking effect
 
 **1. Wrong configuration file path**

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ func LoadConfiguration(fs afero.Fs, flags *Flags) (*UncorsConfig, error) {
 	}
 
 	cfg.Mappings = NormaliseMappings(cfg.Mappings)
+	cfg.Proxy = NormaliseProxy(cfg.Proxy)
 	resolvePaths(cfg, configPath)
 
 	err = cfg.Validate(fs)

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/evg4b/uncors/internal/urlpattern"
 	"github.com/spf13/afero"
@@ -69,14 +70,23 @@ func ValidateProxy(field, value string) error {
 		return nil
 	}
 
-	// A proxy must be an absolute URL with an explicit scheme and host
-	// (e.g. "http://localhost:8080").
-	parsed, err := url.Parse(value)
+	parsed, err := url.Parse(NormaliseProxy(value))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return &ValidationError{fmt.Sprintf("%s is not a valid URL", field)}
 	}
 
 	return nil
+}
+
+// NormaliseProxy fills in the scheme a bare "host:port" leaves out. Go's own
+// http.ProxyFromEnvironment accepts that form for HTTP_PROXY, so a config file
+// that spells the proxy the same way should work too.
+func NormaliseProxy(value string) string {
+	if value == "" || strings.Contains(value, "://") {
+		return value
+	}
+
+	return "http://" + value
 }
 
 func (m *Mapping) Validate(field string, fs afero.Fs) error {

--- a/internal/config/mapping_test.go
+++ b/internal/config/mapping_test.go
@@ -302,3 +302,23 @@ func TestValidateGlobPatternForCache(t *testing.T) {
 		}
 	})
 }
+
+// The environment variables Go itself reads accept a bare host:port, and the
+// documentation offers the same form for `proxy:`.
+func TestValidateProxyAcceptsABareHostPort(t *testing.T) {
+	valid := []string{"", "http://proxy.example.com:8080", "proxy.example.com:8080", "localhost:8080"}
+	for _, value := range valid {
+		require.NoError(t, config.ValidateProxy("proxy", value), value)
+	}
+
+	invalid := []string{"://nonsense", "http://"}
+	for _, value := range invalid {
+		require.Error(t, config.ValidateProxy("proxy", value), value)
+	}
+}
+
+func TestNormaliseProxy(t *testing.T) {
+	assert.Equal(t, "http://proxy.example.com:8080", config.NormaliseProxy("proxy.example.com:8080"))
+	assert.Equal(t, "https://proxy.example.com", config.NormaliseProxy("https://proxy.example.com"))
+	assert.Empty(t, config.NormaliseProxy(""))
+}

--- a/internal/handler/options/middleware_test.go
+++ b/internal/handler/options/middleware_test.go
@@ -21,7 +21,7 @@ func TestMiddleware(t *testing.T) {
 
 		defaultControlAllowOrigin := []string{"*"}
 		defaultControlAllowMethods := []string{
-			"GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS",
+			"GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS",
 		}
 		defaultControlAllowCredentials := []string{"true"}
 		defaultControlAllowHeaders := []string{"*"}
@@ -211,7 +211,7 @@ func TestMiddleware(t *testing.T) {
 		assert.Equal(t, "true", recorder.Header().Get(headers.AccessControlAllowCredentials))
 		assert.Equal(t, "*", recorder.Header().Get(headers.AccessControlAllowHeaders))
 
-		expectedMethods := "GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS"
+		expectedMethods := "GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS"
 		assert.Equal(t, expectedMethods, recorder.Header().Get(headers.AccessControlAllowMethods))
 		assert.Equal(t, "86400", recorder.Header().Get(headers.AccessControlMaxAge))
 		assert.Equal(t, "*", recorder.Header().Get(headers.AccessControlExposeHeaders))

--- a/internal/infra/cors.go
+++ b/internal/infra/cors.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	allowMethods = "GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS"
+	allowMethods = "GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS"
 	maxAge       = "86400" // 24 hours in seconds
 )
 

--- a/internal/infra/cors_test.go
+++ b/internal/infra/cors_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const expectedAllowMethods = "GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS"
+const expectedAllowMethods = "GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS"
 
 func TestWriteCorsHeaders(t *testing.T) {
 	tests := []struct {

--- a/internal/urlreplacer/helpers.go
+++ b/internal/urlreplacer/helpers.go
@@ -99,7 +99,11 @@ func wildCardToRegexp(rawSource string) (*regexp.Regexp, error) {
 		result.WriteString(regexp.QuoteMeta(host[lastIndex:match[0]]))
 
 		key := host[match[0]+1 : match[1]-1] // strip { and }
-		fmt.Fprintf(&result, "(?P<%s>.+)", key)
+
+		// A placeholder stands for one hostname label, so it must not match a
+		// dot: a greedy (.+) makes `{env}.{service}.local` ambiguous about which
+		// name captures what, and lets `{repo}.local` swallow `a.b.c`.
+		fmt.Fprintf(&result, "(?P<%s>[^.]+)", key)
 
 		lastIndex = match[1]
 	}

--- a/internal/urlreplacer/helpers_internal_test.go
+++ b/internal/urlreplacer/helpers_internal_test.go
@@ -29,49 +29,51 @@ var testCases = []struct {
 	{
 		name:            "single placeholder",
 		url:             "{tenant}",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>.+)(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>[^.]+)(:\d+)?(?P<path>[\/?].*)?$`,
 		expectedPattern: "${scheme}${tenant}${path}",
 	},
 	{
 		name:            "single placeholder with port",
 		url:             "{tenant}:3001",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>.+)(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>[^.]+)(:\d+)?(?P<path>[\/?].*)?$`,
 		expectedPattern: "${scheme}${tenant}:3001${path}",
 	},
 	{
 		name:            "single placeholder with url part",
 		url:             "demo.{tenant}.com",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?demo\.(?P<tenant>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?demo\.(?P<tenant>[^.]+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
 		expectedPattern: "${scheme}demo.${tenant}.com${path}",
 	},
 	{
 		name:            "single placeholder with url part and port",
 		url:             "api.{tenant}.com:3001",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?api\.(?P<tenant>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?api\.(?P<tenant>[^.]+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
 		expectedPattern: "${scheme}api.${tenant}.com:3001${path}",
 	},
 	{
-		name:            "multiple placeholders with url part",
-		url:             "{region}.host.{tenant}.com",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<region>.+)\.host\.(?P<tenant>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		name: "multiple placeholders with url part",
+		url:  "{region}.host.{tenant}.com",
+		expectedRegexp: `^(?P<scheme>(http(s?):)?\/\/)?(?P<region>[^.]+)\.host\.` +
+			`(?P<tenant>[^.]+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
 		expectedPattern: "${scheme}${region}.host.${tenant}.com${path}",
 	},
 	{
-		name:            "multiple placeholders with url part and port",
-		url:             "{region}.host.{tenant}.com:3001",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<region>.+)\.host\.(?P<tenant>.+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		name: "multiple placeholders with url part and port",
+		url:  "{region}.host.{tenant}.com:3001",
+		expectedRegexp: `^(?P<scheme>(http(s?):)?\/\/)?(?P<region>[^.]+)\.host\.` +
+			`(?P<tenant>[^.]+)\.com(:\d+)?(?P<path>[\/?].*)?$`,
 		expectedPattern: "${scheme}${region}.host.${tenant}.com:3001${path}",
 	},
 	{
 		name:            "host with default http port",
 		url:             "{tenant}.api.com:80",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>.+)\.api\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>[^.]+)\.api\.com(:\d+)?(?P<path>[\/?].*)?$`,
 		expectedPattern: "${scheme}${tenant}.api.com:80${path}",
 	},
 	{
 		name:            "host with default https port",
 		url:             "{tenant}.api.com:443",
-		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>.+)\.api\.com(:\d+)?(?P<path>[\/?].*)?$`,
+		expectedRegexp:  `^(?P<scheme>(http(s?):)?\/\/)?(?P<tenant>[^.]+)\.api\.com(:\d+)?(?P<path>[\/?].*)?$`,
 		expectedPattern: "${scheme}${tenant}.api.com:443${path}",
 	},
 }

--- a/internal/urlreplacer/replacer_test.go
+++ b/internal/urlreplacer/replacer_test.go
@@ -334,3 +334,33 @@ func TestReplacerIsMatched(t *testing.T) {
 		})
 	}
 }
+
+// A placeholder stands for one hostname label. A greedy match let
+// `{repo}.local.com` swallow `a.b.c`, and made a multi-placeholder pattern
+// ambiguous about which name captured what.
+func TestPlaceholdersMatchOneLabel(t *testing.T) {
+	t.Run("does not span dots", func(t *testing.T) {
+		replacer, err := urlreplacer.NewReplacer("http://{repo}.local.com", "https://{repo}.github.com")
+		require.NoError(t, err)
+
+		result, err := replacer.Replace("http://uncors.local.com")
+		require.NoError(t, err)
+		assert.Equal(t, "https://uncors.github.com", result)
+
+		_, err = replacer.Replace("http://a.b.c.local.com")
+		require.Error(t, err, "a placeholder must not swallow several labels")
+	})
+
+	t.Run("each placeholder captures its own label", func(t *testing.T) {
+		replacer, err := urlreplacer.NewReplacer(
+			"http://{env}.{service}.local.com",
+			"https://{service}-{env}.example.com",
+		)
+		require.NoError(t, err)
+
+		result, err := replacer.Replace("http://staging.billing.local.com")
+
+		require.NoError(t, err)
+		assert.Equal(t, "https://billing-staging.example.com", result)
+	})
+}

--- a/testing/testconstants/constants.go
+++ b/testing/testconstants/constants.go
@@ -1,3 +1,3 @@
 package testconstants
 
-const AllMethods = "GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS"
+const AllMethods = "GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS"

--- a/tests/integration/domains/__snapshots__/domains_test.snap
+++ b/tests/integration/domains/__snapshots__/domains_test.snap
@@ -16,7 +16,7 @@ HTTP/1.1 200 OK
 Content-Length: 12
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400

--- a/tests/integration/mock/__snapshots__/mock_test.snap
+++ b/tests/integration/mock/__snapshots__/mock_test.snap
@@ -4,7 +4,7 @@ HTTP/1.1 201 Created
 Content-Length: 13
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400
@@ -21,7 +21,7 @@ Content-Length: 15
 Accept-Ranges: bytes
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400
@@ -50,7 +50,7 @@ HTTP/1.1 200 OK
 Content-Length: 2
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400

--- a/tests/integration/options/__snapshots__/options_test.snap
+++ b/tests/integration/options/__snapshots__/options_test.snap
@@ -3,7 +3,7 @@
 HTTP/1.1 204 No Content
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: https://example.com
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400
@@ -30,7 +30,7 @@ HTTP/1.1 200 OK
 Content-Length: 2
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400

--- a/tests/integration/proxy/__snapshots__/proxy_test.snap
+++ b/tests/integration/proxy/__snapshots__/proxy_test.snap
@@ -16,7 +16,7 @@ HTTP/1.1 200 OK
 Content-Length: 10
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400
@@ -43,7 +43,7 @@ HTTP/1.1 200 OK
 Content-Length: 10
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400

--- a/tests/integration/rewrite/__snapshots__/rewrite_test.snap
+++ b/tests/integration/rewrite/__snapshots__/rewrite_test.snap
@@ -16,7 +16,7 @@ HTTP/1.1 200 OK
 Content-Length: 2
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400
@@ -43,7 +43,7 @@ HTTP/1.1 200 OK
 Content-Length: 2
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400

--- a/tests/integration/routing/__snapshots__/routing_test.snap
+++ b/tests/integration/routing/__snapshots__/routing_test.snap
@@ -16,7 +16,7 @@ HTTP/1.1 200 OK
 Content-Length: 11
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400

--- a/tests/integration/script/__snapshots__/script_test.snap
+++ b/tests/integration/script/__snapshots__/script_test.snap
@@ -4,7 +4,7 @@ HTTP/1.1 202 Accepted
 Content-Length: 8
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400
@@ -19,7 +19,7 @@ HTTP/1.1 200 OK
 Content-Length: 6
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Headers: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, HEAD, LINK, OPTIONS
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, TRACE, DELETE, PATCH, COPY, LINK, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: *
 Access-Control-Max-Age: 86400


### PR DESCRIPTION
Fixes review finding **D10 — Assorted config and CORS claims that the implementation contradicts**.

Six verified mismatches, each small, together making the reference page
untrustworthy.

- **`proxy: localhost:8080`** was documented and rejected at startup. A bare
  `host:port` is now accepted and assumed to be HTTP, which is what Go's own
  `HTTP_PROXY` handling does and what the docs said two paragraphs apart.
- **Host placeholders matched dots.** `{name}` now matches one hostname label, as
  documented: `{repo}.local.com` no longer swallows `a.b.c`, and in
  `{env}.{service}.local.com` each name captures its own label. Noted in the
  migration guide as a behaviour change.
- **`//` in `from:`** was documented as serving both schemes. One listener is
  either TLS or it is not; `//` means HTTP. `to: //host` does preserve the
  request's scheme, and still does.
- **The CORS header set** was documented three different ways, none correct. It
  is now written once, accurately, including why a preflight echoes the request's
  origin and headers rather than using wildcards. `HEAD` no longer appears twice
  in the method list.
- **POST caching** keys on the body since A16, so the documented example works.
- Smaller fixes: the real empty-mappings message, the real `cache-config`
  defaults, cost-based eviction, `index` also covering directories, and the
  hand-maintained version number dropped from the wiki header.

---

### Review

One commit, `14ad251`. Step **30 of 33** in the review stack.

This PR targets **`fix/d09-docker-image`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
