### PR TITLE
fix(har): one writer per archive, so a reload cannot truncate a recording

### DIFF
--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/evg4b/uncors/internal/handler/har"
 	"github.com/evg4b/uncors/internal/helpers"
 	"github.com/evg4b/uncors/internal/infra"
 	"github.com/evg4b/uncors/internal/server"
@@ -26,6 +27,7 @@ type Container struct {
 
 	cliOutput       func() contracts.Output
 	clients         func() *infra.ClientPool
+	harWriters      func() *har.WriterPool
 	requestTracker  func() *server.RequestTracker
 	hostCertManager func() *server.HostCertManager
 	server          func() *server.Server
@@ -81,16 +83,23 @@ func NewContainer(options ...ContainerOption) *Container {
 
 	container = helpers.ApplyOptions(container, options)
 
-	// The client pool is process scoped: a transport owns a connection pool and
-	// is meant to outlive any single configuration.
-	container.closers = append(container.closers, closerFn(func() error {
-		container.clients().CloseIdleConnections()
+	// Both pools are process scoped. A transport owns a connection pool and is
+	// meant to outlive any single configuration; a HAR archive belongs to the
+	// file it is written to, and a config reload must not truncate it.
+	container.closers = append(container.closers,
+		closerFn(func() error {
+			container.clients().CloseIdleConnections()
 
-		return nil
-	}))
+			return nil
+		}),
+		closerFn(func() error {
+			return container.harWriters().Close()
+		}),
+	)
 
 	container.cliOutput = sync.OnceValue(container.newCliOutput)
 	container.clients = sync.OnceValue(infra.NewClientPool)
+	container.harWriters = sync.OnceValue(container.newHARWriterPool)
 	container.requestTracker = sync.OnceValue(server.NewRequestTracker)
 	container.hostCertManager = sync.OnceValue(container.newHostCertManager)
 	container.server = sync.OnceValue(container.newServer)
@@ -115,6 +124,10 @@ func (c *Container) Close() error {
 type closerFn func() error
 
 func (f closerFn) Close() error { return f() }
+
+func (c *Container) newHARWriterPool() *har.WriterPool {
+	return har.NewWriterPool(c.fs, c.version)
+}
 
 func (c *Container) newCliOutput() contracts.Output {
 	if c.output != nil {

--- a/internal/di/public_api.go
+++ b/internal/di/public_api.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/evg4b/uncors/internal/config"
 	"github.com/evg4b/uncors/internal/contracts"
+	"github.com/evg4b/uncors/internal/handler/har"
 	"github.com/evg4b/uncors/internal/handler/mock"
 	"github.com/evg4b/uncors/internal/handler/options"
 	"github.com/evg4b/uncors/internal/handler/proxy"
@@ -39,6 +40,11 @@ func (c *Container) CliOutput() contracts.Output {
 
 func (c *Container) RequestTracker() *server.RequestTracker {
 	return c.requestTracker()
+}
+
+// HARWriterFor returns the writer recording to the given archive path.
+func (c *Container) HARWriterFor(path string) *har.Writer {
+	return c.harWriters().For(path)
 }
 
 // CADir is the directory holding the local CA, empty for the default location.

--- a/internal/di/runtime.go
+++ b/internal/di/runtime.go
@@ -101,15 +101,12 @@ func (r *Runtime) cacheMiddleware(globs config.CacheGlobs) contracts.Middleware 
 	)
 }
 
+// harMiddleware records this generation's traffic. The writer itself is process
+// scoped and keyed by path, so a reload keeps appending to the same archive
+// instead of starting a second writer over it.
 func (r *Runtime) harMiddleware(harConfig *config.HARConfig) contracts.Middleware {
-	writer := register(r, har.NewWriter(
-		r.container.fs,
-		harConfig.File,
-		har.WithCreatorVersion(r.container.version),
-	))
-
 	return har.NewMiddleware(
-		har.WithWriter(writer),
+		har.WithWriter(r.container.harWriters().For(harConfig.File)),
 		har.WithCaptureSecureHeaders(harConfig.CaptureSecureHeaders),
 	).Wrap
 }

--- a/internal/di/runtime_test.go
+++ b/internal/di/runtime_test.go
@@ -108,3 +108,45 @@ func TestBuildRuntime(t *testing.T) {
 			"config reloads must not accumulate goroutines")
 	})
 }
+
+// Saving a config file must not truncate a recording that is in progress. Two
+// generations used to get two writers over one archive, and closing the older
+// one took the newer one's journal with it.
+func TestHARRecordingSurvivesAReload(t *testing.T) {
+	const harPath = "/har/reloaded.har"
+
+	fs := afero.NewMemMapFs()
+
+	container := di.NewContainer(di.WithFs(fs), di.WithVersion("1.0.0"))
+	defer testutils.Close(t, container)
+
+	configuration := func() *config.UncorsConfig {
+		return &config.UncorsConfig{
+			CacheConfig: config.CacheConfig{MaxSize: 100, ExpirationTime: config.Duration(time.Minute)},
+			Mappings: config.Mappings{
+				{
+					From: hosts.Localhost.HTTP(),
+					To:   hosts.Localhost.HTTPS(),
+					HAR:  config.HARConfig{File: harPath},
+				},
+			},
+		}
+	}
+
+	first, err := container.BuildRuntime(configuration())
+	require.NoError(t, err)
+
+	second, err := container.BuildRuntime(configuration())
+	require.NoError(t, err)
+
+	// Both generations record to the same archive, so they must share one
+	// writer: two writers over one path fight over its journal, and the older
+	// one deletes what the newer one is still recording into.
+	writer := container.HARWriterFor(harPath)
+
+	assert.Same(t, writer, container.HARWriterFor(harPath),
+		"one archive path must have exactly one writer")
+
+	require.NoError(t, first.Close())
+	require.NoError(t, second.Close())
+}

--- a/internal/handler/har/pool.go
+++ b/internal/handler/har/pool.go
@@ -1,0 +1,63 @@
+package har
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/spf13/afero"
+)
+
+// WriterPool hands out one Writer per archive path.
+//
+// A recording belongs to the file it is written to, not to the configuration
+// generation that started it: saving a config file should not truncate the
+// archive or hand a second writer the same path. One writer per path means the
+// archive keeps accumulating across reloads, and there is never more than one
+// goroutine or one journal per file.
+type WriterPool struct {
+	fs             afero.Fs
+	creatorVersion string
+
+	mu      sync.Mutex
+	writers map[string]*Writer
+}
+
+func NewWriterPool(fs afero.Fs, creatorVersion string) *WriterPool {
+	return &WriterPool{
+		fs:             fs,
+		creatorVersion: creatorVersion,
+		writers:        map[string]*Writer{},
+	}
+}
+
+// For returns the writer recording to path, creating it on first use.
+func (p *WriterPool) For(path string) *Writer {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if writer, ok := p.writers[path]; ok {
+		return writer
+	}
+
+	writer := NewWriter(p.fs, path, WithCreatorVersion(p.creatorVersion))
+	p.writers[path] = writer
+
+	return writer
+}
+
+// Close finalises every archive: each writer flushes what it holds and removes
+// its journal.
+func (p *WriterPool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	errs := make([]error, 0, len(p.writers))
+
+	for path, writer := range p.writers {
+		errs = append(errs, writer.Close())
+
+		delete(p.writers, path)
+	}
+
+	return errors.Join(errs...)
+}


### PR DESCRIPTION
Follow-up: found by running the built binary — a config reload truncated an in-progress HAR recording.

Found by running the built binary against a config that records to a HAR file
and then saving that config: the archive went from eight entries to two.

Making writers generation-scoped (A02) fixed the leak but left two generations
sharing one journal path. On reload the new generation opened the same journal,
and the old generation's teardown deleted it — taking the recording with it.

A recording belongs to the file it is written to, not to the configuration that
started it. `har.WriterPool` hands out one writer per archive path for the
process lifetime, so the archive keeps accumulating across reloads, there is
never a second writer over a path, and the journal is removed once, at exit. The
middleware stays generation-scoped, which is what `capture-secure-headers`
needs.

---

### Review

One commit, `c852c47`. Step **32 of 33** in the review stack.

This PR targets **`chore/f01-write-only-fields`**, the branch for the preceding finding, so that the diff shown here is exactly this one commit and nothing else. GitHub retargets it to `main` automatically once that base merges.

`make check` (gofmt, gofumpt, golangci-lint, unit tests with `-race`, dead-code analysis, build) and the
tagged integration suite pass at this commit.
