### PR TITLE
chore: remove write-only struct fields and keep them out

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,10 @@ linters:
     - wrapcheck
     - wsl
   settings:
+    unused:
+      # A field that is only ever written is dead weight, and the default hides
+      # exactly the leftovers a refactor produces.
+      field-writes-are-uses: false
     varnamelen:
       ignore-names:
         - form

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -24,10 +24,9 @@ const (
 type UncorsApp struct {
 	keys keyMap
 
-	app       *uncors.Uncors
-	output    *Output
-	tracker   server.IRequestTracker
-	container *di.Container
+	app     *uncors.Uncors
+	output  *Output
+	tracker server.IRequestTracker
 
 	outputCh   <-chan string
 	logCh      <-chan string
@@ -35,8 +34,7 @@ type UncorsApp struct {
 	appDone    <-chan struct{}
 	cancel     context.CancelFunc
 
-	cfg        *config.UncorsConfig
-	configPath string
+	cfg *config.UncorsConfig
 
 	reloader *uncors.Reloader
 	runner   *uncors.Runner
@@ -86,14 +84,12 @@ func NewUncorsApp(
 		app:           app,
 		output:        output,
 		tracker:       container.RequestTracker(),
-		container:     container,
 		outputCh:      output.Lines(),
 		logCh:         logRecords(),
 		appContext:    func() context.Context { return appCtx },
 		appDone:       appCtx.Done(),
 		cancel:        cancel,
 		cfg:           cfg,
-		configPath:    configPath,
 		reloader:      reloader,
 		runner:        uncors.NewRunner(app, reloader, output, checkVersion),
 		historyWidget: historyWidget,

--- a/internal/tui/app/output.go
+++ b/internal/tui/app/output.go
@@ -18,8 +18,7 @@ import (
 // The renderers and their buffer are built once per Output and reused, rather
 // than allocated per line.
 type Output struct {
-	ch     chan string
-	prefix string
+	ch chan string
 
 	mu          sync.Mutex
 	buf         bytes.Buffer
@@ -32,7 +31,7 @@ func NewOutput() *Output {
 }
 
 func newOutput(ch chan string, prefix string) *Output {
-	output := &Output{ch: ch, prefix: prefix}
+	output := &Output{ch: ch}
 	output.renderer = tui.NewCliOutput(&output.buf, tui.WithPrefix(prefix))
 	output.boxRenderer = tui.NewCliOutput(&output.buf)
 

--- a/internal/uncors/app.go
+++ b/internal/uncors/app.go
@@ -13,12 +13,9 @@ import (
 	"github.com/evg4b/uncors/internal/tui"
 
 	"github.com/evg4b/uncors/internal/config"
-	"github.com/spf13/afero"
 )
 
 type Uncors struct {
-	fs afero.Fs
-
 	output    contracts.Output
 	server    *server.Server
 	container *di.Container
@@ -31,7 +28,6 @@ type Uncors struct {
 
 func CreateUncors(container *di.Container) *Uncors {
 	return &Uncors{
-		fs:        container.Fs(),
 		output:    container.CliOutput(),
 		container: container,
 		server:    container.Server(),

--- a/testing/integration/env.go
+++ b/testing/integration/env.go
@@ -40,10 +40,9 @@ type Env struct {
 }
 
 type route struct {
-	pattern string
-	match   func(string) bool
-	port    int
-	scheme  string
+	match  func(string) bool
+	port   int
+	scheme string
 }
 
 // Option customises the Env.
@@ -102,10 +101,9 @@ func New(t *testing.T, backend *Backend, cfg *config.UncorsConfig, opts ...Optio
 
 		resolver.Set(from.Hostname, loopback)
 		env.routes = append(env.routes, route{
-			pattern: from.Hostname,
-			match:   compileHostPattern(from.Hostname),
-			port:    port,
-			scheme:  from.Scheme,
+			match:  compileHostPattern(from.Hostname),
+			port:   port,
+			scheme: from.Scheme,
 		})
 	}
 


### PR DESCRIPTION
Follow-up: write-only struct fields left by the refactors above.

`unused` counts a field write as a use by default, which hides exactly the
leftovers a refactor produces: the TUI model still held the container and the
config path after the runner took over those jobs, the TUI output still stored a
prefix its renderer had already baked in, and `Uncors` carried a filesystem it
never read.

Turning `field-writes-are-uses` off makes the linter report them, which is the
same guard `make dead-code` gives functions.

---

### Review

One commit, `540dfd4`. Step **31 of 33** in the review stack.

This PR targets **`fix/d10-config-and-cors-claims`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
